### PR TITLE
aws => AWS

### DIFF
--- a/src/models/BlockSchema.ts
+++ b/src/models/BlockSchema.ts
@@ -81,7 +81,7 @@ export class BlockSchema implements IBlockSchema {
         const property = this.fields.properties[key]
 
         if (isBlockSchemaSimpleProperty(property)) {
-          property.title = property.title.replace(expression, 'AWeSome')
+          property.title = property.title.replace(expression, 'AWS')
         }
       })
     }


### PR DESCRIPTION
This PR adds a temporary shim to our BlockSchema constructor that maps iterations of `aws` and `Aws` to the property `AWS`. This is to prevent needing a db migration to update this.