### PR TITLE
BugFix: missed deeper call to crypto

### DIFF
--- a/src/mocks/id.ts
+++ b/src/mocks/id.ts
@@ -9,7 +9,13 @@ declare global {
 export const randomId: MockFunction<string, []> = function() {
   // typescript says crypto will be defined but it might not be
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (!crypto?.randomUUID) {
+  if (!crypto) {
+    return nonCryptoUUID()
+  }
+
+  // typescript says crypto will be defined but it might not be
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!crypto.randomUUID) {
     return backupRandomUUID()
   }
 
@@ -22,4 +28,15 @@ function backupRandomUUID(): string {
     .replace(/[018]/g,
       substring => (+substring ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +substring / 4).toString(16),
     )
+}
+
+function nonCryptoUUID(): string {
+  const first = base16Integer()
+  const last = base16Integer()
+  return `${first.slice(0, 8) }-${ first.slice(8, 12) }-4${ first.slice(13) }-a${ last.slice(1, 4) }-${ last.slice(4)}`
+}
+
+function base16Integer(): string {
+  // eslint-disable-next-line no-loss-of-precision, @typescript-eslint/no-loss-of-precision
+  return `00000000000000000${ (Math.random() * 0xffffffffffffffff).toString(16)}`.slice(-16)
 }


### PR DESCRIPTION
[this pr](https://github.com/PrefectHQ/orion-design/pull/524) was intended to allow mocker to be used in playwright tests, but I missed a nested call to `crypto`. 

This pr has a backup uuid method that doesn't use crypto at all