### PR TITLE
Chore: Make WorkQueueCreate isPaused non nullable

### DIFF
--- a/src/models/WorkQueueCreate.ts
+++ b/src/models/WorkQueueCreate.ts
@@ -1,6 +1,6 @@
 export type WorkQueueCreate = {
   name: string,
-  description?: string,
+  description?: string | null,
   isPaused?: boolean,
-  concurrencyLimit?: number,
+  concurrencyLimit?: number | null,
 }


### PR DESCRIPTION
# Description
Property cannot be null according to the api schema. And having it nullable makes mocking more difficult. So removing null from the type.