### PR TITLE
Bugfix: WorkQueueDetails `alternate` prop 

### DIFF
--- a/demo/sections/MetaWellSection.vue
+++ b/demo/sections/MetaWellSection.vue
@@ -12,6 +12,10 @@
       <DemoSubSection heading="Deployment Meta Well">
         <DeploymentDetails :deployment="deploymentData" class="w-[250px] border-2 border-blue-200 border-dashed" alternate />
       </DemoSubSection>
+
+      <DemoSubSection heading="Work Queue Meta Well">
+        <WorkQueueDetails :work-queue="workQueueData" class="w-[250px] border-2 border-blue-200 border-dashed" alternate />
+      </DemoSubSection>
     </div>
   </DemoSection>
 </template>
@@ -22,6 +26,7 @@
   import DeploymentDetails from '@/components/DeploymentDetails.vue'
   import FlowDetails from '@/components/FlowDetails.vue'
   import FlowRunDetails from '@/components/FlowRunDetails.vue'
+  import WorkQueueDetails from '@/components/WorkQueueDetails.vue'
   import { mocker } from '@/services'
 
   const flowData = mocker.create('flow')
@@ -29,4 +34,6 @@
   const deploymentData = mocker.create('deployment')
 
   const flowRunData = mocker.create('flowRun')
+
+  const workQueueData = mocker.create('workQueue')
 </script>

--- a/src/components/WorkQueueDetails.vue
+++ b/src/components/WorkQueueDetails.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="work-queue-details">
-    <p-key-value label="Description" :value="workQueue.description" />
+    <p-key-value label="Description" :value="workQueue.description" :alternate="alternate" />
 
     <p-divider />
 
-    <p-key-value label="Work Queue ID" :value="workQueue.id" />
+    <p-key-value label="Work Queue ID" :value="workQueue.id" :alternate="alternate" />
 
-    <p-key-value label="Flow Run Concurrency" :value="workQueue.concurrencyLimit" />
+    <p-key-value label="Flow Run Concurrency" :value="workQueue.concurrencyLimit" :alternate="alternate" />
 
-    <p-key-value label="Created" :value="formatDateTimeNumeric(workQueue.created)" />
+    <p-key-value label="Created" :value="formatDateTimeNumeric(workQueue.created)" :alternate="alternate" />
 
-    <p-key-value :label="deploymentLabel">
+    <p-key-value :label="deploymentLabel" :alternate="alternate">
       <template v-if="workQueue.filter.deploymentIds.length" #value>
         <div class="work-queue-details__deployments">
           <template v-for="deploymentId in deploymentIds" :key="deploymentId">
@@ -23,7 +23,7 @@
       </template>
     </p-key-value>
 
-    <p-key-value label="Tags">
+    <p-key-value label="Tags" :alternate="alternate">
       <template v-if="workQueue.filter.tags.length" #value>
         <p-tags :tags="workQueue.filter.tags" class="mt-2" />
       </template>
@@ -39,6 +39,7 @@
 
   const props = defineProps<{
     workQueue: WorkQueue,
+    alternate?: boolean,
   }>()
 
   const deploymentIds = computed(() => {


### PR DESCRIPTION
This PR adds the `alternate` prop to the `WorkQueueDetails` component, in line with other `*Details` components and adds  the component to the meta well section of the demo app.