### PR TITLE
Enhancement: Support `allowUnset` on all combobox components

### DIFF
--- a/src/components/FlowCombobox.vue
+++ b/src/components/FlowCombobox.vue
@@ -15,6 +15,7 @@
   const props = defineProps<{
     selected: string | string[] | null | undefined,
     emptyMessage?: string,
+    allowUnset?: boolean,
   }>()
 
   const emits = defineEmits<{
@@ -41,8 +42,19 @@
   const api = useWorkspaceApi()
   const flowsSubscription = useSubscription(api.flows.getFlows, [{}])
   const flows = computed(() => flowsSubscription.response ?? [])
-  const options = computed<SelectOption[]>(() => flows.value.map(flow => ({
-    value: flow.id,
-    label: flow.name,
-  })))
+  const options = computed<SelectOption[]>(() => {
+    const options: SelectOption[] = flows.value.map(flow => ({
+      value: flow.id,
+      label: flow.name,
+    }))
+
+    if (props.allowUnset) {
+      options.unshift({
+        value: null,
+        label: 'None',
+      })
+    }
+
+    return options
+  })
 </script>

--- a/src/components/WorkQueueCombobox.vue
+++ b/src/components/WorkQueueCombobox.vue
@@ -15,6 +15,7 @@
   const props = defineProps<{
     selected: string | string[] | null | undefined,
     emptyMessage?: string,
+    allowUnset?: boolean,
   }>()
 
   const emits = defineEmits<{
@@ -41,9 +42,20 @@
   const api = useWorkspaceApi()
   const workQueuesSubscription = useSubscription(api.workQueues.getWorkQueues, [{}])
   const workQueues = computed(() => workQueuesSubscription.response ?? [])
-  const options = computed<SelectOption[]>(() => workQueues.value.map(workQueue => ({
-    // Any consumers of the work queue should subscribe to it by name and not id
-    value: workQueue.name,
-    label: workQueue.name,
-  })))
+  const options = computed<SelectOption[]>(() => {
+    const options: SelectOption[] = workQueues.value.map(workQueue => ({
+      // Any consumers of the work queue should subscribe to it by name and not id
+      value: workQueue.name,
+      label: workQueue.name,
+    }))
+
+    if (props.allowUnset) {
+      options.unshift({
+        value: null,
+        label: 'None',
+      })
+    }
+
+    return options
+  })
 </script>


### PR DESCRIPTION
# Description
Following the change to DeploymentCombobox and adding the `allowUnset` prop to the WorkQueueCombobox and the FlowCombobox