### PR TITLE
Bugfix: Deleting a deployment in the UI results in naming mismatch

### DIFF
--- a/src/components/FlowRouterLink.vue
+++ b/src/components/FlowRouterLink.vue
@@ -28,8 +28,6 @@
   const router = useRouter()
   const flowRouteResolved = computed(() => router.resolve(flowRoute(props.flowId)))
   const matched = computed(() => route.matched.some(({ path }) => flowRouteResolved.value.path == path))
-  // as is this subscription will run even if matched is false.
-  // "optional" subscriptions are an issue currently.
 
   const flowSubscriptionArgs = computed<Parameters<typeof flowsApi.getFlow> | null>(() => !matched.value ? [props.flowId] : null)
 


### PR DESCRIPTION
This PR fixes the naming mismatch of flows and deployments when deleting deployments in the deployments table

Closes https://github.com/PrefectHQ/nebula-ui/issues/1023