### PR TITLE
Remove the ability to delete a flow from UI

### DIFF
--- a/src/components/FlowMenu.vue
+++ b/src/components/FlowMenu.vue
@@ -2,14 +2,7 @@
   <p-icon-button-menu v-bind="$attrs">
     <copy-overflow-menu-item label="Copy ID" :item="flow.id" />
     <slot v-bind="{ flow }" />
-    <p-overflow-menu-item v-if="can.delete.flow" label="Delete" @click="open" />
   </p-icon-button-menu>
-  <ConfirmDeleteModal
-    v-model:showModal="showModal"
-    :name="flow.name"
-    label="Flow"
-    @delete="deleteFlow(flow.id)"
-  />
 </template>
 
 <script lang="ts">
@@ -21,31 +14,10 @@
 </script>
 
 <script lang="ts" setup>
-  import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
   import CopyOverflowMenuItem from '@/components/CopyOverflowMenuItem.vue'
-  import { useWorkspaceApi } from '@/compositions'
-  import { useCan } from '@/compositions/useCan'
-  import { useShowModal } from '@/compositions/useShowModal'
   import { Flow } from '@/models'
-  import { deleteItem } from '@/utilities'
 
   defineProps<{
     flow: Flow,
   }>()
-
-  const emits = defineEmits<{
-    (event: 'delete', value: string): void,
-  }>()
-
-  const can = useCan()
-
-  const { showModal, open, close } = useShowModal()
-
-  const api = useWorkspaceApi()
-
-  const deleteFlow = async (id: string): Promise<void> => {
-    close()
-    await deleteItem(id, api.flows.deleteFlow, 'Flow')
-    emits('delete', id)
-  }
 </script>


### PR DESCRIPTION
Currently flows can be deleted from both the UI and the API; however, flows are emergent concepts that are implicitly created whenever runs that reference them are created.  Additionally, flows as an API concept maintain no state (as opposed to deployments, for example, which contain configuration).  Deleting a flow therefore does not _do_ anything, as the flow could re-appear on the next run.  This PR is a part of ongoing reliability work to ensure our object relationships and their mechanics are principled and don't offer ambiguous user experiences.