### PR TITLE
Enhancement: Add a link to the task run page from the radar task run node

### DIFF
--- a/src/components/RadarNodeTaskRun.vue
+++ b/src/components/RadarNodeTaskRun.vue
@@ -6,9 +6,9 @@
       </div>
     </template>
 
-    <div class="radar-node-task-run__content">
+    <p-link v-if="taskRun" :to="taskRunRoute(taskRun.id)" class="radar-node-task-run__content">
       {{ taskRunName }}
-    </div>
+    </p-link>
 
     <template #footer-leading>
       <DurationIconText :duration="duration" />
@@ -29,6 +29,7 @@
   import ORadarNode from './RadarNode.vue'
   import StateIcon from './StateIcon.vue'
   import { TaskRun, GraphNode, StateType } from '@/models'
+  import { taskRunRouteKey } from '@/router/routes'
   import { taskRunsApiKey } from '@/services/TaskRunsApi'
   import { inject } from '@/utilities/inject'
 
@@ -43,6 +44,8 @@
   const taskRun = computed<TaskRun | undefined>(() => {
     return subscription.response
   })
+
+  const taskRunRoute = inject(taskRunRouteKey)
 
   const taskRunName = computed(() => taskRun.value?.name)
 


### PR DESCRIPTION
Enables clicking through to the task run page from the task run node in radar. 

Current:

<img width="612" alt="image" src="https://user-images.githubusercontent.com/40272060/195339044-d0edec87-f078-44b2-8070-b12601912c77.png">

Updated:

<img width="562" alt="image" src="https://user-images.githubusercontent.com/40272060/195339139-8063278a-723d-4a4f-b7c7-fe86ee649adb.png">

Closes https://github.com/PrefectHQ/prefect/issues/6871