### PR TITLE
Bugfix: Radar route record component reference

### DIFF
--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -74,7 +74,7 @@ export function createWorkspaceRouteRecords(components: Partial<WorkspaceRouteCo
         {
           name: 'workspace.flow-runs.flow-run-radar',
           path: 'flow-run/:flowRunId/radar',
-          component: components.flowRun,
+          component: components.flowRunRadar,
         },
         {
           name: 'workspace.flow-runs.task-run',


### PR DESCRIPTION
This PR fixes an issue introduced in #778 that caused the radar route record to reference the flow run page component instead of the flow run radar page component.