### PR TITLE
BugFix: Flow run filter date range not emitting dates if either start or end is reused

### DIFF
--- a/src/components/DateRangeInputWithFlowRunHistory.vue
+++ b/src/components/DateRangeInputWithFlowRunHistory.vue
@@ -45,8 +45,9 @@
 
   watch([startDate, endDate], ([startDate, endDate]) => {
     const [startDateProp, endDateProp] = range.value
+    const sameRange = isEqual(startDate, startDateProp) && isEqual(endDate, endDateProp)
 
-    if (startDate && endDate && !isEqual(startDate, startDateProp) && !isEqual(endDate, endDateProp)) {
+    if (startDate && endDate && !sameRange) {
       emit('update:range', [startDate, endDate])
     }
   })


### PR DESCRIPTION
# Description
Fixes the "isSame" check to look at the range as a whole rather than the dates individually