### PR TITLE
use parseIso instead of parse

### DIFF
--- a/src/services/schemas/properties/SchemaPropertyString.ts
+++ b/src/services/schemas/properties/SchemaPropertyString.ts
@@ -114,7 +114,7 @@ export class SchemaPropertyString extends SchemaPropertyService {
   }
 
   private responseDateTimeValue(value: SchemaValue): Date {
-    const date = dateFunctions.parse(value as string, 'yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'', new Date())
+    const date = dateFunctions.parseISO(value as string)
 
     if (!dateFunctions.isValid(date)) {
       this.invalid()


### PR DESCRIPTION
Rsolves https://github.com/PrefectHQ/prefect/issues/7392 by using parseISO instead of parse.  DateTime blocks expect an ISO 8601 string which does not require a timezone. 