### PR TITLE
Enhancement: Make logo images more visible in dark mode. Add Spacing between block catalog heading and message

### DIFF
--- a/src/components/LogoImage.vue
+++ b/src/components/LogoImage.vue
@@ -16,15 +16,17 @@
     size: 'md',
   })
 
-  const background = computed(() => `url(${props.url})`)
   const classes = computed(() => [`logo-image--size-${props.size}`])
 </script>
 
 <style>
 .logo-image { @apply
   bg-cover
-  bg-center;
-  background-image: v-bind(background)
+  bg-center
+  dark:rounded
+  dark:p-0.5
+  dark:overflow-hidden
+  dark:bg-white
 }
 
 .logo-image--size-sm { @apply

--- a/src/components/PageHeadingBlocksCatalog.vue
+++ b/src/components/PageHeadingBlocksCatalog.vue
@@ -1,13 +1,15 @@
 <template>
-  <page-heading class="page-heading-blocks-catalog" :crumbs="crumbs" />
+  <p-content>
+    <page-heading class="page-heading-blocks-catalog" :crumbs="crumbs" />
 
-  <p-message>
-    If you don't see a block for the service you're using, check out our
-    <p-link :to="localization.docs.collections">
-      Collections Catalog
-    </p-link>
-    to view a list of integrations and their corresponding blocks.
-  </p-message>
+    <p-message>
+      If you don't see a block for the service you're using, check out our
+      <p-link :to="localization.docs.collections">
+        Collections Catalog
+      </p-link>
+      to view a list of integrations and their corresponding blocks.
+    </p-message>
+  </p-content>
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
# Description

Before
<img width="969" alt="image" src="https://user-images.githubusercontent.com/6200442/218158897-3a753821-08a1-4440-82cd-d64e083b145c.png">

After
<img width="986" alt="image" src="https://user-images.githubusercontent.com/6200442/218158793-2106d534-48bf-4e76-8237-1f7bb66363c0.png">
