### PR TITLE
Enhancement: Add optional preCommand prop to Codebanner

### DIFF
--- a/src/components/CodeBanner.vue
+++ b/src/components/CodeBanner.vue
@@ -18,7 +18,12 @@
         </template>
       </div>
     </template>
-    <p-terminal :command="command" class="code-banner__terminal" />
+
+    <p-terminal
+      :command="command"
+      :pre-command="preCommand"
+      class="code-banner__terminal"
+    />
   </div>
 </template>
 
@@ -29,6 +34,7 @@
     title?: string,
     subtitle?: string,
     command: string,
+    preCommand?: string,
   }>()
 
   const slots = useSlots()


### PR DESCRIPTION
Needs a prefect design update with https://github.com/PrefectHQ/prefect-design/pull/523

Adds an optional pre-command prop to the codebanner to facilitate two line commands

Part of https://github.com/PrefectHQ/nebula-ui/issues/2022