### PR TITLE
Make the action prop optional in the confirm-delete modal

### DIFF
--- a/src/components/ConfirmDeleteModal.vue
+++ b/src/components/ConfirmDeleteModal.vue
@@ -30,7 +30,7 @@
   const props = withDefaults(defineProps<{
     showModal: boolean,
     name?: string,
-    action: 'Delete' | 'Remove',
+    action?: 'Delete' | 'Remove',
   }>(), {
     name: '',
     action: 'Delete',


### PR DESCRIPTION
This removes the plethora of warnings the demo UI was throwing as a result. Since the `action` property has a default, making it optional should have no impact on functionality. 