### PR TITLE
Upgrade prefect-design from 1.1.4 to 1.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "vue-tsc": "0.40.13"
             },
             "peerDependencies": {
-                "@prefecthq/prefect-design": "^1.1.4",
+                "@prefecthq/prefect-design": "^1.1.15",
                 "pinia": "^2.0.14",
                 "vee-validate": "^4.5.11",
                 "vue": "^3.2.39",
@@ -204,9 +204,9 @@
             }
         },
         "node_modules/@prefecthq/prefect-design": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-1.1.4.tgz",
-            "integrity": "sha512-t/hLN17AYg3Zn/s530XBFnd7e/AHiLdCafNIvvw38rIW98uqoHwsfs9wgLmU7FtdQwp/7wy50eUsOcF1abEm7g==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-1.1.15.tgz",
+            "integrity": "sha512-DomvLNLGiY+aBqHY120aMWjEfijPr7viX+bwTbGt4m+j/MgDJLlLzxXVnN0PoTlVfQ00IBch7RNMk0fHnbXoLg==",
             "peer": true,
             "dependencies": {
                 "@heroicons/vue": "^1.0.6",
@@ -4777,9 +4777,9 @@
             }
         },
         "@prefecthq/prefect-design": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-1.1.4.tgz",
-            "integrity": "sha512-t/hLN17AYg3Zn/s530XBFnd7e/AHiLdCafNIvvw38rIW98uqoHwsfs9wgLmU7FtdQwp/7wy50eUsOcF1abEm7g==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-1.1.15.tgz",
+            "integrity": "sha512-DomvLNLGiY+aBqHY120aMWjEfijPr7viX+bwTbGt4m+j/MgDJLlLzxXVnN0PoTlVfQ00IBch7RNMk0fHnbXoLg==",
             "peer": true,
             "requires": {
                 "@heroicons/vue": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "vue-tsc": "0.40.13"
     },
     "peerDependencies": {
-        "@prefecthq/prefect-design": "^1.1.4",
+        "@prefecthq/prefect-design": "^1.1.15",
         "pinia": "^2.0.14",
         "vee-validate": "^4.5.11",
         "vue": "^3.2.39",


### PR DESCRIPTION
Since orion-design includes styles from prefect-design, it appears that the old version results in fonts being included incorrectly, instead of using the bundled Fontsource versions. I believe that this change resolves the issue by requiring a minimum version that includes the new bundled fonts.