### PR TITLE
BugFix: Block Schema `required` property is optional

### DIFF
--- a/src/components/BlockSchemaFormFields.vue
+++ b/src/components/BlockSchemaFormFields.vue
@@ -49,7 +49,9 @@
   })
 
   function isRequired(blockSchemaPropertyKey: string): boolean {
-    return props.blockSchema.fields.required.includes(blockSchemaPropertyKey)
+    const required = props.blockSchema.fields.required ?? []
+
+    return required.includes(blockSchemaPropertyKey)
   }
 
   function getPropertyValue(blockSchemaPropertyKey: string): unknown {

--- a/src/models/BlockSchema.ts
+++ b/src/models/BlockSchema.ts
@@ -33,7 +33,7 @@ export type BlockSchemaFields = {
   description: string,
   type: BlockSchemaFieldsType,
   properties: Record<string, BlockSchemaProperty>,
-  required: string[],
+  required?: string[],
   blockTypeName: string,
   blockSchemaReferences: BlockSchemaReferences,
 }


### PR DESCRIPTION
# Description
The `required` property is optional in the api but was required in the ui model. This meant there was a js error that broke the whole page if a schema that didn't not have required fields. Fixed by defaulting to an empty array and marking the property as optional