### PR TITLE
BugFix: Add back the default start and end dates for the flow run filters

### DIFF
--- a/src/components/FlowRunsFilterGroup.vue
+++ b/src/components/FlowRunsFilterGroup.vue
@@ -40,12 +40,18 @@
   import StateNameSelect from '@/components/StateNameSelect.vue'
   import WorkPoolCombobox from '@/components/WorkPoolCombobox.vue'
   import { useFlowRunsFilterFromRoute } from '@/compositions/filters'
+  import { dateFunctions } from '@/utilities/timezone'
 
   const flowRunNameLike = ref<string>()
   const flowRunNameLikeDebounced = useDebouncedRef(flowRunNameLike, 1200)
+  const expectedStartTimeAfter = dateFunctions.subDays(dateFunctions.startOfToday(), 7)
+  const expectedStartTimeBefore = dateFunctions.addDays(dateFunctions.endOfToday(), 1)
+
   const { filter } = useFlowRunsFilterFromRoute({
     flowRuns: {
       nameLike: flowRunNameLikeDebounced,
+      expectedStartTimeAfter,
+      expectedStartTimeBefore,
     },
   })
 </script>


### PR DESCRIPTION
# Description
Default `expectedStartTimeAfter` and `expectedStartTimeBefore` dates used to be applied in the `useFlowRunFilter`. The latest filters rework removed those default values from the composition because the composition is now much more generic. However it did not add the defaults to the FlowRunFilterGroupComponent that expected those default dates. Adding them in this PR