### PR TITLE
Chore: Remove "Deployments" filter from Flows page

### DIFF
--- a/src/components/FlowsTable.vue
+++ b/src/components/FlowsTable.vue
@@ -55,7 +55,7 @@
 <script lang="ts" setup>
   import { PTable, PEmptyResults, PLink } from '@prefecthq/prefect-design'
   import { useSubscription } from '@prefecthq/vue-compositions'
-  import { computed, unref } from 'vue'
+  import { computed } from 'vue'
   import DeploymentsCount from './DeploymentsCount.vue'
   import ResultsCount from './ResultsCount.vue'
   import SearchInput from './SearchInput.vue'


### PR DESCRIPTION
This PR removes the "Deployments" filter from the Flows page

Closes https://github.com/PrefectHQ/prefect/issues/7402