### PR TITLE
Update: Allow notification feature to take is_active 

### DIFF
--- a/src/models/NotificationFilter.ts
+++ b/src/models/NotificationFilter.ts
@@ -1,4 +1,5 @@
 export type NotificationFilter = {
   offset?: number,
   limit?: number,
+  is_active: boolean,
 }


### PR DESCRIPTION
Adds is_active as an option for the notification filter to match a [backend update](https://github.com/PrefectHQ/orion/pull/2071) and to allow us to filter the notification table by active/paused/all status. 