### PR TITLE
Chore: Temporarily hide the link to concurrency limit page so we can release without it

### DIFF
--- a/src/components/ConcurrencyLimitsTable.vue
+++ b/src/components/ConcurrencyLimitsTable.vue
@@ -1,10 +1,5 @@
 <template>
   <p-table class="concurrency-limits-table__table" :columns="columns" :data="concurrencyLimits">
-    <template #tag="{ row }">
-      <p-link :to="routes.concurrencyLimit(row.id)">
-        {{ row.tag }}
-      </p-link>
-    </template>
     <template #active-task-runs="{ row }">
       <ConcurrencyTableActiveSlots v-if="row.activeSlots" :active-slots="row.activeSlots" />
     </template>


### PR DESCRIPTION
The full concurrency limit page is not ready yet.  But we need to release orion design to fix the task run list item.  This temporarily hides it so we can release orion design and then add this back. 
