### PR TITLE
BugFix: Remove block image border

### DIFF
--- a/src/components/BlockTypeLogo.vue
+++ b/src/components/BlockTypeLogo.vue
@@ -19,9 +19,6 @@
 
 <style>
 .block-type-logo { @apply
-  border-gray-300
-  rounded
-  border-[1px]
   bg-cover
   bg-center
   w-8


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/orion-design/issues/442
With this change:
<img width="653" alt="image" src="https://user-images.githubusercontent.com/40272060/181354838-97603cc7-8f3e-495f-afa0-ec5a2d792ec9.png">

Before:
<img width="811" alt="image" src="https://user-images.githubusercontent.com/40272060/181354884-017f14e2-5e5e-4830-a7a8-70fa2c3e0575.png">
