### PR TITLE
Chore: Mark vee-validate as an external dependency in the vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig(({ mode }) => {
       },
       rollupOptions: {
       // ensures vue isn't added to the bundle
-        external: ['vue', 'vue-router'],
+        external: ['vue', 'vue-router', 'vee-validate'],
         output: {
           exports: 'named',
           // Provide vue as a global variable to use in the UMD build


### PR DESCRIPTION
# Description
vee-validate is a peer dependency but it was not set as an external dependency in the vite config. This meant that orion-design had its own version of vee-validate. Which causes issues when wrapping any vee-validate compositions in orion-design versions