### PR TITLE
FlowRunTimeline: add recenter and fullscreen buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@prefecthq/prefect-ui-library",
             "version": "1.1.1",
             "dependencies": {
-                "@prefecthq/graphs": "0.1.16",
+                "@prefecthq/graphs": "0.1.17",
                 "@prefecthq/radar": "0.0.19",
                 "@prefecthq/vue-charts": "0.0.19",
                 "@types/lodash.isequal": "4.5.6",
@@ -939,9 +939,9 @@
             }
         },
         "node_modules/@prefecthq/graphs": {
-            "version": "0.1.16",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.16.tgz",
-            "integrity": "sha512-l6x4L3GPjsXz7tuvoMq9Qfef/ZHuY7RaiCVk0R6le5TRtm8oMZhNcozi4a136zerGPvLSKmvvS6DkTcrWfUjlw==",
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.17.tgz",
+            "integrity": "sha512-I/xcoO0jUY3wV7hYpAc3hU7zxDeQxxbkzYjYGdg9Hb0XyUMJggSE54nPkSBfFnYbzUwuNWTkLG00vBlFS0EwaA==",
             "dependencies": {
                 "@pixi-essentials/cull": "^1.1.0",
                 "@prefecthq/vue-compositions": "1.0.0",
@@ -6966,9 +6966,9 @@
             }
         },
         "@prefecthq/graphs": {
-            "version": "0.1.16",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.16.tgz",
-            "integrity": "sha512-l6x4L3GPjsXz7tuvoMq9Qfef/ZHuY7RaiCVk0R6le5TRtm8oMZhNcozi4a136zerGPvLSKmvvS6DkTcrWfUjlw==",
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.17.tgz",
+            "integrity": "sha512-I/xcoO0jUY3wV7hYpAc3hU7zxDeQxxbkzYjYGdg9Hb0XyUMJggSE54nPkSBfFnYbzUwuNWTkLG00vBlFS0EwaA==",
             "requires": {
                 "@pixi-essentials/cull": "^1.1.0",
                 "@prefecthq/vue-compositions": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@prefecthq/prefect-ui-library",
             "version": "1.1.1",
             "dependencies": {
-                "@prefecthq/graphs": "0.1.17",
+                "@prefecthq/graphs": "0.1.18",
                 "@prefecthq/radar": "0.0.19",
                 "@prefecthq/vue-charts": "0.0.19",
                 "@types/lodash.isequal": "4.5.6",
@@ -939,9 +939,9 @@
             }
         },
         "node_modules/@prefecthq/graphs": {
-            "version": "0.1.17",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.17.tgz",
-            "integrity": "sha512-I/xcoO0jUY3wV7hYpAc3hU7zxDeQxxbkzYjYGdg9Hb0XyUMJggSE54nPkSBfFnYbzUwuNWTkLG00vBlFS0EwaA==",
+            "version": "0.1.18",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.18.tgz",
+            "integrity": "sha512-HyriFm5oV3OD9O/zaQJ1/+vL3zGEd15ZsCki2lvWQQ6FzMfWd0AkxVlxPSO5u78CMOwuK4Ayow62J0VEjs044Q==",
             "dependencies": {
                 "@pixi-essentials/cull": "^1.1.0",
                 "@prefecthq/vue-compositions": "1.0.0",
@@ -6966,9 +6966,9 @@
             }
         },
         "@prefecthq/graphs": {
-            "version": "0.1.17",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.17.tgz",
-            "integrity": "sha512-I/xcoO0jUY3wV7hYpAc3hU7zxDeQxxbkzYjYGdg9Hb0XyUMJggSE54nPkSBfFnYbzUwuNWTkLG00vBlFS0EwaA==",
+            "version": "0.1.18",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.18.tgz",
+            "integrity": "sha512-HyriFm5oV3OD9O/zaQJ1/+vL3zGEd15ZsCki2lvWQQ6FzMfWd0AkxVlxPSO5u78CMOwuK4Ayow62J0VEjs044Q==",
             "requires": {
                 "@pixi-essentials/cull": "^1.1.0",
                 "@prefecthq/vue-compositions": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "vue-router": "^4.0.12"
     },
     "dependencies": {
-        "@prefecthq/graphs": "0.1.17",
+        "@prefecthq/graphs": "0.1.18",
         "@prefecthq/radar": "0.0.19",
         "@prefecthq/vue-charts": "0.0.19",
         "@types/lodash.isequal": "4.5.6",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "vue-router": "^4.0.12"
     },
     "dependencies": {
-        "@prefecthq/graphs": "0.1.16",
+        "@prefecthq/graphs": "0.1.17",
         "@prefecthq/radar": "0.0.19",
         "@prefecthq/vue-charts": "0.0.19",
         "@types/lodash.isequal": "4.5.6",

--- a/src/components/FlowRunTimeline.vue
+++ b/src/components/FlowRunTimeline.vue
@@ -110,7 +110,7 @@
   })
 
   const timelineGraphContainer = ref<HTMLElement | null>(null)
-  const timelineGraph = ref<typeof FlowRunTimeline | null>(null)
+  const timelineGraph = ref<InstanceType<typeof FlowRunTimeline> | null>(null)
   const isFullscreen = ref(false)
   const showTaskRunPanel = ref(false)
   const selectedNode: Ref<string | null> = ref(null)
@@ -181,13 +181,13 @@
       const newWidth = timelineGraphContainer.value?.clientWidth ?? 0
       const newHeight = timelineGraphContainer.value?.clientHeight ?? 0
 
-      const offsetX = (newWidth - originalWidth) / 2
-      const offsetY = (newHeight - originalHeight) / 2
+      const xOffset = (newWidth - originalWidth) / 2
+      const yOffset = (newHeight - originalHeight) / 2
 
-      timelineGraph.value?.updateViewportCenter(
-        offsetX,
-        offsetY,
-      )
+      timelineGraph.value?.moveViewportCenter({
+        xOffset,
+        yOffset,
+      })
     }, 0)
   }
 

