### PR TITLE
Chore: Add flag for cloud

### DIFF
--- a/src/components/FlowRunRetryButton.vue
+++ b/src/components/FlowRunRetryButton.vue
@@ -35,13 +35,9 @@
   }>()
   const can = useCan()
   const api = useWorkspaceApi()
-  const isCloud = window.location.toString().includes('account')
 
   const canRetry = computed(()=> {
-    if (isCloud) {
-      return false
-    }
-    if (!can.update.flow_run || !props.flowRun.stateType || !props.flowRun.deploymentId) {
+    if (!can.update.flow_run || !props.flowRun.stateType || !props.flowRun.deploymentId || !can.access.retry) {
       return false
     }
     return isTerminalStateType(props.flowRun.stateType)

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -118,6 +118,7 @@ const featureFlags = [
   'access:scim',
   'access:selfServeOrgs',
   'access:auditLogs',
+  'access:retry',
 ] as const
 
 export type FeatureFlagString = typeof featureFlags[number]


### PR DESCRIPTION
Adds a feature flag for the retry button so we can update orion design without showing it in nebula/cloud yet. 