### PR TITLE
Enhancement: Add created time and date to the flows table

### DIFF
--- a/src/components/FlowsTable.vue
+++ b/src/components/FlowsTable.vue
@@ -12,6 +12,10 @@
         </p-link>
       </template>
 
+      <template #created="{ row }">
+        {{ formatDateTimeNumeric(row.created) }}
+      </template>
+
       <template #activity="{ row }">
         <FlowActivityChart :flow="row" class="flows-table__activity-chart" />
       </template>
@@ -43,7 +47,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { PTable, PEmptyResults, PLink } from '@prefecthq/prefect-design'
+  import { PTable, PEmptyResults, PLink, formatDateTimeNumeric } from '@prefecthq/prefect-design'
   import { computed, ref } from 'vue'
   import ResultsCount from './ResultsCount.vue'
   import SearchInput from './SearchInput.vue'
@@ -69,7 +73,12 @@
     {
       property: 'name',
       label: 'Name',
-      width: '150px',
+      width: '125px',
+    },
+    {
+      property: 'created',
+      label: 'Created',
+      width: '125px',
     },
     {
       property: 'activity',


### PR DESCRIPTION
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/40272060/189231132-bfcc20fc-9338-4fba-947e-e5ed8b327cfb.png">


Added after discussion with Taylor about requests made from users comparing Cloud 1.0 and 2.0.  (They also want created by but that's a bigger piece of work.)