### PR TITLE
BUGFIX: Missing blocks and notifications

### DIFF
--- a/src/maps/blockSchemaFields.ts
+++ b/src/maps/blockSchemaFields.ts
@@ -6,6 +6,6 @@ import { mapSnakeToCamelCase } from '@/utilities'
 export const mapBlockSchemaFieldsResponseToBlockSchemaFields: MapFunction<BlockSchemaFieldsResponse, BlockSchemaFields> = function(source: BlockSchemaFieldsResponse): BlockSchemaFields {
   return {
     ...mapSnakeToCamelCase(source),
-    blockSchemaReferences: this.map('BlockSchemaReferencesResponse', source.block_schema_references, 'BlockSchemaReferences'),
+    blockSchemaReferences: source.block_schema_references ? this.map('BlockSchemaReferencesResponse', source.block_schema_references, 'BlockSchemaReferences') : {},
   }
 }

--- a/src/models/api/BlockSchemaResponse.ts
+++ b/src/models/api/BlockSchemaResponse.ts
@@ -15,7 +15,7 @@ export type BlockSchemaFieldsResponse = {
   properties: Record<string, BlockSchemaProperty>,
   required: string[],
   block_type_name: string,
-  block_schema_references: BlockSchemaReferencesResponse,
+  block_schema_references?: BlockSchemaReferencesResponse,
 }
 
 export type BlockSchemaResponse = {


### PR DESCRIPTION
This PR addresses an issue where the API was sending a payload missing the `block_schema_references` key on BlockDocuments; when we were going to map that response, the mapper was throwing an error (appropriately) BUT the error was being swallowed somewhere, potentially at the the actual application level (orion-ui + nebula-ui both have this issue). This all resulted in missing notification bodies and the entire blocks page failing to render any blocks. 