### PR TITLE
BugFix: Don't use a default value for name

### DIFF
--- a/src/components/BlockTypeSnippet.vue
+++ b/src/components/BlockTypeSnippet.vue
@@ -3,20 +3,23 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed, withDefaults } from 'vue'
+  import { computed } from 'vue'
   import CodeSnippet from '@/components/CodeSnippet.vue'
 
-  const props = withDefaults(defineProps<{
+  const props = defineProps<{
     snippet: string,
     name?: string,
-  }>(), {
-    name: '',
-  })
+  }>()
 
   const snippet = computed(() => {
     const [, genericSnippet = ''] = props.snippet.match(/```python([\S\s]*)```/) ?? []
-    const customSnippet = genericSnippet.replace('BLOCK_NAME', props.name)
 
-    return customSnippet.trim()
+    if (props.name) {
+      const customSnippet = genericSnippet.replace('BLOCK_NAME', props.name)
+
+      return customSnippet.trim()
+    }
+
+    return genericSnippet.trim()
   })
 </script>


### PR DESCRIPTION
# Description
Currently the `name` prop is optional but it always gets used to replace `BLOCK_NAME`. Removing the default and only doing the name replacement if name is passed in. 