### PR TITLE
Bugfix: fix bug when Cancel modal doesn't close on Submit

### DIFF
--- a/src/components/FlowRunCancelModal.vue
+++ b/src/components/FlowRunCancelModal.vue
@@ -62,6 +62,7 @@
       await api.flowRuns.setFlowRunState(props.flowRunId, { state: values })
       flowRunSubscription.refresh()
       internalValue.value = false
+      emit('cancel')
       showToast(localization.success.cancelFlowRun, 'success')
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
This PR fixes an issue when modal for the Cancel button wouldn't cancel on submit