### PR TITLE
BugFix: Fix work queue edit mapper

### DIFF
--- a/src/components/WorkQueueCreateForm.vue
+++ b/src/components/WorkQueueCreateForm.vue
@@ -46,7 +46,7 @@
   import { WorkQueueCreate } from '@/models'
   import { isRequired, withMessage } from '@/services/validate'
 
-  const { values, handleSubmit, isSubmitting, errors } = useForm<WorkQueueCreate>()
+  const { handleSubmit, isSubmitting, errors } = useForm<WorkQueueCreate>()
 
   const rules = {
     name: [withMessage(isRequired, 'Name is required')],
@@ -71,7 +71,7 @@
     (event: 'cancel'): void,
   }>()
 
-  const submit = handleSubmit(() => {
+  const submit = handleSubmit((values) => {
     emit('submit', values)
   })
 

--- a/src/components/WorkQueueEditForm.vue
+++ b/src/components/WorkQueueEditForm.vue
@@ -2,7 +2,7 @@
   <p-form class="work-queue-edit-form" @submit="submit">
     <p-content>
       <p-label label="Name">
-        <p-text-input v-model="name" disabled />
+        <p-text-input :model-value="workQueue.name" disabled />
       </p-label>
 
       <p-label label="Description (Optional)">
@@ -41,15 +41,21 @@
 <script lang="ts" setup>
   import { PLabel, PTextInput, PNumberInput, PToggle, PForm } from '@prefecthq/prefect-design'
   import { useField, useForm } from 'vee-validate'
-  import { computed, ref } from 'vue'
+  import { computed } from 'vue'
   import SubmitButton from './SubmitButton.vue'
-  import { WorkQueueEditRequest, WorkQueue } from '@/models'
+  import { WorkQueueEdit, WorkQueue } from '@/models'
 
   const props = defineProps<{
     workQueue: WorkQueue,
   }>()
 
-  const { values, handleSubmit, isSubmitting } = useForm({ initialValues: props.workQueue })
+  const { handleSubmit, isSubmitting } = useForm<WorkQueueEdit>({
+    initialValues: {
+      description: props.workQueue.description,
+      isPaused: props.workQueue.isPaused,
+      concurrencyLimit: props.workQueue.concurrencyLimit,
+    },
+  })
 
   const isActive = computed({
     get() {
@@ -60,17 +66,17 @@
     },
   })
 
-  const name = ref(props.workQueue.name)
+
   const { value: description } = useField<string|null>('description')
   const { value: isPaused } = useField<boolean | undefined>('isPaused')
   const { value: concurrencyLimit } = useField<number|null>('concurrencyLimit')
 
   const emit = defineEmits<{
-    (event: 'submit', value: WorkQueueEditRequest): void,
+    (event: 'submit', value: WorkQueueEdit): void,
     (event: 'cancel'): void,
   }>()
 
-  const submit = handleSubmit(() => {
+  const submit = handleSubmit((values) => {
     emit('submit', values)
   })
 

--- a/src/maps/workQueue.ts
+++ b/src/maps/workQueue.ts
@@ -35,12 +35,7 @@ export const mapWorkQueueCreateToWorkQueueCreateRequest: MapFunction<WorkQueueCr
 }
 
 export const mapWorkQueueEditToWorkQueueEditRequest: MapFunction<WorkQueueEdit, WorkQueueEditRequest> = function(source: WorkQueueEdit): WorkQueueEditRequest {
-  const updatedWorkQueue = {
-    description: source.description,
-    isPaused: source.isPaused,
-    concurrencyLimit: source.concurrencyLimit,
-  }
   return {
-    ...mapCamelToSnakeCase(updatedWorkQueue),
+    ...mapCamelToSnakeCase(source),
   }
 }


### PR DESCRIPTION
Bug:
https://user-images.githubusercontent.com/40272060/185606905-fadf8d58-3645-45d6-9cdb-e9c9f3cdf6d6.mov

If it try to edit a work queue from the UI there's an error - the network tab shows:

```
exception_message: "Invalid request received.",…}
exception_detail: [{loc: ["body", "created"], msg: "extra fields not permitted", type: "value_error.extra"},…]
0: {loc: ["body", "created"], msg: "extra fields not permitted", type: "value_error.extra"}
1: {loc: ["body", "id"], msg: "extra fields not permitted", type: "value_error.extra"}
2: {loc: ["body", "updated"], msg: "extra fields not permitted", type: "value_error.extra"}
exception_message: "Invalid request received."
request_body: {id: "a3feca1a-f5f0-4b5f-aa8f-cc1abbee9ae6", created: "2022-08-18T11:50:15.073Z",…}

```