### PR TITLE
BugFix: Flow run name not updating when navigating to a subflow run

### DIFF
--- a/src/components/PageHeadingFlowRun.vue
+++ b/src/components/PageHeadingFlowRun.vue
@@ -40,6 +40,7 @@
     { text: flowRun.value?.name ?? '' },
   ])
 
-  const flowRunSubscription =  useSubscription(api.flowRuns.getFlowRun, [props.flowRunId], { interval: 30000 })
+  const flowRunId = computed(() => props.flowRunId)
+  const flowRunSubscription =  useSubscription(api.flowRuns.getFlowRun, [flowRunId], { interval: 30000 })
   const flowRun = computed(() => flowRunSubscription.response)
 </script>


### PR DESCRIPTION
# Description
the `flowRunId` prop was being used directly in the subscription which meant it was not reactive. Using a computed ensures the subscription updates whenever the prop changes. 