### PR TITLE
BugFix: Fix deployments page breaking due to incorrect type

### DIFF
--- a/src/maps/deployment.ts
+++ b/src/maps/deployment.ts
@@ -5,7 +5,7 @@ import { MapFunction } from '@/services/Mapper'
 import { mapCamelToSnakeCase } from '@/utilities'
 
 export const mapDeploymentResponseToDeployment: MapFunction<DeploymentResponse, Deployment> = function(source: DeploymentResponse): Deployment {
-  const schema = this.map('SchemaResponse', source.parameter_openapi_schema, 'Schema')
+  const schema = this.map('SchemaResponse', source.parameter_openapi_schema ?? {}, 'Schema')
   const values = this.map('SchemaValuesResponse', { values: source.parameters, schema }, 'SchemaValues')
 
   return new Deployment({

--- a/src/models/DeploymentResponse.ts
+++ b/src/models/DeploymentResponse.ts
@@ -18,7 +18,7 @@ export type DeploymentResponse = {
   manifest_path: string | null,
   path: string | null,
   entrypoint: string | null,
-  parameter_openapi_schema: SchemaResponse,
+  parameter_openapi_schema: SchemaResponse | null,
   storage_document_id: string | null,
   infrastructure_document_id: string | null,
   work_queue_name: string | null,


### PR DESCRIPTION
# Description
Make `DeploymentResponse.parameter_openapi_schema` nullable to match what's being returned by the api. 