### PR TITLE
Update: Switch copy id to copy names for blocks menu

### DIFF
--- a/src/components/BlockDocumentMenu.vue
+++ b/src/components/BlockDocumentMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <p-icon-button-menu v-bind="$attrs">
-    <copy-overflow-menu-item label="Copy ID" :item="blockDocument.id" />
+    <copy-overflow-menu-item label="Copy Name" :item="blockDocument.name" />
     <p-overflow-menu-item v-if="can.update.block" label="Edit" @click="editBlock" />
     <p-overflow-menu-item v-if="can.delete.block" label="Delete" @click="openDeleteBlockModal" />
   </p-icon-button-menu>


### PR DESCRIPTION
As discussed in our UI screening, blocks are referred to by name in code to maintain readability.  Rather than copying the id from the 3 dot menu, I've updated to copy name, which is likely to be more useful. 