### PR TITLE
Feature: Add validation to notification form

### DIFF
--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -61,9 +61,7 @@
     (event: 'cancel'): void,
   }>()
 
-  const { handleSubmit, errors } = useForm()
-
-
+  const { handleSubmit } = useForm()
   const blockDocumentsApi = inject(blockDocumentsApiKey)
   const blockTypesApi = inject(blockTypesApiKey)
   const blockSchemasApi = inject(blockSchemasApiKey)


### PR DESCRIPTION
Fixes a tiny formatting error and adds vee-validate to the notification form to ensure required fields (such as slack url) get flagged. 