### PR TITLE
BugFix: Flow run filters null dates and recursive filtering

### DIFF
--- a/src/components/DateRangeInputWithFlowRunHistory.vue
+++ b/src/components/DateRangeInputWithFlowRunHistory.vue
@@ -3,7 +3,6 @@
     v-model:startDate="startDate"
     v-model:endDate="endDate"
     v-model:viewingDate="viewingDate"
-    clearable
   >
     <template #date="{ date }">
       <div class="date-range-input-with-flow-run-history__date">
@@ -20,7 +19,8 @@
 
 <script lang="ts" setup>
   import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-  import { computed, ref } from 'vue'
+  import { isEqual } from 'lodash'
+  import { computed, ref, toRefs, watch } from 'vue'
   import DateRangeInput from '@/components/DateRangeInput.vue'
   import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
   import { FlowRunsHistoryFilter } from '@/models/Filters'
@@ -31,31 +31,29 @@
   import { dateFunctions } from '@/utilities/timezone'
 
   const props = defineProps<{
-    startDate: Date | null | undefined,
-    endDate: Date | null | undefined,
+    range: [Date, Date],
   }>()
 
   const emit = defineEmits<{
-    (event: 'update:startDate' | 'update:endDate', value: Date | null | undefined): void,
+    (event: 'update:range', value: [Date, Date]): void,
   }>()
 
-  const startDate = computed({
-    get() {
-      return props.startDate
-    },
-    set(value) {
-      emit('update:startDate', value)
-    },
+  const { range } = toRefs(props)
+  const startDate = ref<Date | null>()
+  const endDate = ref<Date | null>()
+
+  watch([startDate, endDate], ([startDate, endDate]) => {
+    const [startDateProp, endDateProp] = range.value
+
+    if (startDate && endDate && !isEqual(startDate, startDateProp) && !isEqual(endDate, endDateProp)) {
+      emit('update:range', [startDate, endDate])
+    }
   })
 
-  const endDate = computed({
-    get() {
-      return props.endDate
-    },
-    set(value) {
-      emit('update:endDate', value)
-    },
-  })
+  watch(range, ([startDateProp, endDateProp]) => {
+    startDate.value = startDateProp
+    endDate.value = endDateProp
+  }, { immediate: true })
 
   const api = useWorkspaceApi()
 

--- a/src/components/DateRangeInputWithFlowRunHistory.vue
+++ b/src/components/DateRangeInputWithFlowRunHistory.vue
@@ -3,6 +3,7 @@
     v-model:startDate="startDate"
     v-model:endDate="endDate"
     v-model:viewingDate="viewingDate"
+    clearable
   >
     <template #date="{ date }">
       <div class="date-range-input-with-flow-run-history__date">

--- a/src/components/FlowRunsFilterGroup.vue
+++ b/src/components/FlowRunsFilterGroup.vue
@@ -2,7 +2,7 @@
   <div class="flow-runs-filter-group">
     <div class="flow-runs-filter-group__row">
       <p-label :label="media.hover ? 'Date Range' : ''">
-        <DateRangeInputWithFlowRunHistory v-model:start-date="filter.flowRuns.expectedStartTimeAfter" v-model:end-date="filter.flowRuns.expectedStartTimeBefore" />
+        <DateRangeInputWithFlowRunHistory v-model:range="range" />
       </p-label>
       <p-label label="States">
         <StateNameSelect v-model:selected="filter.flowRuns.state.name" empty-message="All run states" multiple />
@@ -31,7 +31,7 @@
 <script lang="ts" setup>
   import { media, PLabel } from '@prefecthq/prefect-design'
   import { useDebouncedRef } from '@prefecthq/vue-compositions'
-  import { ref } from 'vue'
+  import { computed, ref } from 'vue'
   import DateRangeInputWithFlowRunHistory from '@/components/DateRangeInputWithFlowRunHistory.vue'
   import DeploymentCombobox from '@/components/DeploymentCombobox.vue'
   import FlowCombobox from '@/components/FlowCombobox.vue'
@@ -52,6 +52,16 @@
       nameLike: flowRunNameLikeDebounced,
       expectedStartTimeAfter,
       expectedStartTimeBefore,
+    },
+  })
+
+  const range = computed<[Date, Date]>({
+    get() {
+      return [filter.flowRuns.expectedStartTimeAfter!, filter.flowRuns.expectedStartTimeBefore!]
+    },
+    set([expectedStartTimeAfter, expectedStartTimeBefore]) {
+      filter.flowRuns.expectedStartTimeAfter = expectedStartTimeAfter
+      filter.flowRuns.expectedStartTimeBefore = expectedStartTimeBefore
     },
   })
 </script>

