### PR TITLE
Enhancement: NotificationForm - Use schema from block document if editing a block document

### DIFF
--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -136,6 +136,10 @@
       return null
     }
 
+    if (blockDocument.value && selectedBlockTypeId.value === blockDocument.value.blockTypeId) {
+      return null
+    }
+
     return [
       {
         blockSchemas: {
@@ -147,7 +151,13 @@
     ]
   })
   const blockSchemaSubscription = useSubscriptionWithDependencies(blockSchemasApi.getBlockSchemas, blockSchemaSubscriptionArgs)
-  const blockSchema = computed(() => blockSchemaSubscription.response?.[0])
+  const blockSchema = computed(() => {
+    if (blockDocument.value && selectedBlockTypeId.value === blockDocument.value.blockTypeId) {
+      return blockDocument.value.blockSchema
+    }
+
+    return blockSchemaSubscription.response?.[0]
+  })
 
 
   const submit = handleSubmit(async () => {


### PR DESCRIPTION
# Description
This change makes the notification form use the schema from the block document associated with a notification when editing an existing notification. This means if a notification's block document was created with an outdated schema you would still be able to edit it. 

**This is different than was agreed upon**
@billpalombi @zhen0 @marichka-offen and I talked about this sync and because of technical and product challenges we agreed to always use the most recent schema. We acknowledged that user experience 
- is different than editing blocks (where the schema the block was created with is always used)
- is potentially a bad user experience if a breaking change to a schema was introduced

More work was done on the form component after this agreement which removed the technical challenges. So this PR goes against that decision and possibly should not be merged. 

## Potential risks
With this change if you had a notification that used an outdated block schema and you wanted to use the new schema you would have to either
- Change the notification's block type and save the notification, then switch the block type back (which would give you the newest scheme)
- Delete the notification and recreated it using the newest schema. 

Blocks in general have this same experience. If you created a block with an old schema via the blocks UI you'd have to create a new one in order to get the latest schema. 