### PR TITLE
Chore: Fix release workflow tag name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,5 +60,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.publish.outputs.version }}
+          tag_name: v${{ steps.publish.outputs.version }}
           release_name: Release ${{ steps.publish.outputs.version }}


### PR DESCRIPTION
The release workflow was creating duplicate tags (without the `v` prefix). We create tags automatically using `npm version`.