### PR TITLE
Fix prefect-design peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "vue-tsc": "0.35.2"
             },
             "peerDependencies": {
-                "@prefecthq/prefect-design": "0.0.37",
+                "@prefecthq/prefect-design": "^0.0.38",
                 "pinia": "^2.0.14",
                 "vee-validate": "^4.5.11",
                 "vue": "^3.2.34",
@@ -162,9 +162,9 @@
             }
         },
         "node_modules/@prefecthq/prefect-design": {
-            "version": "0.0.37",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-0.0.37.tgz",
-            "integrity": "sha512-n8VeAJqxLeZprf31IvzIx70wpsWVOpTwZBM0KqMb6UmfAxaPQC8XNMQ0Q/I8VkwlmGDmfYcmDGjYAYuVtDcgnQ==",
+            "version": "0.0.38",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-0.0.38.tgz",
+            "integrity": "sha512-sr8AXtw/Rzsg/Wa2lPCVUju3W3E4wqaQMZkWJtws+Lht3fj6HBtNPM+Kz/SHkRGuAt6HxdDruzLIU48KVaeUAw==",
             "peer": true,
             "dependencies": {
                 "@headlessui/vue": "^1.6.0",
@@ -4559,9 +4559,9 @@
             }
         },
         "@prefecthq/prefect-design": {
-            "version": "0.0.37",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-0.0.37.tgz",
-            "integrity": "sha512-n8VeAJqxLeZprf31IvzIx70wpsWVOpTwZBM0KqMb6UmfAxaPQC8XNMQ0Q/I8VkwlmGDmfYcmDGjYAYuVtDcgnQ==",
+            "version": "0.0.38",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-0.0.38.tgz",
+            "integrity": "sha512-sr8AXtw/Rzsg/Wa2lPCVUju3W3E4wqaQMZkWJtws+Lht3fj6HBtNPM+Kz/SHkRGuAt6HxdDruzLIU48KVaeUAw==",
             "peer": true,
             "requires": {
                 "@headlessui/vue": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "vue-tsc": "0.35.2"
     },
     "peerDependencies": {
-        "@prefecthq/prefect-design": "0.0.37",
+        "@prefecthq/prefect-design": "^0.0.38",
         "pinia": "^2.0.14",
         "vee-validate": "^4.5.11",
         "vue": "^3.2.34",


### PR DESCRIPTION
I think this is correct but we can close if not - installing orion-design alongside prefect-design breaks right now unless the versions explicitly match. 