### PR TITLE
BugFix: fixed breakpoints on CodeBanner

### DIFF
--- a/src/components/CodeBanner.vue
+++ b/src/components/CodeBanner.vue
@@ -55,11 +55,10 @@
   rounded
   text-white
   flex
-  flex-col
-  gap-6
+  flex-wrap
+  gap-x-6
   justify-center
   items-center
-  md:flex-row
   bg-prefect-600;
   background-image: url(/constellations.svg);
   background-position: center;
@@ -68,8 +67,7 @@
 
 .code-banner__message { @apply
   text-center
-  m-4
-  md:ml-8
+  m-8
 }
 
 .code-banner__message-title { @apply
@@ -80,18 +78,15 @@
 
 .code-banner__terminal { @apply
   flex
-  flex-grow
   flex-col
+  self-end
   px-5
   py-4
-  gap-3
+  gap-6
+  max-w-2xl
   bg-gray-900
   rounded-t
   w-11/12
-  md:min-h-[136px]
-  md:mx-2
-  md:mt-4
-  md:self-end
 }
 
 .code-banner__terminal-top-bar { @apply


### PR DESCRIPTION
because CodeBanner previously used tailwind media breakpoints like `md:flex-row` it would only break when the **window** was a certain size, but with the context sidebar the size really needed to be based on the content not the window. My solution was to skip media queries all together in favor of `flex-wrap`

**before:** 
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/6098901/173205283-127e6827-6ac7-4c99-884a-354dde3f336e.png">

**after:** 
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/6098901/173205231-337f522c-e5cf-4e31-9fc6-f782ba0786a5.png">

**before:** 
<img width="491" alt="image" src="https://user-images.githubusercontent.com/6098901/173205281-e09d44e9-017b-417f-899a-34e7f49fedf1.png">

**after:**
<img width="526" alt="image" src="https://user-images.githubusercontent.com/6098901/173205228-076da819-6f24-4d2e-9e8c-0998e8075467.png">

**before:**
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/6098901/173205288-a8ff9244-a412-4b33-b439-bb1d4d0e3165.png">

**after:**
<img width="1698" alt="Screen Shot 2022-06-11 at 4 19 41 PM" src="https://user-images.githubusercontent.com/6098901/173205236-22ee031a-edd9-4109-8e88-05a00cf029cb.png">

**before:**
<img width="2417" alt="image" src="https://user-images.githubusercontent.com/6098901/173205312-e557b62e-f60f-4b9e-97bb-ac9cdb6b8235.png">

**after:**
<img width="2415" alt="image" src="https://user-images.githubusercontent.com/6098901/173205249-434d4dd8-7a73-40c8-afcf-28da6195d8e5.png">