--- a/src/components/FlowRunsFilterGroup.vue
+++ b/src/components/FlowRunsFilterGroup.vue
@@ -39,19 +39,14 @@
   import SearchInput from '@/components/SearchInput.vue'
   import StateNameSelect from '@/components/StateNameSelect.vue'
   import WorkPoolCombobox from '@/components/WorkPoolCombobox.vue'
-  import { useFlowRunsFilterFromRoute } from '@/compositions/filters'
-  import { dateFunctions } from '@/utilities/timezone'
+  import { useRecentFlowRunsFilterFromRoute } from '@/compositions/filters'
 
   const flowRunNameLike = ref<string>()
   const flowRunNameLikeDebounced = useDebouncedRef(flowRunNameLike, 1200)
-  const expectedStartTimeAfter = dateFunctions.subDays(dateFunctions.startOfToday(), 7)
-  const expectedStartTimeBefore = dateFunctions.addDays(dateFunctions.endOfToday(), 1)
 
-  const { filter } = useFlowRunsFilterFromRoute({
+  const { filter } = useRecentFlowRunsFilterFromRoute({
     flowRuns: {
       nameLike: flowRunNameLikeDebounced,
-      expectedStartTimeAfter,
-      expectedStartTimeBefore,
     },
   })
 

--- a/src/compositions/filters.ts
+++ b/src/compositions/filters.ts
@@ -594,6 +594,15 @@ export function useRecentFlowRunsFilter(defaultValue: MaybeReactive<FlowRunsFilt
   }
 }
 
+export function useRecentFlowRunsFilterFromRoute(defaultValue: MaybeReactive<FlowRunsFilter> = {}, prefix?: string): UseFilter<FlowRunsFilter> {
+  const response = useRecentFlowRunsFilter(defaultValue)
+  const { filter: query } = useSortableFilterFromRoute(flowRunsFilterSchema, defaultValue, defaultFlowRunSort, prefix)
+
+  syncFilterWithFilterFromRoute(response.filter, query)
+
+  return response
+}
+
 export function useFlowRunsHistoryFilter(defaultValue: MaybeReactive<FlowRunsHistoryFilter>): UseFilter<FlowRunsHistoryFilter> {
   const defaultValueReactive = reactive(defaultValue)
   const { filter: flowRunsFilter } = useFlowRunsFilter(defaultValueReactive)

--- a/src/utilities/object.ts
+++ b/src/utilities/object.ts
@@ -107,7 +107,7 @@ export function hasString(obj: Record<string | number | symbol, unknown>, str: s
 }
 
 export function isRecord(item: unknown): item is Record<PropertyKey, unknown> {
-  return item !== null && typeof item === 'object' && !Array.isArray(item)
+  return item !== null && typeof item === 'object' && !Array.isArray(item) && !isDate(item)
 }
 
 export function merge<T extends Record<PropertyKey, unknown>>(target: T, ...sources: T[]): T {


### PR DESCRIPTION
# Description
Fixed several issues here
1. Make sure the date range doesn't return nulls while picking a new range
2. Make sure the default date ranges apply to all components (not just the filters component)
3. Fix `isRecord` utility incorrectly returning `true` when given a `Date`. 