### PR TITLE
Remove references to flow tags

### DIFF
--- a/src/components/FlowsTable.vue
+++ b/src/components/FlowsTable.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { PTable, PTagWrapper, PEmptyResults, PLink } from '@prefecthq/prefect-design'
+  import { PTable, PEmptyResults, PLink } from '@prefecthq/prefect-design'
   import { computed, ref } from 'vue'
   import ResultsCount from './ResultsCount.vue'
   import SearchInput from './SearchInput.vue'


### PR DESCRIPTION
Per the sequence of changes described in https://www.notion.so/prefect/2-0-Metadata-Spring-Cleaning-d1478b8c5ade47488ff6b5d6c04e056a, removing references to Flow Tags to streamline our "tags" concept.

Note: this change should be non-breaking and backwards compatible.