### PR TITLE
Chore: fix invisible text in code snippet

### DIFF
--- a/src/components/CodeLines.vue
+++ b/src/components/CodeLines.vue
@@ -33,6 +33,7 @@
   h-5
   w-full
   block
+  text-white
 }
 
 .code-lines--with-line-numbers .code-lines__line:before { @apply


### PR DESCRIPTION
This PR fixes invisible text in light mode

Issue:

https://user-images.githubusercontent.com/40467112/219389636-d40e34ec-1590-448a-b0e7-97957e51e437.mov

<br/>

Now:

https://user-images.githubusercontent.com/40467112/219389698-0819fc89-c086-4ffa-a1f7-f3b8e3a5a8e8.mov

<br/>

The dark mode is not impacted since all text by default has the color white
<img width="211" alt="Screenshot 2023-02-16 at 9 16 19 AM" src="https://user-images.githubusercontent.com/40467112/219389803-b945d21e-8ccc-4df2-a4b5-69d698cafc6a.png">