--- a/src/components/FlowRunTimeline.vue
+++ b/src/components/FlowRunTimeline.vue
@@ -241,7 +241,7 @@
 
 .flow-run-timeline--fullscreen { @apply
   h-screen
-  w-screen
+  w-full
   absolute
   top-0
   left-0

--- a/src/components/FlowRunTimeline.vue
+++ b/src/components/FlowRunTimeline.vue
@@ -246,6 +246,8 @@
   top-0
   left-0
   z-50
+  bg-background-600
+  dark:bg-background
 }
 
 .flow-run-timeline__options { @apply
@@ -273,6 +275,10 @@
   bg-background-600
   dark:bg-background
   rounded-lg
+}
+
+.flow-run-timeline--fullscreen .flow-run-timeline__graph {
+  animation: fadeGraphIn 1.5s ease
 }
 
 @media (min-width: 640px) {
@@ -308,5 +314,10 @@
 .flow-run-timeline__task-panel--panel-open { @apply
   translate-x-0
   duration-500
+}
+
+@keyframes fadeGraphIn {
+  0% { opacity: 0 }
+  100% { opacity: 1 }
 }
 </style>

--- a/src/components/FlowRunTimeline.vue
+++ b/src/components/FlowRunTimeline.vue
@@ -1,6 +1,34 @@
 <template>
-  <div class="flow-run-timeline">
+  <div
+    class="flow-run-timeline"
+    :class="{ 'flow-run-timeline--fullscreen': isFullscreen }"
+    tabindex="0"
+    aria-label="Flow run timeline graph"
+    @keydown.c="recenterGraph"
+    @keydown.f="toggleFullscreen"
+    @keydown.a="updateHideEdges(!hideEdges)"
+  >
+    <p-button
+      v-if="isFullscreen"
+      class="flow-run-timeline__fullscreen-exit"
+      icon="XIcon"
+      flat
+      size="lg"
+      @click="toggleFullscreen"
+    />
     <div class="flow-run-timeline__options">
+      <p-button
+        title="Recenter Timeline (c)"
+        icon="Target"
+        flat
+        @click="recenterGraph"
+      />
+      <p-button
+        title="View Timeline in Fullscreen (f)"
+        icon="ArrowsExpandIcon"
+        flat
+        @click="toggleFullscreen"
+      />
       <FlowRunTimelineOptions
         :layout="layout"
         :hide-edges="hideEdges"
@@ -10,6 +38,7 @@
     </div>
     <div v-if="graphData.length > 0" class="flow-run-timeline__graph-wrapper">
       <FlowRunTimeline
+        ref="timelineGraph"
         class="flow-run-timeline__graph"
         :class="{ 'flow-run-timeline__graph--panel-open': showTaskRunPanel }"
         :graph-data="graphData"
@@ -63,6 +92,8 @@
     hideEdges: 40,
   }
 
