### PR TITLE
Feature: added support for size prop on PageHeading

### DIFF
--- a/src/components/PageHeading.vue
+++ b/src/components/PageHeading.vue
@@ -2,7 +2,7 @@
   <header class="page-heading">
     <div class="page-heading__leading">
       <div class="page-heading__crumbs">
-        <p-bread-crumbs :crumbs="crumbs" />
+        <p-bread-crumbs :class="classes" :crumbs="crumbs" />
         <slot name="after-crumbs" />
       </div>
       <slot />
@@ -15,11 +15,27 @@
 </template>
 
 <script lang="ts" setup>
-  import { PBreadCrumbs, BreadCrumbs } from '@prefecthq/prefect-design'
+  import { PBreadCrumbs, BreadCrumbs, Size } from '@prefecthq/prefect-design'
+  import { PropType, computed } from 'vue'
 
-  defineProps<{
-    crumbs: BreadCrumbs,
-  }>()
+  const props = defineProps({
+    crumbs: {
+      type: Array as PropType<BreadCrumbs>,
+      required: true,
+    },
+    size: {
+      type: String as PropType<Size>,
+      default: 'xl',
+    },
+  })
+
+  const classes = computed(() => ({
+    'page-heading__crumbs--xs': props.size === 'xs',
+    'page-heading__crumbs--sm': props.size === 'sm',
+    'page-heading__crumbs--md': props.size === 'md',
+    'page-heading__crumbs--lg': props.size === 'lg',
+    'page-heading__crumbs--xl': props.size === 'xl',
+  }))
 </script>
 
 <style>
@@ -60,5 +76,25 @@
     gap-2
     grid-flow-col
   }
+}
+
+.page-heading__crumbs--xs { @apply
+  text-xs
+}
+
+.page-heading__crumbs--sm { @apply
+  text-sm
+}
+
+.page-heading__crumbs--md { @apply
+  text-base
+}
+
+.page-heading__crumbs--lg { @apply
+  text-lg
+}
+
+.page-heading__crumbs--xl { @apply
+  text-xl
 }
 </style>


### PR DESCRIPTION
```html
<PageHeading size="xs | sm | md | lg | xl" />
```

default size is "xl" (text-xl) (approx 20px) (same as before)

this prop enables the following design
<img width="745" alt="image" src="https://user-images.githubusercontent.com/6098901/176577300-56a6d364-47de-4483-8e46-843ae4ca7e12.png">
