### PR TITLE
Switch the toast type on the deployment toggle to success instead of error

### DIFF
--- a/src/components/DeploymentToggle.vue
+++ b/src/components/DeploymentToggle.vue
@@ -41,7 +41,7 @@
         showToast(`${props.deployment.name} active`, 'success')
       } else {
         await deploymentsApi.pauseDeployment(props.deployment.id)
-        showToast(`${props.deployment.name} paused`, 'error')
+        showToast(`${props.deployment.name} paused`, 'success')
       }
 
       emit('update')


### PR DESCRIPTION
This PR switches the toast type on the deployment toggle to success instead of error

Closes https://github.com/PrefectHQ/orion-design/issues/328