### PR TITLE
BugFix: Remove the run option from the deployment menu since it was never hooked up

### DIFF
--- a/src/components/DeploymentMenu.vue
+++ b/src/components/DeploymentMenu.vue
@@ -1,7 +1,6 @@
 <template>
   <p-icon-button-menu size="xs" v-bind="$attrs">
     <copy-overflow-menu-item label="Copy ID" :item="deployment.id" />
-    <p-overflow-menu-item v-if="can.create.flow_run" label="Run" class="deployments-table__hide-on-desktop" />
     <p-overflow-menu-item v-if="can.delete.deployment" label="Delete" @click="open" />
   </p-icon-button-menu>
   <ConfirmDeleteModal


### PR DESCRIPTION
On mobile the deployment 3dot menu showed a "Run" option but clicking on it didn't do anything.  It was also hidden on mobile.  I've removed that option in favor of the Run button on the deployment page. 