### PR TITLE
BugFix: using original `name` in title if `label` is not sent

### DIFF
--- a/src/components/ConfirmDeleteModal.vue
+++ b/src/components/ConfirmDeleteModal.vue
@@ -6,7 +6,7 @@
     <template #title>
       <div class="delete-modal__title">
         <slot name="title">
-          {{ `${action} ${label}` }}
+          {{ `${action} ${label ?? name}` }}
         </slot>
       </div>
     </template>


### PR DESCRIPTION
at some point `label` got added as a way to say `Delete (TYPE of thing)` in the heading while preserving `Are you sure you want to delete (NAME of thing)` in the body. For any ConfirmDeleteModal's that aren't going to use `label`, this PR ensures it doesn't show up as `Delete undefined`

<img width="563" alt="image" src="https://user-images.githubusercontent.com/6098901/180626115-1659b294-0a14-4fa8-8352-81dded13b638.png">
