### PR TITLE
Feature: add `null` option to timezone-select component

### DIFF
--- a/src/components/TimezoneSelect.vue
+++ b/src/components/TimezoneSelect.vue
@@ -29,5 +29,9 @@
   })
 
   const timezones = Intl.supportedValuesOf('timeZone').map(timezone => ({ label: timezone, value: timezone }))
-  const options: SelectOption[] = [{ label: 'UTC', value: utcTimezone }, ...timezones]
+  const options: SelectOption[] = [
+    { label: 'Use browser default', value: null },
+    { label: 'UTC', value: utcTimezone },
+    ...timezones,
+  ]
 </script>


### PR DESCRIPTION
as part of [this suggestion](https://github.com/PrefectHQ/nebula-ui/pull/1852#issuecomment-1315533721), I've added a `null` option to the timezone-select

ps: color-mode select already had a `null` option