### PR TITLE
Fix: Add cache to utilities export

### DIFF
--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,5 +1,6 @@
 export * from './api'
 export * from './arrays'
+export * from './cache'
 export * from './colorMode'
 export * from './components'
 export * from './copy'


### PR DESCRIPTION
Fixes an issue where the cache utilities file wasn't exported like the rest of the utilities files. 