### PR TITLE
BugFix: alignment of hidden textarea on json-input

### DIFF
--- a/src/components/JsonInput.vue
+++ b/src/components/JsonInput.vue
@@ -105,7 +105,7 @@
   caret-slate-50
   p-4
   m-0
-  whitespace-nowrap
+  whitespace-pre-wrap
   top-0
 }
 


### PR DESCRIPTION
closes #6285

the issue says that you can't edit the value, but in fact the value just doesn't have line breaks, so in my example the full value is on the top line of the textarea (hidden by transparent font color)

<img width="1462" alt="Screen Shot 2022-08-15 at 3 28 50 PM" src="https://user-images.githubusercontent.com/6098901/184713417-6d3cfe45-394d-4cb6-a0f5-51f84eca62e1.png">

https://user-images.githubusercontent.com/6098901/184713561-60005c75-eaad-4ca8-9206-0f5088e5bb48.mov

moved from `whitespace-nowrap` to `whitespace-pre-wrap` to preserve new lines in textarea value on firefox. Still works as expected on Chrome

<img width="1451" alt="Screen Shot 2022-08-15 at 3 29 39 PM" src="https://user-images.githubusercontent.com/6098901/184713443-342fc98b-7c9a-4ce0-a58f-edf59d230ab1.png">


