### PR TITLE
BugFix: Remove overscroll-contain on the logs container

### DIFF
--- a/src/components/LogsContainer.vue
+++ b/src/components/LogsContainer.vue
@@ -56,7 +56,6 @@
   grid
   gap-1
   text-sm
-  overscroll-contain;
 }
 
 .logs__divider { @apply


### PR DESCRIPTION
# Description
The `LogsContainer` currently has `overscroll-contain` applied. This means that you cannot scroll the page while hovering over the logs. Which effectively means you cannot scroll the page to see the rest of the logs. 