### PR TITLE
BugFix: spacing of subflow run

### DIFF
--- a/demo/sections/RadarNodeSection.vue
+++ b/demo/sections/RadarNodeSection.vue
@@ -37,7 +37,7 @@
       <RadarNodeFlowRun :graph-node="flowRun" :collapsed="collapsedMap" :downstream-nodes="0" :toggle="toggleCollapsed" />
     </SubSection>
 
-    <SubSection heading="Sub flow run">
+    <SubSection heading="Subflow run">
       <RadarNodeSubFlowRun :graph-node="flowRun" :collapsed="collapsedMap" :downstream-nodes="20" :toggle="toggleCollapsed" />
     </SubSection>
   </Section>

--- a/src/components/FlowRunSubFlows.vue
+++ b/src/components/FlowRunSubFlows.vue
@@ -10,7 +10,7 @@
 
     <PEmptyResults v-if="empty">
       <template #message>
-        No sub flow runs
+        No subflow runs
       </template>
       <template v-if="hasFilters" #actions>
         <p-button size="sm" secondary @click="clear">


### PR DESCRIPTION
This PR removes a space between sub and flow per documentation standards

> Task run, flow run, and subflow are the current usage in the docs