### PR TITLE
BugFix: Flow run logs flashing because of polling and subscription reactivity issues

### DIFF
--- a/src/compositions/usePaginatedSubscription.ts
+++ b/src/compositions/usePaginatedSubscription.ts
@@ -1,5 +1,6 @@
 import { useSubscription, ActionArguments, ActionResponse, SubscribeArguments, UseSubscription, unrefArgs, watchableArgs } from '@prefecthq/vue-compositions'
 import { computed, getCurrentInstance, onUnmounted, reactive, ref, watch } from 'vue'
+import { uniqueValueWatcher } from '@/utilities/reactivity'
 
 export type Paginated = { limit?: number, offset?: number }
 // any is correct here
@@ -55,7 +56,7 @@ export function usePaginatedSubscription<T extends PaginatedAction>(...[action, 
   }
 
   if (watchable !== null) {
-    unwatch = watch(watchable, () => {
+    unwatch = uniqueValueWatcher(watchable, () => {
       if (!isSubscribed()) {
         unwatch!()
         return

--- a/src/utilities/arrays.ts
+++ b/src/utilities/arrays.ts
@@ -1,6 +1,10 @@
 import { mocker } from '@/services'
 import { floor, random } from '@/utilities/math'
 
+export function isArray(value: unknown): value is unknown[] {
+  return Array.isArray(value)
+}
+
 // we really do want any here
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toMap<T extends any[], K extends keyof T[number]>(source: T, key: K): Map<T[number][K], T[number]> {

--- a/src/utilities/reactivity.ts
+++ b/src/utilities/reactivity.ts
@@ -1,0 +1,45 @@
+import { isEqual } from 'lodash'
+import { isRef, unref, watch } from 'vue'
+import { isArray, isRecord, mapValues } from '@/utilities'
+
+function getRawValue(value: unknown): unknown {
+  if (typeof value === 'object') {
+    if (isRef(value)) {
+      return unref(value)
+    }
+
+    if (isArray(value)) {
+      return getRawArrayValue(value)
+    }
+
+    if (isRecord(value)) {
+      return getRawRecordValue(value)
+    }
+  }
+
+  return value
+}
+
+function getRawArrayValue(values: unknown[]): unknown[] {
+  return values.map(value => getRawValue(value))
+}
+
+function getRawRecordValue(value: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
+  return mapValues(value, (key, value) => getRawValue(value))
+}
+
+export function uniqueValueWatcher(...[source, callback, options]: Parameters<typeof watch>): ReturnType<typeof watch> {
+  let previous = getRawValue(source)
+
+  return watch(source, (...args) => {
+    const current = getRawValue(source)
+
+    if (isEqual(previous, current)) {
+      return
+    }
+
+    previous = current
+
+    callback(...args)
+  }, options)
+}


### PR DESCRIPTION
# Description
The flow run logs use the flow run id in its filter. Since the flow run itself is on a 5 second interval, reactive effects are triggered every 5 seconds. Since the `usePaginatedSubscription ` composition joins multiple calls together, the reactive effect of the filter empties the response array. 

There used to be a check in place that checked for equality of the watcher's new and old values. But the old and new values [will be the same when deep watching](https://vuejs.org/guide/essentials/watchers.html#deep-watchers) an object. So that [check was removed](https://github.com/PrefectHQ/prefect-ui-library/commit/85afa18c369b5a4bdc86d29d56c12b3f8aaccab5) in order to support the latest filters work. Removing that ensured filter objects were accurate, but also caused paginated subscriptions to be be resubscribed even when the actual value itself hadn't changed. 

Putting back an equality check that actually works for both simple and object values in the form of a new utility called `uniqueValueWatcher`. Which is effectively the following but written in a way that supports complex objects an arrays as the watch source. 

```typescript
watch(value, (newValue, oldValue) => {
  if(newValue === oldValue) {
    return
  }
  // do stuff
})
```