### PR TITLE
Change button text to Cancel/Create

### DIFF
--- a/src/components/BlockSchemaForm.vue
+++ b/src/components/BlockSchemaForm.vue
@@ -10,10 +10,10 @@
 
     <template #footer>
       <p-button inset @click="cancel">
-        Reset
+        Cancel
       </p-button>
       <p-button type="submit">
-        Submit
+        Create
       </p-button>
     </template>
   </p-form>

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -35,7 +35,7 @@
         Cancel
       </p-button>
       <p-button type="submit" :disabled="disabled" :loading="loading">
-        Submit
+        Create
       </p-button>
     </template>
   </p-form>

--- a/src/components/WorkQueueForm.vue
+++ b/src/components/WorkQueueForm.vue
@@ -48,7 +48,7 @@
         Cancel
       </p-button>
       <p-button type="submit" :loading="isSubmitting">
-        Submit
+        Create
       </p-button>
     </template>
   </p-form>


### PR DESCRIPTION
Few buttons when creating a new functionality say “reset” or “submit”, the wording was changed to more consistent “cancel” and “create”

Closes https://github.com/PrefectHQ/orion-design/issues/329