### PR TITLE
Feature: added actions slot to ConfirmDeleteModal

### DIFF
--- a/src/components/ConfirmDeleteModal.vue
+++ b/src/components/ConfirmDeleteModal.vue
@@ -16,9 +16,11 @@
       </slot>
     </span>
     <template #actions>
-      <p-button class="delete-modal__delete-button" @click="handleDeleteClick">
-        {{ action }}
-      </p-button>
+      <slot name="actions">
+        <p-button class="delete-modal__delete-button" @click="handleDeleteClick">
+          {{ action }}
+        </p-button>
+      </slot>
     </template>
   </p-modal>
 </template>


### PR DESCRIPTION
added missing #actions slot to ConfirmDeleteModal, which I need to conditionally make the "delete" button disabled