### PR TITLE
Feature: Display the block type slug when viewing the details for an individual block type

### DIFF
--- a/src/components/BlockTypeCard.vue
+++ b/src/components/BlockTypeCard.vue
@@ -5,6 +5,8 @@
 
       <p-key-value label="Name" :value="blockType.name" />
 
+      <p-key-value label="Slug" :value="blockType.slug" />
+
       <template v-if="blockSchema && hasCapabilities">
         <p-key-value label="Capabilities">
           <template #value>


### PR DESCRIPTION
# Description
Adds the block type slug to the BlockTypeCard component to surface that to users who might want to copy the slug into a flow or script. 

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/6200442/192061024-6a84edc2-d4ef-496e-928f-4bf64eff735e.png">

Closes https://github.com/PrefectHQ/prefect/issues/6775