### PR TITLE
Chore: remove Cancel button

### DIFF
--- a/src/components/PageHeadingFlowRun.vue
+++ b/src/components/PageHeadingFlowRun.vue
@@ -5,7 +5,6 @@
     </template>
     <template #actions>
       <FlowRunRetryButton :flow-run="flowRun" class="page-heading-flow-run__retry-button" />
-      <FlowRunCancelButton :flow-run="flowRun" class="page-heading-flow-run__cancel-button" />
       <p-icon-button-menu>
         <template #default>
           <p-overflow-menu-item v-if="canRetry" label="Retry" class="page-heading-flow-run__retry-menu-item" @click="openRetryModal" />
@@ -39,7 +38,6 @@
   import { PIconButtonMenu, showToast } from '@prefecthq/prefect-design'
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed, ref } from 'vue'
-  import FlowRunCancelButton from './FlowRunCancelButton.vue'
   import { StateBadge, PageHeading, CopyOverflowMenuItem, ConfirmDeleteModal, FlowRunRetryButton, FlowRunRetryModal, ConfirmStateChangeModal } from '@/components'
   import { useWorkspaceApi } from '@/compositions'
   import { useCan } from '@/compositions/useCan'


### PR DESCRIPTION
The world is not ready for Cancelling. This PR temporarily removes the Cancel button from FlowRunsPageHeading until better times