### PR TITLE
BugFix: Import workQueueIconText on flow run details page

### DIFF
--- a/src/components/FlowRunDetails.vue
+++ b/src/components/FlowRunDetails.vue
@@ -39,12 +39,10 @@
   import  WorkQueueIconText  from '@/components/WorkQueueIconText.vue'
   import { FlowRun } from '@/models/FlowRun'
 
-  const props = defineProps<{
+  defineProps<{
     flowRun: FlowRun,
     alternate?: boolean,
   }>()
-
-  console.log('flowRun', props.flowRun)
 </script>
 
 <style>


### PR DESCRIPTION
Bug:

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/40272060/186349098-fa46824b-0af1-4b16-addc-8af145ca4ffe.png">


Fixed: 

<img width="730" alt="image" src="https://user-images.githubusercontent.com/40272060/186348984-dde018fd-c518-4850-9555-739113b28643.png">
