### PR TITLE
BugFix: simplified page-heading layout, trailing 100% width on mobile

### DIFF
--- a/src/components/PageHeading.vue
+++ b/src/components/PageHeading.vue
@@ -39,14 +39,11 @@
 </script>
 
 <style>
-.page-heading,
-.page-heading__leading { @apply
-  grid
+.page-heading { @apply
+  flex
   gap-2
-}
-
-.page-heading {
-  align-items: start;
+  items-start
+  flex-wrap
 }
 
 .page-heading__crumbs { @apply
@@ -57,25 +54,14 @@
 }
 
 .page-heading__trailing { @apply
+  flex-grow
+  flex
   items-center
-  justify-start
-  grid
-  grid-flow-col
   gap-2
-}
-
-@screen md {
-  .page-heading { @apply
-    min-h-[42px]
-    flex
-    justify-between
-  }
-
-  .page-heading__trailing { @apply
-    grid
-    gap-2
-    grid-flow-col
-  }
+  justify-start
+  w-full
+  md:w-fit
+  md:justify-end
 }
 
 .page-heading__crumbs--xs { @apply

--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -40,12 +40,13 @@
 </script>
 
 <style>
-.search__label { @apply
-  sr-only
+.search { @apply
+  w-full
+  md:max-w-xs
 }
 
-.search__input { @apply
-  w-auto
+.search__label { @apply
+  sr-only
 }
 
 .search__icon { @apply


### PR DESCRIPTION
before:
<img width="614" alt="image" src="https://user-images.githubusercontent.com/6098901/177455481-1b0c3f55-01de-4dad-9661-04684176e072.png">

after: 
<img width="621" alt="image" src="https://user-images.githubusercontent.com/6098901/177455370-ba694465-20cd-4016-950a-32ff9bb6803b.png">
