### PR TITLE
BugFix: Block snippets not displaying properly

### DIFF
--- a/src/components/BlockTypeSnippet.vue
+++ b/src/components/BlockTypeSnippet.vue
@@ -13,5 +13,10 @@
     name: '',
   })
 
-  const snippet = computed(() => props.snippet.replace('BLOCK_NAME', props.name).replace(/^```python/, '').replace(/```$/, '').trim())
+  const snippet = computed(() => {
+    const [, genericSnippet = ''] = props.snippet.match(/```python([\S\s]*)```/) ?? []
+    const customSnippet = genericSnippet.replace('BLOCK_NAME', props.name)
+
+    return customSnippet.trim()
+  })
 </script>


### PR DESCRIPTION
# Description
Block snippets are markdown and can have additional content. Using regex to just display the code snippet within the markdown content. 

## Before
<img width="603" alt="image" src="https://user-images.githubusercontent.com/6200442/180562917-f832a0f2-8988-436c-8db6-b1462b04e090.png">

## After
<img width="556" alt="image" src="https://user-images.githubusercontent.com/6200442/180562676-650a7577-f750-4ab9-ab7c-df8f6ad9f32a.png">

