### PR TITLE
Enhancement: add states prop to FlowRunFilteredList

### DIFF
--- a/src/components/FlowRunFilteredList.vue
+++ b/src/components/FlowRunFilteredList.vue
@@ -44,8 +44,8 @@
 
   const state = ref<StateType[]>(props.states ?? [])
 
-  const updateState = (newValue: StateType[]): void => {
-    state.value = newValue
+  const updateState = (newValue: string | string[] | null): void => {
+    state.value = newValue as StateType[]
     emit('update:states', state.value)
   }
 


### PR DESCRIPTION
This PR introduces a new optional `states` prop to FlowRunFilteredList component. Usecase in this PR: https://github.com/PrefectHQ/nebula-ui/pull/1712

I tried to pass state as a part of a `flowRunFilter`, but couldn't rewrite it on demand properly, and ended up getting only Running/Pending flow runs at all time

Usecase on video:

https://user-images.githubusercontent.com/40467112/193603078-684e436f-a215-4c9b-9d3b-91f406b0a502.mov

