### PR TITLE
BugFix: Fix block schema inputs breaking if you have a nested block

### DIFF
--- a/src/components/BlockSchemaPropertyInputReference.vue
+++ b/src/components/BlockSchemaPropertyInputReference.vue
@@ -6,7 +6,7 @@
       <template v-if="blockDocuments.length">
         <BlockDocumentsSelect v-model:selected="model" v-bind="{ blockDocuments, state }" class="block-schema-property-input-reference__select" />
       </template>
-      <router-link :to="blockCatalogCreateRoute(blockTypeSlug)">
+      <router-link v-if="blockTypeSlug" :to="blockCatalogCreateRoute(blockTypeSlug)">
         <p-button inset>
           Add <p-icon icon="PlusIcon" />
         </p-button>


### PR DESCRIPTION
# Description
Nested blocks inputs were bombing out and causing any block document with a nested block to not be able to be created or edited. Hotfix until we figure out why