### PR TITLE
BUG: Deleting a block does not route the application back to the blocks overview

### DIFF
--- a/src/components/PageHeadingBlock.vue
+++ b/src/components/PageHeadingBlock.vue
@@ -1,7 +1,7 @@
 <template>
   <page-heading class="page-heading-blocks" :crumbs="crumbs">
     <template #actions>
-      <BlockDocumentMenu :block-document="blockDocument" />
+      <BlockDocumentMenu :block-document="blockDocument" @delete="$emit('delete')" />
     </template>
   </page-heading>
 </template>
@@ -19,6 +19,10 @@
   }>()
 
   const blocksRoute = inject(blocksRouteKey)
+
+  defineEmits<{
+    (event: 'delete'): void,
+  }>()
 
   const crumbs: BreadCrumbs = [
     { text: 'Blocks', to: blocksRoute() },


### PR DESCRIPTION
This PR is one of three that adds redirection to Blocks overview page and fixes the bug. The other PRs are in nebula-ui and orion

Part of https://github.com/PrefectHQ/orion-design/issues/360