### PR TITLE
Feature: changed logic for preventing dupe slashes in api

### DIFF
--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -57,15 +57,13 @@ export class Api<T extends PrefectConfig = PrefectConfig> {
     }, {})
   }
 
-  protected removeLeadingAndTrailingSlashes(input: string): string {
-    return input.replace(/^(\/)|(\/)$/g, '')
-  }
-
   protected combinePath(route: string | undefined): string {
+    const repeatingSlashes = /(\/+)/g
+
     return [this.routePrefix, route]
       .filter(isDefined)
-      .map(this.removeLeadingAndTrailingSlashes)
       .join('/')
+      .replace(repeatingSlashes, '/')
   }
 
   protected instance(): AxiosInstance {


### PR DESCRIPTION
cc @pleek91 https://github.com/PrefectHQ/nebula-ui/pull/2435#issuecomment-1439364126

This came to me when thinking about this problem last night. I think this is the best solution because it means developers can continue to not worry about where to put leading/trailing slashes but if we need to make sure a route ends in slash this will not conflict with such logic.