### PR TITLE
Feature: Update work pool edit form to allow updates to the default values for the base job template

### DIFF
--- a/src/components/WorkPoolEditForm.vue
+++ b/src/components/WorkPoolEditForm.vue
@@ -20,7 +20,7 @@
       </p-label>
 
       <p-label v-if="can.access.workers" label="Type">
-        <WorkPoolTypeSelect v-model:selected="type" disabled />
+        <WorkPoolTypeSelect :selected="type" disabled />
       </p-label>
 
       <p-label v-if="type && schemaHasProperties && can.access.workers" label="Base Job Configuration">

--- a/src/components/WorkPoolEditForm.vue
+++ b/src/components/WorkPoolEditForm.vue
@@ -43,7 +43,7 @@
   import { useValidationObserver } from '@prefecthq/vue-compositions'
   import { ref, computed } from 'vue'
   import { useRouter } from 'vue-router'
-  import { SubmitButton, WorkPoolTypeSelect, SchemaFormFieldsWithValues, SchemaPropertiesKeyValues } from '@/components'
+  import { SubmitButton, WorkPoolTypeSelect, SchemaFormFieldsWithValues } from '@/components'
   import { useCan, useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPool, WorkPoolEdit } from '@/models'

--- a/src/components/WorkPoolEditForm.vue
+++ b/src/components/WorkPoolEditForm.vue
@@ -49,7 +49,7 @@
   import { WorkPool, WorkPoolEdit } from '@/models'
   import { mapper } from '@/services/Mapper'
   import { Schema } from '@/types/schemas'
