### PR TITLE
Feature: Use FontSource package for Inter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "@prefecthq/orion-design",
             "version": "1.0.100",
             "dependencies": {
+                "@fontsource/inter": "4.5.12",
                 "@prefecthq/radar": "0.0.17",
                 "@prefecthq/vue-charts": "0.0.19",
                 "@prefecthq/vue-compositions": "0.1.49",
@@ -94,6 +95,11 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/@fontsource/inter": {
+            "version": "4.5.12",
+            "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.12.tgz",
+            "integrity": "sha512-bGKk4/8tube/nCk8hav0ZDBVbzJzc7m0Vt4xF5p15IN4YImwGdtKG38Oq5bU8xHNS+VfvbFFCepgQNj7Pr/Lvg=="
         },
         "node_modules/@heroicons/vue": {
             "version": "1.0.6",
@@ -4690,6 +4696,11 @@
                 "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             }
+        },
+        "@fontsource/inter": {
+            "version": "4.5.12",
+            "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.12.tgz",
+            "integrity": "sha512-bGKk4/8tube/nCk8hav0ZDBVbzJzc7m0Vt4xF5p15IN4YImwGdtKG38Oq5bU8xHNS+VfvbFFCepgQNj7Pr/Lvg=="
         },
         "@heroicons/vue": {
             "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "vue-router": "^4.0.12"
     },
     "dependencies": {
+        "@fontsource/inter": "4.5.12",
         "@prefecthq/radar": "0.0.17",
         "@prefecthq/vue-charts": "0.0.19",
         "@prefecthq/vue-compositions": "0.1.49",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1,4 +1,4 @@
-@import "https://rsms.me/inter/inter.css";
+@import "@fontsource/inter/variable.css";
 @import 'https://fonts.googleapis.com/css2?family=Inconsolata&display=swap';
 
 @import "./colors.css";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,7 +46,7 @@ module.exports = {
   ],
   theme: {
     fontFamily: {
-      sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      sans: ["InterVariable", ...defaultTheme.fontFamily.sans],
       mono: ['Inconsolata', ...defaultTheme.fontFamily.mono],
     },
     extend: {


### PR DESCRIPTION
Load the Inter font from FontSource, rather than loading it from the author's domain.

---

This has some benefits:

* Avoids the author being able to track our users
* Allows us to simplify our Content-Security-Policy headers
* Should improve page load performance, as all content comes from a single origin (I've seen this bump Lighthouse scores by quite a bit)
* Allows us to control exact font versions, so we can decide when to upgrade

There are also some drawbacks:

* We have to update an additional package periodically
* This will increase our bandwidth usage by a small amount
* This increases our bundle size
* This may mean that we end up with several copies of these fonts (from orion-design, prefect-design, and nebula-ui) and I'm not sure how to avoid this

If this change looks good to everyone, I'll repeat the same for Inconsolata.

---

Build before:

```
08:33 jawnsy@consilience ~/projects/work/orion-design $ git switch main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

08:41 jawnsy@consilience ~/projects/work/orion-design $ npm run build

> @prefecthq/orion-design@1.0.93 build
> vue-tsc && tsc-alias && vite build

vite v2.9.13 building for production...
✓ 1154 modules transformed.
dist/style.css            85.11 KiB / gzip: 14.63 KiB
dist/orion-design.es.js   2509.08 KiB / gzip: 409.65 KiB
No name was provided for external module 'vue-router' in output.globals – guessing 'vueRouter'
dist/orion-design.umd.js   1415.08 KiB / gzip: 320.13 KiB
```

Build after:

```
08:41 jawnsy@consilience ~/projects/work/orion-design $ git switch jawnsy/inter-fontsource
Switched to branch 'jawnsy/inter-fontsource'
Your branch is up to date with 'origin/jawnsy/inter-fontsource'.

08:41 jawnsy@consilience ~/projects/work/orion-design $ npm run build

> @prefecthq/orion-design@1.0.93 build
> vue-tsc && tsc-alias && vite build

vite v2.9.13 building for production...
✓ 1154 modules transformed.
dist/style.css            322.61 KiB / gzip: 196.03 KiB
dist/orion-design.es.js   2746.58 KiB / gzip: 590.60 KiB
No name was provided for external module 'vue-router' in output.globals – guessing 'vueRouter'
dist/orion-design.umd.js   1652.58 KiB / gzip: 501.23 KiB
```