### PR TITLE
BugFix: WorkQueueToggle toast when turning off work queue

### DIFF
--- a/src/components/WorkQueueToggle.vue
+++ b/src/components/WorkQueueToggle.vue
@@ -36,10 +36,10 @@
     try {
       if (value) {
         await workQueuesApi.resumeWorkQueue(props.workQueue.id)
-        showToast(`${props.workQueue.name} active`, 'success', undefined, 3000)
+        showToast(`${props.workQueue.name} active`, 'success')
       } else {
         await workQueuesApi.pauseWorkQueue(props.workQueue.id)
-        showToast(`${props.workQueue.name} paused`, 'error', undefined, 3000)
+        showToast(`${props.workQueue.name} paused`, 'success')
       }
 
       emit('update')


### PR DESCRIPTION
# Description
Change the toast when turning off a work queue to use success not error