### PR TITLE
Chore: Update release workflow to use checkout v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps: 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Check Package Version
         uses: EndBug/version-check@v2.1.0
@@ -34,7 +34,7 @@ jobs:
     environment: 'prod'
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Read .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"


### PR DESCRIPTION
# Description
Hoping this fixes the release workflow which is currently failing on the commit changelog step. Comparing this project's release workflow with the one from vue-comopsitions (which works just fine) the only major difference is which version of checkout is being used. 