### PR TITLE
BugFix: Use start-date on filters and add additional filters at the api level

### DIFF
--- a/src/components/SaveFilterModal.vue
+++ b/src/components/SaveFilterModal.vue
@@ -20,21 +20,28 @@
 </template>
 
 <script lang="ts" setup>
+  import { useSubscription } from '@prefecthq/vue-compositions'
   import { useField, useForm } from 'vee-validate'
   import { computed } from 'vue'
+  import { workspaceApiKey } from '@/utilities'
+  import { inject } from '@/utilities/inject'
   import { isRequired, withMessage, isValidIf } from '@/utilities/validation'
+
+  const api = inject(workspaceApiKey)
+  const savedSearchesSubscription = useSubscription(api.savedSearches.getSavedSearches)
+  const savedSearches = computed(()=> savedSearchesSubscription.response ?? [])
 
   const props = defineProps<{
     showModal: boolean,
-    filterNames: string[],
   }>()
 
   const { handleSubmit, handleReset, isSubmitting } = useForm<{
     filterName: string,
   }>()
 
-  const nameDoesNotExist = isValidIf(value => !value || !props.filterNames.includes(value as string))
+  const filterNames = savedSearches.value.map(search => search.name)
 
+  const nameDoesNotExist = isValidIf(value => !value || !filterNames.includes(value as string))
   const { value: filterName, meta: filterNameState, errorMessage: filterErrorMessage } = useField<string>('filterName', [withMessage(nameDoesNotExist, 'Name must be unique'), isRequired('Name')])
 
   const emit = defineEmits<{

--- a/src/components/SavedFilters.vue
+++ b/src/components/SavedFilters.vue
@@ -9,7 +9,7 @@
       Delete View
     </p-overflow-menu-item>
   </p-icon-button-menu>
-  <SaveFilterModal v-model:show-modal="showSaveModal" :filter-names="filterNames" @save="saveFilter" />
+  <SaveFilterModal v-model:show-modal="showSaveModal" @save="saveFilter" />
   <ConfirmDeleteModal
     v-model:showModal="showDeleteModal"
     label="Saved Filter"
@@ -31,7 +31,7 @@
   import { localization } from '@/localization'
   import { workspaceApiKey } from '@/utilities'
   import { inject } from '@/utilities/inject'
-  import { oneWeekFilter, noScheduleFilter, isCustomFilter } from '@/utilities/savedFilters'
+  import { isCustomFilter, defaultFilterValue } from '@/utilities/savedFilters'
 
   const can = useCan()
   const route = useRoute()
@@ -43,7 +43,7 @@
   const { showModal: showDeleteModal, open: openDeleteModal } = useShowModal()
   const savedSearchesSubscription = useSubscription(api.savedSearches.getSavedSearches)
   const savedSearches = computed(()=> savedSearchesSubscription.response ?? [])
-  const defaultFilterValue = 'Default view'
+
 
   onMounted(() => {
     selectedSavedSearch.value = hasFilters.value ? 'Custom' : defaultFilterValue
@@ -84,29 +84,16 @@
     }
   }
 
-  const modifiedSavedSearches = computed(()=> [
-    { name: 'Custom', id: null },
-    {
-      name: defaultFilterValue,
-      filters: oneWeekFilter,
-    },
-    {
-      name: 'No scheduled',
-      filters: noScheduleFilter,
-    },
-    ...savedSearches.value,
-  ])
-
   const selectedSearchIsCustom = computed(() => selectedSavedSearch.value == 'Custom')
 
-  const options = computed<SelectOption[]>(() => modifiedSavedSearches.value.map(search => {
+  const options = computed<SelectOption[]>(() => savedSearches.value.map(search => {
     return { label: search.name, value: search.name,  disabled: search.name === 'Custom' }
   }))
 
   const filterNames = computed(()=>options.value.map(option => option.label))
 
   const selectedSavedSearch = ref()
-  const selectedSavedSearchValue = computed(() => modifiedSavedSearches.value.find(filter => filter.name === selectedSavedSearch.value))
+  const selectedSavedSearchValue = computed(() => savedSearches.value.find(filter => filter.name === selectedSavedSearch.value))
   const savedSearchId = computed(() => selectedSavedSearchValue.value?.id)
 
   watchEffect(async ()=> {

--- a/src/maps/savedSearch.ts
+++ b/src/maps/savedSearch.ts
@@ -18,8 +18,8 @@ function mapSavedSearchFilters(filters: SavedSearchFilterResponse[] | undefined)
     tag: [],
     flow: [],
     deployment: [],
-    startDate: formatDateTimeNumeric(subDays(startOfToday(), 7)),
-    endDate: formatDateTimeNumeric(addDays(endOfToday(), 1)),
+    'start-date': formatDateTimeNumeric(subDays(startOfToday(), 7)),
+    'end-date': formatDateTimeNumeric(addDays(endOfToday(), 1)),
   }
   if (filters) {
     filter.flow = filters.find(filter => filter.property === 'flow')?.value ?? []

--- a/src/models/SavedSearch.ts
+++ b/src/models/SavedSearch.ts
@@ -28,6 +28,6 @@ export type SavedSearchFilter = {
   flow?: FilterResponseValue,
   tag?: FilterResponseValue,
   deployment?: FilterResponseValue,
-  startDate?: FilterResponseValue,
-  endDate?: FilterResponseValue,
+  'start-date'?: FilterResponseValue,
+  'end-date'?: FilterResponseValue,
 }

--- a/src/services/WorkspaceSavedSearchesApi.ts
+++ b/src/services/WorkspaceSavedSearchesApi.ts
@@ -2,15 +2,16 @@ import { WorkspaceApi } from './WorkspaceApi'
 import { SavedSearchResponse } from '@/models/api/SavedSearchResponse'
 import { SavedSearch, SavedSearchCreate } from '@/models/SavedSearch'
 import { mapper } from '@/services/Mapper'
+import { additionalFilters, AdditionalFilter } from '@/utilities/savedFilters'
 
 export class WorkspaceSavedSearchesApi extends WorkspaceApi {
 
   protected routePrefix = '/saved_searches'
 
-  public async getSavedSearches(filter = {}): Promise<SavedSearch[]> {
+  public async getSavedSearches(filter = {}): Promise<(SavedSearch| AdditionalFilter)[] > {
     const { data } = await this.post<SavedSearchResponse[]>('/filter', filter)
 
-    return mapper.map('SavedSearchResponse', data, 'SavedSearch')
+    return [...additionalFilters, ...mapper.map('SavedSearchResponse', data, 'SavedSearch')]
   }
 
   public async getSavedSearch(id: string): Promise<SavedSearch> {

--- a/src/utilities/savedFilters.ts
+++ b/src/utilities/savedFilters.ts
@@ -4,6 +4,8 @@ import { Ref } from 'vue'
 import { SavedSearchFilter } from '@/models/SavedSearch'
 import { isSame } from '@/utilities/arrays'
 
+export const defaultFilterValue = 'Default view'
+
 
 // eslint-disable-next-line max-params
 export function isCustomFilter(savedFilter: SavedSearchFilter, states: Ref<string[]>, flows: Ref<string[]>, deployments: Ref<string[]>, tags: Ref<string[]>): boolean {
@@ -65,3 +67,23 @@ export const noScheduleFilter = {
   startDate: formatDateTimeNumeric(subDays(startOfToday(), 7)),
   endDate: formatDateTimeNumeric(addDays(endOfToday(), 1)),
 }
+
+export type AdditionalFilter = {
+  name: string,
+  filters?: SavedSearchFilter,
+  id: null,
+}
+
+export const additionalFilters: AdditionalFilter[] = [
+  { name: 'Custom', id: null },
+  {
+    name: defaultFilterValue,
+    filters: oneWeekFilter,
+    id: null,
+  },
+  {
+    name: 'No scheduled',
+    filters: noScheduleFilter,
+    id: null,
+  },
+]


### PR DESCRIPTION
No real impact on functionality but some code cleaning requested by @pleek91 and switching to use start-date instead of startDate which will be helpful for adding time/date filters. 