-  import { getSchemaDefaults } from '@/utilities/parameters'
+  import { getSchemaDefaults, getSchemaWithoutDefaults } from '@/utilities/parameters'
 
   const props = defineProps<{
     workPool: WorkPool,
@@ -64,7 +64,7 @@
   const description = ref<string | null | undefined>(props.workPool.description)
   const type = ref<string>(props.workPool.type)
   const concurrencyLimit = ref<number | null | undefined>(props.workPool.concurrencyLimit)
-  const schema = computed<Schema>(() => mapper.map('SchemaResponse', props.workPool.baseJobTemplate.variables ?? {}, 'Schema'))
+  const schema = computed<Schema>(() => mapper.map('SchemaResponse', getSchemaWithoutDefaults(props.workPool.baseJobTemplate.variables ?? {}), 'Schema'))
   // Set parameters to the default values from the schema so they are pre-filled in the form
   const parameters = ref(
     getSchemaDefaults(props.workPool.baseJobTemplate.variables ?? {}),

--- a/src/components/WorkPoolEditForm.vue
+++ b/src/components/WorkPoolEditForm.vue
@@ -23,9 +23,10 @@
         <WorkPoolTypeSelect :selected="type" disabled />
       </p-label>
 
-      <p-label v-if="showSchemaForm" label="Base Job Configuration">
+      <template v-if="showSchemaForm">
+        <h3>Base Job Configuration</h3>
         <SchemaFormFieldsWithValues v-model:values="parameters" :schema="schema" />
-      </p-label>
+      </template>
     </p-content>
 
 

--- a/src/components/WorkPoolEditForm.vue
+++ b/src/components/WorkPoolEditForm.vue
@@ -18,7 +18,16 @@
           <p-number-input :id="id" v-model="concurrencyLimit" placeholder="Unlimited" :min="0" />
         </template>
       </p-label>
+
+      <p-label v-if="can.access.workers" label="Type">
+        <WorkPoolTypeSelect v-model:selected="type" disabled />
+      </p-label>
+
+      <p-label v-if="type && schemaHasProperties && can.access.workers" label="Base Job Configuration">
+        <SchemaFormFieldsWithValues v-model:values="parameters" :schema="schema" />
+      </p-label>
     </p-content>
+
 
     <template #footer>
       <p-button inset @click="cancel">
@@ -32,35 +41,53 @@
 <script lang="ts" setup>
   import { showToast } from '@prefecthq/prefect-design'
   import { useValidationObserver } from '@prefecthq/vue-compositions'
-  import { ref } from 'vue'
+  import { ref, computed } from 'vue'
   import { useRouter } from 'vue-router'
-  import { SubmitButton } from '@/components'
-  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import { SubmitButton, WorkPoolTypeSelect, SchemaFormFieldsWithValues } from '@/components'
+  import { useCan, useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
-  import { WorkPool } from '@/models'
+  import { WorkPool, WorkPoolEdit } from '@/models'
+  import { mapper } from '@/services/Mapper'
+  import { Schema } from '@/types/schemas'
 
   const props = defineProps<{
     workPool: WorkPool,
   }>()
 
   const api = useWorkspaceApi()
+  const can = useCan()
   const router = useRouter()
   const routes = useWorkspaceRoutes()
   const { validate, pending } = useValidationObserver()
 
   const description = ref<string | null | undefined>(props.workPool.description)
+  const type = ref<string>(props.workPool.type)
   const concurrencyLimit = ref<number | null | undefined>(props.workPool.concurrencyLimit)
+  const schema = computed<Schema>(() => mapper.map('SchemaResponse', props.workPool.baseJobTemplate.variables ?? {}, 'Schema'))
+  // Set parameters to the default values from the schema so they are pre-filled in the form
+  const parameters = ref<Record<string, unknown>>(
+    Object.entries(props.workPool.baseJobTemplate.variables?.properties ?? {}).reduce((acc, [key, value]) => ({ ...acc, [key]: value?.default }), {}),
+  )
+
+  const schemaHasProperties = computed(() => {
+    const { properties } = schema.value
+
+    return properties && Object.keys(properties).length > 0
+  })
 
   function cancel(): void {
     router.back()
   }
 
   const submit = async (): Promise<void> => {
+    const baseJobTemplateSchema = mapper.map('WorkerSchemaProperty', { values: parameters.value, schema: props.workPool.baseJobTemplate }, 'WorkerSchemaPropertyRequest')
+
     const valid = await validate()
     if (valid) {
-      const values = {
+      const values: WorkPoolEdit = {
         description: description.value,
         concurrencyLimit: concurrencyLimit.value,
+        baseJobTemplate: baseJobTemplateSchema,
       }
       try {
         await api.workPools.updateWorkPool(props.workPool.name, values)

--- a/src/components/WorkPoolTypeSelect.vue
+++ b/src/components/WorkPoolTypeSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <PSelect v-model="model" :options="options" class="block-type-select" :disabled="disabled">
+  <PSelect v-model="model" class="block-type-select" v-bind="{ options, disabled }">
     <template #default="{ label }">
       {{ label }}
     </template>

--- a/src/components/WorkPoolTypeSelect.vue
+++ b/src/components/WorkPoolTypeSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <PSelect v-model="model" :options="options" class="block-type-select">
+  <PSelect v-model="model" :options="options" class="block-type-select" :disabled="disabled">
     <template #default="{ label }">
       {{ label }}
     </template>
@@ -13,9 +13,10 @@
   import { useWorkspaceApi } from '@/compositions'
   import { titleCase } from '@/utilities'
 
-  const props = defineProps<{
+  const props = withDefaults(defineProps<{
     selected: string | null | undefined,
-  }>()
+    disabled: boolean,
+  }>(), { disabled: false })
 
   const emit = defineEmits<{
     (event: 'update:selected', value: string | null): void,

--- a/src/components/WorkPoolTypeSelect.vue
+++ b/src/components/WorkPoolTypeSelect.vue
@@ -13,10 +13,10 @@
   import { useWorkspaceApi } from '@/compositions'
   import { titleCase } from '@/utilities'
 
-  const props = withDefaults(defineProps<{
+  const props = defineProps<{
     selected: string | null | undefined,
-    disabled: boolean,
-  }>(), { disabled: false })
+    disabled?: boolean,
+  }>()
 
   const emit = defineEmits<{
     (event: 'update:selected', value: string | null): void,

--- a/src/maps/workPool.ts
+++ b/src/maps/workPool.ts
@@ -43,10 +43,16 @@ export const mapWorkPoolCreateToWorkPoolCreateRequest: MapFunction<WorkPoolCreat
 }
 
 export const mapWorkPoolEditToWorkPoolEditRequest: MapFunction<WorkPoolEdit, WorkPoolEditRequest> = function(source) {
+  const baseJobTemplateSchema = this.map(
+    'WorkerSchemaProperty',
+    { values: source.updatedDefaultVariableValues ?? {}, schema: source.baseJobTemplate ?? {} },
+    'WorkerSchemaPropertyRequest',
+  )
+
   return {
     description: source.description,
     is_paused: source.isPaused,
     concurrency_limit: source.concurrencyLimit,
-    base_job_template: source.baseJobTemplate,
+    base_job_template: baseJobTemplateSchema,
   }
 }

--- a/src/maps/workerCollection.ts
+++ b/src/maps/workerCollection.ts
@@ -1,7 +1,6 @@
 import {
   PrefectWorkerCollectionResponse,
-  WorkerCollectionItem,
-  WorkerCollectionItemResponse
+  WorkerCollectionItem
 } from '@/models'
 import { MapFunction } from '@/services/Mapper'
 import {
@@ -15,7 +14,7 @@ PrefectWorkerCollectionResponse,
 WorkerCollectionItem[]
 > = function(source) {
   return Object.values(source)
-    .reduce<WorkerCollectionItemResponse[]>((acc, package_data) => [...acc, ...Object.values(package_data)], [])
+    .flatMap((package_data) => Object.values(package_data))
     .map((worker_data) => ({
       defaultBaseJobConfiguration: worker_data.default_base_job_configuration,
       description: worker_data.description,

--- a/src/maps/workerCollection.ts
+++ b/src/maps/workerCollection.ts
@@ -15,10 +15,7 @@ PrefectWorkerCollectionResponse,
 WorkerCollectionItem[]
 > = function(source) {
   return Object.values(source)
-    .reduce<WorkerCollectionItemResponse[]>(
-    (acc, package_data) => [...acc, ...Object.values(package_data)],
-    [],
-    )
+    .reduce<WorkerCollectionItemResponse[]>((acc, package_data) => [...acc, ...Object.values(package_data)], [])
     .map((worker_data) => ({
       defaultBaseJobConfiguration: worker_data.default_base_job_configuration,
       description: worker_data.description,

--- a/src/maps/workerCollection.ts
+++ b/src/maps/workerCollection.ts
@@ -4,23 +4,29 @@ import {
   WorkerCollectionItemResponse
 } from '@/models'
 import { MapFunction } from '@/services/Mapper'
-import { SchemaValues, WorkerBaseJobTemplate, SchemaProperty } from '@/types/schemas'
+import {
+  SchemaValues,
+  WorkerBaseJobTemplate,
+  SchemaProperty
+} from '@/types/schemas'
 
 export const mapPrefectWorkerCollectionResponseToWorkerCollectionItemArray: MapFunction<
 PrefectWorkerCollectionResponse,
 WorkerCollectionItem[]
 > = function(source) {
-  return Object.values(source).reduce<WorkerCollectionItemResponse[]>(
+  return Object.values(source)
+    .reduce<WorkerCollectionItemResponse[]>(
     (acc, package_data) => [...acc, ...Object.values(package_data)],
     [],
-  ).map((worker_data) => ({
-    defaultBaseJobConfiguration: worker_data.default_base_job_configuration,
-    description: worker_data.description,
-    documentationUrl: worker_data.documentation_url,
-    installCommand: worker_data.install_command,
-    logoUrl: worker_data.logo_url,
-    type: worker_data.type,
-  }))
+    )
+    .map((worker_data) => ({
+      defaultBaseJobConfiguration: worker_data.default_base_job_configuration,
+      description: worker_data.description,
+      documentationUrl: worker_data.documentation_url,
+      installCommand: worker_data.install_command,
+      logoUrl: worker_data.logo_url,
+      type: worker_data.type,
+    }))
 }
 
 type MapSchemaValuesSource = {
@@ -34,14 +40,10 @@ WorkerBaseJobTemplate
 > = function(source) {
   const { values = {}, schema } = source
 
-  if (schema.variables !== undefined) {
-    schema.variables.properties = schema.variables.properties ?? {}
-  }
-
   const keys = Object.keys(schema.variables?.properties ?? {})
 
   keys.forEach((key) => {
-    if (schema.variables?.properties && values[key] !== undefined) {
+    if (schema.variables?.properties) {
       const property = schema.variables.properties[key] as
         | SchemaProperty
         | undefined

--- a/src/models/WorkPoolEdit.ts
+++ b/src/models/WorkPoolEdit.ts
@@ -1,8 +1,9 @@
-import { WorkerBaseJobTemplate } from '@/types/schemas'
+import { SchemaValues, WorkerBaseJobTemplate } from '@/types/schemas'
 
 export type WorkPoolEdit = Partial<{
   description: string | null,
   isPaused: boolean,
   concurrencyLimit: number | null,
   baseJobTemplate: WorkerBaseJobTemplate,
+  updatedDefaultVariableValues: SchemaValues,
 }>

--- a/src/services/WorkspaceWorkPoolsApi.ts
+++ b/src/services/WorkspaceWorkPoolsApi.ts
@@ -39,14 +39,6 @@ export class WorkspaceWorkPoolsApi extends WorkspaceApi implements IWorkspaceWor
   }
 
   public updateWorkPool(name: string, request: WorkPoolEdit): Promise<void> {
-    const baseJobTemplateSchema = mapper.map(
-      'WorkerSchemaProperty',
-      { values: request.updatedDefaultVariableValues ?? {}, schema: request.baseJobTemplate ?? {} },
-      'WorkerSchemaPropertyRequest',
-    )
-
-    request.baseJobTemplate = baseJobTemplateSchema
-
     const body = mapper.map('WorkPoolEdit', request, 'WorkPoolEditRequest')
 
     return this.patch(`/${name}`, body)

--- a/src/services/WorkspaceWorkPoolsApi.ts
+++ b/src/services/WorkspaceWorkPoolsApi.ts
@@ -39,6 +39,14 @@ export class WorkspaceWorkPoolsApi extends WorkspaceApi implements IWorkspaceWor
   }
 
   public updateWorkPool(name: string, request: WorkPoolEdit): Promise<void> {
+    const baseJobTemplateSchema = mapper.map(
+      'WorkerSchemaProperty',
+      { values: request.updatedDefaultVariableValues ?? {}, schema: request.baseJobTemplate ?? {} },
+      'WorkerSchemaPropertyRequest',
+    )
+
+    request.baseJobTemplate = baseJobTemplateSchema
+
     const body = mapper.map('WorkPoolEdit', request, 'WorkPoolEditRequest')
 
     return this.patch(`/${name}`, body)

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -1,5 +1,6 @@
 import { Schema, SchemaProperties, SchemaValues } from '@/types/schemas'
 import { stringify } from '@/utilities/json'
+import { mapEntries } from '@/utilities/object'
 
 export function getSchemaValuesWithDefaults(
   values: SchemaValues,
@@ -37,17 +38,12 @@ export function getSchemaDefaults(schema: Schema): SchemaValues {
 export function getSchemaPropertiesWithoutDefaults(
   schemaProperties: SchemaProperties = {},
 ): SchemaProperties {
-  return Object.entries(schemaProperties).reduce((acc, [key, property]) => {
-    if (!property) {
-      return acc
-    }
+  return mapEntries(schemaProperties, (key, property) => {
     // eslint-disable-next-line no-unused-vars
-    const { default: _default, ...rest } = property
-    return {
-      ...acc,
-      [key]: rest,
-    }
-  }, {})
+    const { default: __, ...rest } = property
+
+    return [key, rest]
+  })
 }
 
 export function getSchemaWithoutDefaults(schema: Schema): Schema {

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -1,4 +1,4 @@
-import { Schema, SchemaValues } from '@/types/schemas'
+import { Schema, SchemaProperties, SchemaValues } from '@/types/schemas'
 import { stringify } from '@/utilities/json'
 
 export function getSchemaValuesWithDefaults(
@@ -32,4 +32,26 @@ export function getSchemaDefaults(schema: Schema): SchemaValues {
   }
 
   return values
+}
+
+export function getSchemaPropertiesWithoutDefaults(
+  schemaProperties: SchemaProperties = {},
+): SchemaProperties {
+  return Object.entries(schemaProperties).reduce((acc, [key, property]) => {
+    if (!property) {
+      return acc
+    }
+    const { default: __, ...rest } = property
+    return {
+      ...acc,
+      [key]: rest,
+    }
+  }, {})
+}
+
+export function getSchemaWithoutDefaults(schema: Schema): Schema {
+  return {
+    ...schema,
+    properties: getSchemaPropertiesWithoutDefaults(schema.properties),
+  }
 }

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -41,7 +41,8 @@ export function getSchemaPropertiesWithoutDefaults(
     if (!property) {
       return acc
     }
-    const { default: __, ...rest } = property
+    // eslint-disable-next-line no-unused-vars
+    const { default: _default, ...rest } = property
     return {
       ...acc,
       [key]: rest,


### PR DESCRIPTION
## Summary
Updates `WorkPoolEditForm` to allow changes to the default values for the base job template variables for a work pool. Similar to `WorkPoolCreateForm`, the values from the form are used to set the default values for the `variables` section of the base job template. The starting values for the form fields are taken from the default values in the `variables` section of the base job template for easy editing. The type dropdown for the work pool is displayed, but disabled because a work pool's type cannot be changed after creation.

Note, this PR's base branch is the branch for #1173 due this PR's dependence on work in that PR. I recommend reviewing #1173 first.

## Screenshot
![Screenshot 2023-02-28 at 9 18 12 AM](https://user-images.githubusercontent.com/12350579/221897030-3a6aff02-2bf9-4d49-b0fd-d92a08f501bb.png)
