### PR TITLE
Enhancement: Increase window for showing lateness to 60 seconds

### DIFF
--- a/src/models/FlowRun.ts
+++ b/src/models/FlowRun.ts
@@ -105,7 +105,7 @@ export class FlowRun implements IFlowRun {
   }
 
   public get delta(): string | null {
-    if (!this.estimatedStartTimeDelta || this.estimatedStartTimeDelta <= 1) {
+    if (!this.estimatedStartTimeDelta || this.estimatedStartTimeDelta <= 60) {
       return null
     }
 


### PR DESCRIPTION
As pointed out by @anna-geller - the XX seconds late can feel a little overzealous - this PR increases the window for showing lateness to 60 seconds/1 minute. 