### PR TITLE
Feature: Adds display of base job configuration details for work pool

### DIFF
--- a/src/components/SchemaPropertiesKeyValues.vue
+++ b/src/components/SchemaPropertiesKeyValues.vue
@@ -1,7 +1,7 @@
 <template>
   <PContent class="schema-properties-key-values">
     <template v-for="[key, property] in sortedSchemaProperties" :key="key">
-      <SchemaProperty v-if="property" :property="property" :value="getPropertyValue(key)" />
+      <SchemaProperty v-if="property" :value="getPropertyValue(key)" v-bind="{ property, alternate }" />
     </template>
   </PContent>
 </template>
@@ -15,6 +15,7 @@
   const props = defineProps<{
     schema: Schema,
     values: SchemaValues,
+    alternate?: boolean,
   }>()
 
   function getPropertyValue(blockSchemaPropertyKey: string): unknown {

--- a/src/components/SchemaPropertyKeyValue.vue
+++ b/src/components/SchemaPropertyKeyValue.vue
@@ -4,7 +4,7 @@
   </template>
   <!-- todo: support displaying nested objects -->
   <template v-else>
-    <p-key-value :label="property.title" :value="value" class="schema-property-key-value">
+    <p-key-value :label="property.title" class="schema-property-key-value" v-bind="{ value, alternate }">
       <template v-if="isDefined && isJsonProperty" #value>
         <CopyableWrapper :text-to-copy="jsonValue ?? ''">
           <p-code-highlight lang="json" :text="jsonValue ?? ''" />
@@ -26,6 +26,7 @@
   const props = defineProps<{
     property: SchemaProperty,
     value: SchemaValue,
+    alternate?: boolean,
   }>()
 
   const isJsonProperty = computed(() => {


### PR DESCRIPTION
## Summary
Adds display of a work pool's base job configuration to `WorkPoolDetails`.

## Screenshots

### Wider screen
![Screenshot 2023-02-28 at 2 29 58 PM](https://user-images.githubusercontent.com/12350579/221971712-426d74fa-4a25-4039-af7b-3cb45b634389.png)

### Narrower Screen
![Screenshot 2023-02-28 at 2 30 22 PM](https://user-images.githubusercontent.com/12350579/221971748-4be9e27b-bf22-4a67-b6f6-0cdf95705e0e.png)

### Agent work pool with no base job configuration
![Screenshot 2023-02-28 at 2 30 51 PM](https://user-images.githubusercontent.com/12350579/221971855-9917908f-76c3-486c-b07d-de9400945aed.png)
