### PR TITLE
Enhancement: Add emphasis on "into your flows" on block page 

### DIFF
--- a/src/components/BlockDocumentCard.vue
+++ b/src/components/BlockDocumentCard.vue
@@ -4,7 +4,7 @@
       <template v-if="blockType.codeExample || blockType.documentationUrl">
         <p class="block-document-card__help">
           <template v-if="blockType.codeExample">
-            Paste this snippet into your flows to use this block.
+            Paste this snippet <span class="block-document-card__emphasized-section">into your flows</span> to use this block.
           </template>
           <template v-if="blockType.documentationUrl">
             Need help? <p-link :to="blockType.documentationUrl">
@@ -67,6 +67,10 @@
 .block-document-card__help { @apply
   text-gray-500
   text-sm
+}
+
+.block-document-card__emphasized-section {
+  @apply font-semibold
 }
 
 .block-document-card__type { @apply


### PR DESCRIPTION
To help with an issue raised [here](https://github.com/PrefectHQ/orion/issues/2569), I've added semibold to the "into your flows" message. 

<img width="1301" alt="image" src="https://user-images.githubusercontent.com/40272060/181555249-76867cd0-c2e7-44a0-b72a-87319719d1eb.png">


