### PR TITLE
BugFix: Don't create new block unless block data has changed in notification

### DIFF
--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -187,7 +187,11 @@
     }
 
     try {
-      if (blockDocument.value?.id) {
+      if (
+        blockDocument.value?.id &&
+        blockDocument.value.blockSchemaId === blockSchema.value.id &&
+        blockDocument.value.blockTypeId === selectedBlockTypeId.value
+      ) {
         blockDocumentId.value = blockDocument.value.id
         await blockDocumentsApi.updateBlockDocument(blockDocumentId.value, {
           data: data.value,


### PR DESCRIPTION
Addresses https://github.com/PrefectHQ/prefect/issues/6003 - a bug where editing a notification stopped it from working because the url was saved as an obfuscated string. This happened because the UI was creating. a new block document every time a notification was edited, even if the block document data was not edited. This PR adds a check for an existing block document and then checks if the data has changed.  If  the block document data has not changed, it uses the existing block document to update the notification. 