### PR TITLE
Added references to `SchemaValuesResponse` -> `SchemaValues` mapping

### DIFF
--- a/src/maps/blockDocument.ts
+++ b/src/maps/blockDocument.ts
@@ -6,7 +6,7 @@ import { mapSnakeToCamelCase } from '@/utilities/mapping'
 
 export const mapBlockDocumentResponseToBlockDocument: MapFunction<BlockDocumentResponse, BlockDocument> = function(source: BlockDocumentResponse): BlockDocument {
   const blockSchema = this.map('BlockSchemaResponse', source.block_schema, 'BlockSchema')
-  const data = this.map('SchemaValuesResponse', { values: source.data, schema: blockSchema.fields }, 'SchemaValues')
+  const data = this.map('SchemaValuesResponse', { values: source.data, references: source.block_document_references, schema: blockSchema.fields }, 'SchemaValues')
 
   return new BlockDocument({
     ...mapSnakeToCamelCase(source),


### PR DESCRIPTION
When viewing a block document that references another block document, the reference shows up as None even when a referenced block document exists. 

Similarly, when loading the editor for a block document that references another block document, the select box displays None even if the document was saved with a reference to another block document. If you don't re-set the referenced block document by selecting it again, the reference will be erased when you save your other changes. 

This PR fixes the problem by adding `references` to the `SchemaValuesResponse` -> `SchemaValues` mapping.