### PR TITLE
BugFix: Temporary: Filter block types by name - slack

### DIFF
--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -106,11 +106,12 @@
   })
 
   const blockTypesSubscriptionFilter: BlockTypeFilter = {
-    blockSchemas: {
-      blockCapabilities: {
-        all_: ['notify'],
+    blockTypes: {
+      name: {
+        like_: 'slack',
       },
     },
+
   }
   const blockTypesSubscription = useSubscription(blockTypesApi.getBlockTypes, [blockTypesSubscriptionFilter])
   const blockTypes = computed(() => blockTypesSubscription.response ?? [])

--- a/src/maps/blockTypeFilter.ts
+++ b/src/maps/blockTypeFilter.ts
@@ -26,6 +26,18 @@ export const mapBlockTypeFilterToBlockTypeFilterRequest: MapFunction<BlockTypeFi
     }
   }
 
+  if (source.blockTypes) {
+    filter.block_types = {}
+
+    if (source.blockTypes.name) {
+      filter.block_types.name = {}
+
+      if (source.blockTypes.name.like_) {
+        filter.block_types.name.like_ = source.blockTypes.name.like_
+      }
+    }
+  }
+
 
   return filter
 }

--- a/src/models/BlockTypeFilter.ts
+++ b/src/models/BlockTypeFilter.ts
@@ -1,6 +1,11 @@
 import { BlockSchemaCapability } from '@/models/BlockSchema'
 
 export type BlockTypeFilter = {
+  blockTypes?: {
+    name?: {
+      like_?: string | string[],
+    },
+  },
   blockSchemas?: {
     blockCapabilities?: {
       all_?: BlockSchemaCapability[],

--- a/src/models/api/BlockTypeFilterRequest.ts
+++ b/src/models/api/BlockTypeFilterRequest.ts
@@ -4,6 +4,11 @@ export type BlockTypeFilterRequest = {
       all_?: string[],
     },
   },
+  block_types?: {
+    name?: {
+      like_?: string | string[],
+    },
+  },
   limit?: number,
   offset?: number,
 }


### PR DESCRIPTION
The UI was built to show all blocks of type "notify" - however, the API is currently returning some blocks that we do not want to show by default.  There is work underway to better filter on the API side.  This is a temporary fix for the UI to add a filter until the API work is complete.  We may not need it - waiting for updates from @desertaxle before we merge. 

Related slack conversation here: https://prefecthq.slack.com/archives/C03JE6BS8CE/p1657113536065719