### PR TITLE
Bugfix: 'Late' stateName badge doesn't match color scheme of its type Scheduled

### DIFF
--- a/src/components/StateBadge.vue
+++ b/src/components/StateBadge.vue
@@ -1,6 +1,6 @@
 <template>
   <p-tag class="state-badge" :class="classes" :dismissible="dismissible">
-    <StateIcon v-if="!stateWithNoType" :state-type="state?.type" :shade="iconShade" class="state-badge__icon" />
+    <StateIcon v-if="!stateWithNoType" :state-type="type" :shade="iconShade" class="state-badge__icon" />
     <span>{{ name }}</span>
   </p-tag>
 </template>
@@ -10,6 +10,7 @@
   import StateIcon from './StateIcon.vue'
   import { StateType } from '@/models/StateType'
   import { TailwindColor } from '@/types/tailwind'
+  import { mapStateNameToStateType } from '@/utilities/state'
 
   const props = defineProps<{
     state: { name: string, type: StateType | null } | null,
@@ -18,7 +19,7 @@
   }>()
 
   const stateWithNoType = computed(() => props.state && !props.state.type)
-  const type = computed(() => props.state?.type ?? 'unknown')
+  const type = computed(() => mapStateNameToStateType(props.state?.name).type)
   const name = computed(() => props.state?.name ?? 'Unknown')
 
   const classes = computed(() => [

--- a/src/utilities/state.ts
+++ b/src/utilities/state.ts
@@ -1,6 +1,6 @@
 import { StateType } from '@/models'
 
-export function mapStateNameToStateType(stateName: string): { name: string, type: StateType | null } {
+export function mapStateNameToStateType(stateName: string = 'Unknown'): { name: string, type: StateType | null } {
   switch (stateName.toLowerCase()) {
     case 'completed': return { name: 'Completed', type: 'completed' }
     case 'failed': return { name: 'Failed ', type: 'failed' }


### PR DESCRIPTION
This PR fixes a bug where state badges with the name 'Late' don't have the correct color and icon of the Scheduled state

Closes https://github.com/PrefectHQ/prefect/issues/6480