+  const timelineGraph = ref<InstanceType<typeof FlowRunTimeline> | null>(null)
+  const isFullscreen = ref(false)
   const showTaskRunPanel = ref(false)
   const selectedNode: Ref<string | null> = ref(null)
   const formatDateFns: FormatDateFns = {
@@ -94,6 +125,11 @@
 
   function updateHideEdges(value: boolean): void {
     hideEdges.value = value
+  }
+
+  function toggleFullscreen(): void {
+    isFullscreen.value = !isFullscreen.value
+    recenterGraph()
   }
 
   const isRunning = computed(() => {
@@ -131,6 +167,10 @@
       unwatchInitialData()
     }
   })
+
+  function recenterGraph(): void {
+    timelineGraph.value?.recenter()
+  }
 
   /*
   * Theme overrides
@@ -193,8 +233,19 @@
 <style>
 .flow-run-timeline { @apply
   flex
+  h-[320px]
   overflow-hidden
   relative
+  outline-none
+}
+
+.flow-run-timeline--fullscreen { @apply
+  h-screen
+  w-screen
+  absolute
+  top-0
+  left-0
+  z-50
 }
 
 .flow-run-timeline__options { @apply
@@ -204,8 +255,15 @@
   z-10
 }
 
+.flow-run-timeline__fullscreen-exit { @apply
+  absolute
+  top-1
+  right-1
+  z-10
+}
+
 .flow-run-timeline__graph-wrapper { @apply
-  h-[320px]
+  h-full
   w-full
   relative
   overflow-hidden
@@ -221,6 +279,9 @@
   .flow-run-timeline__graph--panel-open {
     width: calc(100% - 320px);
   }
+  .flow-run-timeline--fullscreen .flow-run-timeline__graph--panel-open { @apply
+    w-full
+  }
 }
 
 .flow-run-timeline__task-panel { @apply
@@ -235,6 +296,13 @@
   translate-x-full
   transition-transform
   duration-300
+}
+
+.flow-run-timeline--fullscreen .flow-run-timeline__task-panel { @apply
+  h-auto
+  top-4
+  right-4
+  bottom-auto
 }
 
 .flow-run-timeline__task-panel--panel-open { @apply

--- a/src/components/FlowRunTimelineOptions.vue
+++ b/src/components/FlowRunTimelineOptions.vue
@@ -22,7 +22,7 @@
           </p-radio-group>
         </div>
         <div class="flow-run-timeline-options__popover-option-set">
-          <p-checkbox v-model="hideDependencyArrowsModel" label="Hide Dependency Arrows (a)" />
+          <p-checkbox v-model="hideDependencyArrowsModel" label="Hide Dependency Arrows" />
         </div>
       </p-overflow-menu>
     </div>

--- a/src/components/FlowRunTimelineOptions.vue
+++ b/src/components/FlowRunTimelineOptions.vue
@@ -22,7 +22,7 @@
           </p-radio-group>
         </div>
         <div class="flow-run-timeline-options__popover-option-set">
-          <p-checkbox v-model="hideDependencyArrowsModel" label="Hide Dependency Arrows" />
+          <p-checkbox v-model="hideDependencyArrowsModel" label="Hide Dependency Arrows (a)" />
         </div>
       </p-overflow-menu>
     </div>


### PR DESCRIPTION
Adds recenter and fullscreen buttons. Also includes some keyboard shortcuts.

<img width="188" alt="image" src="https://user-images.githubusercontent.com/6776415/218780214-f302056c-ef93-47d5-88e7-b4c6d9508a0e.png">

https://user-images.githubusercontent.com/6776415/218782934-fc37ccfc-b1e7-4552-85b0-5f2895cc6d6a.mov

Note: this will require adding a `position: relative` to the `ContextSidebarLayout` in nebula so it doesn't compete with the sidebar (fixed positioning still constrains it to the parent stacking contexts)
