### PR TITLE
Bugfix: Add border color to scatterplot dots

### DIFF
--- a/src/components/FlowRunsScatterPlot.vue
+++ b/src/components/FlowRunsScatterPlot.vue
@@ -37,7 +37,7 @@
 }
 
 .scatter-plot-item { @apply
-  border-2
+  border-[1px]
   border-white
 }
 
@@ -52,29 +52,36 @@
 
 .scatter-plot-item--running {
   background-color: var(--state-running-500);
+  border-color: var(--state-running-600);
 }
 
 .scatter-plot-item--scheduled {
   background-color: var(--state-scheduled-500);
+  border-color: var(--state-scheduled-600);
 }
 
 .scatter-plot-item--pending {
   background-color: var(--state-pending-500);
+  border-color: var(--state-pending-600);
 }
 
 .scatter-plot-item--cancelled {
   background-color: var(--state-cancelled-500);
+  border-color: var(--state-cancelled-600);
 }
 
 .scatter-plot-item--completed {
   background-color: var(--state-completed-500);
+  border-color: var(--state-completed-600);
 }
 
 .scatter-plot-item--failed {
   background-color: var(--state-failed-500);
+  border-color: var(--state-failed-600);
 }
 
 .scatter-plot-item--crashed {
   background-color: var(--state-crashed-500);
+  border-color: var(--state-crashed-600);
 }
 </style>


### PR DESCRIPTION
This PR adds border color to scatterplot dots because when they don't have it, it looks bad
Before:
<img width="1161" alt="Screen Shot 2022-09-20 at 6 04 40 PM" src="https://user-images.githubusercontent.com/40467112/191374805-233cb69b-ed66-4bb9-afb1-a4adcc0288c8.png">
After:
<img width="1171" alt="Screen Shot 2022-09-20 at 6 18 53 PM" src="https://user-images.githubusercontent.com/40467112/191374918-31fdb16a-66a0-4bcf-93b1-8312af8da700.png">

