### PR TITLE
Enhancement: Remove empty span when value is nullish

### DIFF
--- a/src/components/BlockDocumentProperty.vue
+++ b/src/components/BlockDocumentProperty.vue
@@ -1,12 +1,7 @@
 <template>
   <PKeyValue :label="property.title" :value="value" class="block-document-property">
-    <template #value>
-      <template v-if="isJsonProperty(value)">
-        <JsonView :value="JSON.stringify(value)" />
-      </template>
-      <template v-else>
-        <span>{{ value }}</span>
-      </template>
+    <template v-if="isJsonProperty(value)" #value>
+      <JsonView :value="JSON.stringify(value)" />
     </template>
   </PKeyValue>
 </template>


### PR DESCRIPTION
This PR fixes an issue where the `BlockDocumentProperty` component was passing an empty span to the `p-key-value` component and thereby overriding the empty state. 