### PR TITLE
Little refactoring and cleanup

### DIFF
--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -135,7 +135,7 @@ export function getAppPermissions(
     const [action, key] = permission.split(':') as [PermissionAction, AccountKey | WorkspaceKey | FeatureFlag]
     const resultAction = result[action] ??= {}
 
-    Object.assign(resultAction, { [key]: checkPermission(permission) })
+    resultAction[key] = checkPermission(permission)
 
     return result
   }, {}) as Can


### PR DESCRIPTION
# Description
This started as a suggestion for simplifying the `Action` type by skipping the mapped type and mapping over `PermissionString` directly. Ended up making a few more tweaks so I thought I'd create a PR. 

Primary changes are
- More explicit naming of all exported types `PermissionAction` rather than just `Action`
- Use generic default for in `ActionKeys` to avoid passing in `PermissionAction` for all of the specific permission key types
- Use some shorthand to simplify the reduce and avoid having to use a `!`