### PR TITLE
Fix issue where SeparatedList doesn't wrap well

### DIFF
--- a/src/components/NotificationDetails.vue
+++ b/src/components/NotificationDetails.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="notification-details">
-    If a run of any flow with
+    If a run of any flow with <span v-if="notification.tags?.length">a</span>
     <SeparatedList :item-array="notification.tags || []">
       <template #first-items="{ item }">
         <span class="notification-details__tag">

--- a/src/components/SeparatedList.vue
+++ b/src/components/SeparatedList.vue
@@ -1,7 +1,6 @@
 <template>
   <span class="separated-list">
     <template v-if="itemArray.length">
-      a
       <div class="separated-list__tags">
         <template v-for="item in allButLastArrayItems(itemArray)" :key="item">
           <slot name="first-items" :item="item" />


### PR DESCRIPTION
This PR is an attempt to fix wrapping for long tags in notifications
<img width="500" alt="Screen Shot 2022-08-09 at 11 55 55 AM" src="https://user-images.githubusercontent.com/40467112/183700316-0934e6f6-0f94-43a2-aea9-bb1765a53139.png">




Closes https://github.com/PrefectHQ/orion-design/issues/475