### PR TITLE
Create notificationStatusSelect components

### DIFF
--- a/demo/sections/NotificationsSection.vue
+++ b/demo/sections/NotificationsSection.vue
@@ -4,6 +4,7 @@
       <!--  -->
     </DemoSubSection>
     <DemoSubSection heading="Notification Table">
+      <NotificationStatusSelect v-model:selected="searchTerm" />
       <!--  -->
     </DemoSubSection>
     <DemoSubSection heading="Notification Form">
@@ -13,9 +14,15 @@
 </template>
 
 <script lang="ts" setup>
+  import { ref } from 'vue'
   import DemoSection from '../components/DemoSection.vue'
   import DemoSubSection from '../components/DemoSubSection.vue'
+  import NotificationStatusSelect from '@/components/NotificationStatusSelect.vue'
+  import { NotificationStatus } from '@/models'
   import { mocker } from '@/services'
+
+  const searchTerm = ref<NotificationStatus>('all')
+
   const notification = mocker.create('notification')
   const emptyNotification = {
     blockDocumentId: mocker.create('id'),

--- a/src/components/NotificationStatusSelect.vue
+++ b/src/components/NotificationStatusSelect.vue
@@ -1,0 +1,31 @@
+<template>
+  <p-select v-model="model" :options="options" class="notification-status-select" />
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { NotificationStatus } from '@/models'
+
+  const props = defineProps<{
+    selected: NotificationStatus,
+  }>()
+
+  const emit = defineEmits<{
+    (event: 'update:selected', value: NotificationStatus): void,
+  }>()
+
+  const model = computed({
+    get() {
+      return props.selected
+    },
+    set(value: NotificationStatus) {
+      emit('update:selected', value)
+    },
+  })
+
+  const options: { label: string, value: NotificationStatus }[] = [
+    { label: 'Status: All', value: 'all' },
+    { label: 'Status: Active', value: 'active' },
+    { label: 'Status: Paused', value: 'paused' },
+  ]
+</script>

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -1,4 +1,8 @@
 import { IState } from './State'
+
+export const notificationStatus = ['all', 'active', 'paused'] as const
+export type NotificationStatus = typeof notificationStatus[number]
+
 export interface INotification {
   id: string,
   created: Date,


### PR DESCRIPTION
This PR adds a component that will be used for filtering Notifications. Notifications can only be filtered by status (All, Active, Paused), this functionality is provided by NotificationStatusSelect component which will be used with the NotificationsTable.

Screenshot from Figma:
<img width="400" alt="Screen Shot 2022-06-16 at 11 08 15 AM" src="https://user-images.githubusercontent.com/40467112/174101409-6f96c73a-5671-4b52-aeab-6a6256a1c278.png">

Screenshot from demo:
<img width="400" alt="Screen Shot 2022-06-16 at 11 09 03 AM" src="https://user-images.githubusercontent.com/40467112/174101563-ea6998ec-c1f5-48dc-a63c-c8d53705656f.png">

