### PR TITLE
Feature: Object required type guard

### DIFF
--- a/src/utilities/object.ts
+++ b/src/utilities/object.ts
@@ -62,6 +62,6 @@ export function isEmptyObject(value: unknown): value is Record<string, never> {
   return typeof value === 'object' && !Array.isArray(value) && value !== null && Object.keys(value).length === 0
 }
 
-export function satisfiesRequired<T extends Record<string | number | symbol, unknown>>(value: Partial<T>): value is Required<T> {
+export function isTypeRequired<T extends Record<string | number | symbol, unknown>>(value: Partial<T>): value is Required<T> {
   return Object.values(value).every(value => value !== undefined)
 }


### PR DESCRIPTION
often times with vee-validate, your type is assumed to be a partial

```ts
type MyType = {
  name: string,
  age: number,
  favoriteColor: Color
}

const { handleSubmit } = useForm<MyType>()
```

and even when you have rules that require the value, it will still be a `Partial` at time of submit

```ts
const submit = handleSubmit(async values => {
  // values is still Partial<MyType>
})
```

this type guard is an easy way to assert that a thing that has some optional properties does not currently have anything missing from it

```ts
const submit = handleSubmit(async values => {
  if(isRequired(values)) {
    // values is Required<MyType>
  }
})
```