### PR TITLE
Chore: Artifact mocker and types update

### DIFF
--- a/demo/compositions/useArtifactsMock.ts
+++ b/demo/compositions/useArtifactsMock.ts
@@ -1,0 +1,46 @@
+import { useSeeds } from './useSeeds'
+import { Artifact } from '@/models'
+import { mocker } from '@/services'
+import { coinflip, repeat } from '@/utilities'
+
+export function useArtifactMock(override?: Partial<Artifact>, useTaskRun: boolean = coinflip(0.5)): Artifact {
+  const flow = mocker.create('flow')
+  const deployment = mocker.create('deployment')
+  const workQueue = mocker.create('workQueue')
+  const flowRun = mocker.create('flowRun', [
+    {
+      flowId: flow.id,
+      deploymentId: deployment.id,
+      workQueueName: workQueue.name,
+    },
+  ])
+
+  const taskRun = mocker.create('taskRun', [
+    {
+      flowRunId: flowRun.id,
+    },
+  ])
+
+  const artifact = mocker.create('artifact', [
+    {
+      flowRunId: flowRun.id,
+      taskRunId: useTaskRun ? taskRun.id : null,
+      ...override,
+    },
+  ])
+
+  useSeeds({
+    artifacts: [artifact],
+    flows: [flow],
+    deployments: [deployment],
+    workQueues: [workQueue],
+    flowRuns: [flowRun],
+    taskRuns: [taskRun],
+  })
+
+  return artifact
+}
+
+export function useArtifactsMock(count: number, override?: Partial<Artifact>): Artifact[] {
+  return repeat(count, () => useArtifactMock(override))
+}

--- a/demo/compositions/useSeeds.ts
+++ b/demo/compositions/useSeeds.ts
@@ -1,9 +1,10 @@
 import { onUnmounted } from 'vue'
 import { data } from '../utilities/data'
 import { FlowRunGraphMock } from '@/demo/types/flowRunGraphMock'
-import { Flow, FlowRun, Deployment, WorkQueue, TaskRun, BlockDocument, BlockType, BlockSchema, ConcurrencyLimit, WorkPool, WorkPoolQueue, WorkPoolWorker } from '@/models'
+import { Artifact, Flow, FlowRun, Deployment, WorkQueue, TaskRun, BlockDocument, BlockType, BlockSchema, ConcurrencyLimit, WorkPool, WorkPoolQueue, WorkPoolWorker } from '@/models'
 
 type Seeds = {
+  artifacts?: Artifact[],
   blockDocuments?: BlockDocument[],
   blockSchemaCapabilities?: string[],
   blockSchemas?: BlockSchema[],
@@ -51,6 +52,14 @@ export function useSeeds(seed: Seeds): void {
     const ids = taskRuns.map(taskRun => taskRun.id)
 
     onUnmounted(() => data.taskRuns.deleteAll(ids))
+  }
+
+  if (seed.artifacts) {
+    const artifacts = data.artifacts.createAll(seed.artifacts)
+
+    const ids = artifacts.map(artifact => artifact.id)
+
+    onUnmounted(() => data.artifacts.deleteAll(ids))
   }
 
   if (seed.deployments) {

--- a/demo/utilities/api.ts
+++ b/demo/utilities/api.ts
@@ -14,11 +14,12 @@ import { MockWorkspaceWorkPoolsApi } from '../services/mockWorkspaceWorkPoolsApi
 import { MockWorkspaceWorkPoolWorkerApi } from '../services/mockWorkspaceWorkPoolWorkerApi'
 import { MockWorkspaceWorkQueuesApi } from '../services/mockWorkspaceWorkQueuesApi'
 import { FlowRunGraphMock } from '@/demo/types/flowRunGraphMock'
-import { BlockDocument, BlockSchema, BlockType, Deployment, Flow, FlowRun, TaskRun, WorkPool, WorkPoolQueue, WorkQueue, WorkPoolWorker } from '@/models'
+import { Artifact, BlockDocument, BlockSchema, BlockType, Deployment, Flow, FlowRun, TaskRun, WorkPool, WorkPoolQueue, WorkQueue, WorkPoolWorker } from '@/models'
 import { ConcurrencyLimit } from '@/models/ConcurrencyLimit'
 import { CreateApi, workspaceApiKey } from '@/utilities'
 
 export type ApiMockSeeds = {
+  artifacts?: Artifact[],
   flows?: Flow[],
   flowRuns?: FlowRun[],
   flowRunGraphs?: FlowRunGraphMock[],

--- a/demo/utilities/data.ts
+++ b/demo/utilities/data.ts
@@ -2,7 +2,7 @@ import { KeyedDataStore } from '../services/KeyedDataStore'
 import { SimpleDataStore } from '../services/SimpleDataStore'
 import { ApiMockSeeds } from './api'
 import { FlowRunGraphMock } from '@/demo/types/flowRunGraphMock'
-import { Flow, FlowRun, BlockDocument, BlockSchema, TaskRun, Deployment, WorkQueue, BlockType, WorkPool, WorkPoolQueue, WorkPoolWorker, GraphNode } from '@/models'
+import { Flow, FlowRun, BlockDocument, BlockSchema, TaskRun, Deployment, WorkQueue, BlockType, WorkPool, WorkPoolQueue, WorkPoolWorker, GraphNode, Artifact } from '@/models'
 import { resolveSchema } from '@/services/schemas/resolvers/schemas'
 
 function hydrateBlockSchema(blockSchema: BlockSchema): BlockSchema {
@@ -22,6 +22,7 @@ function hydrateGraph({ id, graph }: FlowRunGraphMock): FlowRunGraphMock {
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createDataStores(seeds: ApiMockSeeds = {}) {
   return {
+    artifacts: new KeyedDataStore({ seeds: seeds.artifacts, hydrate: artifact => new Artifact(artifact) }),
     flows: new KeyedDataStore({ seeds: seeds.flows, hydrate: flow => new Flow(flow) }),
     flowRuns: new KeyedDataStore({ seeds: seeds.flowRuns, hydrate: flowRun => new FlowRun(flowRun) }),
     flowRunGraphs: new KeyedDataStore({ seeds: seeds.flowRunGraphs, hydrate: hydrateGraph }),

--- a/src/maps/artifact.ts
+++ b/src/maps/artifact.ts
@@ -1,6 +1,7 @@
 import { ArtifactResponse } from '@/models/api/ArtifactResponse'
-import { Artifact } from '@/models/Artifact'
+import { Artifact, ArtifactType } from '@/models/Artifact'
 import { MapFunction } from '@/services/Mapper'
+import { isKnownArtifactType } from '@/types/artifact'
 
 export const mapArtifactResponseToArtifact: MapFunction<ArtifactResponse, Artifact> = function(source) {
   return new Artifact({
@@ -9,7 +10,7 @@ export const mapArtifactResponseToArtifact: MapFunction<ArtifactResponse, Artifa
     updated: this.map('string', source.updated, 'Date'),
     description: source.description,
     key: source.key,
-    type: source.type,
+    type: isKnownArtifactType(source.type) ? source.type : ArtifactType.Unknown,
     data: source.data,
     metadata: source.metadata_,
     flowRunId: source.flow_run_id,

--- a/src/maps/artifact.ts
+++ b/src/maps/artifact.ts
@@ -7,6 +7,7 @@ export const mapArtifactResponseToArtifact: MapFunction<ArtifactResponse, Artifa
     id: source.id,
     created: this.map('string', source.created, 'Date'),
     updated: this.map('string', source.updated, 'Date'),
+    description: source.description,
     key: source.key,
     type: source.type,
     data: source.data,

--- a/src/maps/artifact.ts
+++ b/src/maps/artifact.ts
@@ -1,5 +1,5 @@
 import { ArtifactResponse } from '@/models/api/ArtifactResponse'
-import { Artifact, ArtifactType } from '@/models/Artifact'
+import { Artifact } from '@/models/Artifact'
 import { MapFunction } from '@/services/Mapper'
 import { isKnownArtifactType } from '@/types/artifact'
 
@@ -10,7 +10,7 @@ export const mapArtifactResponseToArtifact: MapFunction<ArtifactResponse, Artifa
     updated: this.map('string', source.updated, 'Date'),
     description: source.description,
     key: source.key,
-    type: isKnownArtifactType(source.type) ? source.type : ArtifactType.Unknown,
+    type: isKnownArtifactType(source.type) ? source.type : 'unknown',
     data: source.data,
     metadata: source.metadata_,
     flowRunId: source.flow_run_id,

--- a/src/mocks/artifact.ts
+++ b/src/mocks/artifact.ts
@@ -1,18 +1,39 @@
-import { Artifact } from '@/models'
+import { Artifact, ArtifactType } from '@/models'
 import { MockFunction } from '@/services/Mocker'
 import { choice } from '@/utilities'
 
 export const randomArtifact: MockFunction<Artifact, [Partial<Artifact>?]> = function(overrides = {}) {
+  const type = choice<ArtifactType>([ArtifactType.Markdown, ArtifactType.Result, ArtifactType.Table])
+  let data = null
+
+  switch (type) {
+    case ArtifactType.Result:
+      data = {
+        type: choice(['literal']),
+        value: this.create('string'),
+      }
+      break
+    case ArtifactType.Markdown:
+      data = this.create('markdownString', [{ sections: 4 }])
+      break
+    case ArtifactType.Table:
+      // TODO: Figure out table data type
+      data = []
+      break
+    default:
+      break
+  }
+
   return new Artifact({
     id: this.create('string'),
     created: this.create('date'),
     updated: this.create('date'),
     key: choice([null, this.create('noun')]),
-    type: this.create('string'),
-    description: this.create('markdownString', [{ sections: 2 }]),
+    type,
+    description: this.create('markdownString', [{ sections: 1 }]),
     flowRunId: this.create('id'),
     taskRunId: this.create('id'),
-    data: { [this.create('noun')]: this.create('string') },
+    data,
     metadata: {},
     ...overrides,
   })

--- a/src/mocks/artifact.ts
+++ b/src/mocks/artifact.ts
@@ -1,0 +1,19 @@
+import { Artifact } from '@/models'
+import { MockFunction } from '@/services/Mocker'
+import { choice } from '@/utilities'
+
+export const randomArtifact: MockFunction<Artifact, [Partial<Artifact>?]> = function(overrides = {}) {
+  return new Artifact({
+    id: this.create('string'),
+    created: this.create('date'),
+    updated: this.create('date'),
+    key: choice([null, this.create('noun')]),
+    type: this.create('string'),
+    description: this.create('markdownString', [{ sections: 2 }]),
+    flowRunId: this.create('id'),
+    taskRunId: this.create('id'),
+    data: { [this.create('noun')]: this.create('string') },
+    metadata: {},
+    ...overrides,
+  })
+}

--- a/src/mocks/artifact.ts
+++ b/src/mocks/artifact.ts
@@ -1,22 +1,22 @@
-import { Artifact, ArtifactType } from '@/models'
+import { Artifact, ArtifactType, artifactTypes } from '@/models'
 import { MockFunction } from '@/services/Mocker'
 import { choice } from '@/utilities'
 
 export const randomArtifact: MockFunction<Artifact, [Partial<Artifact>?]> = function(overrides = {}) {
-  const type = choice<ArtifactType>([ArtifactType.Markdown, ArtifactType.Result, ArtifactType.Table])
+  const type = choice<ArtifactType>(artifactTypes)
   let data = null
 
   switch (type) {
-    case ArtifactType.Result:
+    case 'result':
       data = {
         type: choice(['literal']),
         value: this.create('string'),
       }
       break
-    case ArtifactType.Markdown:
+    case 'markdown':
       data = this.create('markdownString', [{ sections: 4 }])
       break
-    case ArtifactType.Table:
+    case 'table':
       // TODO: Figure out table data type
       data = []
       break

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,4 +1,5 @@
 import { randomAny } from '@/mocks/any'
+import { randomArtifact } from '@/mocks/artifact'
 import { randomBlockDocument } from '@/mocks/blockDocument'
 import { randomBlockDocumentData } from '@/mocks/blockDocumentData'
 import { randomBlockSchema } from '@/mocks/blockSchema'
@@ -22,6 +23,7 @@ import { randomFlowRunStateHistory } from '@/mocks/flowRunStateHistory'
 import { randomId } from '@/mocks/id'
 import { randomImage } from '@/mocks/image'
 import { randomLogLevel, randomLog } from '@/mocks/log'
+import { randomMarkdownString, randomMarkdownCodeBlockString, randomMarkdownCodeSpanString, randomMarkdownContentString, randomMarkdownHeaderString, randomMarkdownQuoteString, randomMarkdownTableString } from '@/mocks/markdown'
 import { randomNotification } from '@/mocks/notification'
 import { randomNotificationCreate } from '@/mocks/notificationCreate'
 import { randomNumber } from '@/mocks/number'
@@ -44,6 +46,7 @@ import { randomWorkQueueStatus } from '@/mocks/workQueueStatus'
 
 export const mocks = {
   any: randomAny,
+  artifact: randomArtifact,
   blockDocument: randomBlockDocument,
   blockDocumentData: randomBlockDocumentData,
   blockSchema: randomBlockSchema,
@@ -71,6 +74,13 @@ export const mocks = {
   image: randomImage,
   log: randomLog,
   logLevel: randomLogLevel,
+  markdownCodeBlockString: randomMarkdownCodeBlockString,
+  markdownCodeSpanString: randomMarkdownCodeSpanString,
+  markdownContentString: randomMarkdownContentString,
+  markdownHeaderString: randomMarkdownHeaderString,
+  markdownQuoteString: randomMarkdownQuoteString,
+  markdownString: randomMarkdownString,
+  markdownTableString: randomMarkdownTableString,
   notification: randomNotification,
   notificationCreate: randomNotificationCreate,
   noun: randomNoun,

--- a/src/mocks/markdown.ts
+++ b/src/mocks/markdown.ts
@@ -1,0 +1,158 @@
+import { choice } from '..'
+import { MockFunction } from '@/services/Mocker'
+import { random, uniform } from '@/utilities/math'
+
+export const randomMarkdownHeaderString: MockFunction<string, [{ level?: number }?]> = function({ level = uniform(1, 6) } = {}) {
+  return `${'#'.repeat(level)} ${this.create('noun')}`
+}
+
+export const randomMarkdownQuoteString: MockFunction<string, [{ lines?: number }?]> = function({ lines = uniform(1, 5) } = {}) {
+  const quoteLines: string[] = []
+
+  for (let i = 0; i < lines; i++) {
+    quoteLines.push(`> ${this.create('sentence')}`)
+  }
+
+  return `\n${quoteLines.join('\n')}`
+}
+
+export const randomMarkdownContentString: MockFunction<string, [{ lines?: number }?]> = function({ lines = uniform(1, 5) } = {}) {
+  const contentLines: string[] = []
+
+  for (let i = 0; i < lines; i++) {
+    const hasCodeSpan = random() > 0.95
+    let line = ''
+
+    if (hasCodeSpan) {
+      line = `${this.create('sentence')} ${this.create('markdownCodeSpanString')} ${this.create('sentence')}`
+    } else {
+      line = this.create('sentence')
+    }
+
+    contentLines.push(line)
+  }
+
+  return contentLines.join('\n')
+}
+
+export const randomMarkdownTableString: MockFunction<string, [{ rows?: number, columns?: number }?]> = function({ rows = uniform(4, 10), columns = uniform(3, 8) } = {}) {
+  const tableLines: string[] = []
+
+  const columnHeaders = []
+  const headerAlignments = []
+  for (let i = 0; i < columns; i++) {
+    const alignment = choice([':--', ':--:', '--:'])
+    columnHeaders.push(this.create('noun'))
+    headerAlignments.push(alignment)
+  }
+  tableLines.push(`| ${columnHeaders.join(' | ')} |`)
+  tableLines.push(`| ${headerAlignments.join(' | ')} |`)
+
+
+  for (let i = 0; i < rows; i++) {
+    const rowLines: string[] = []
+
+    for (let i_ = 0; i_ < columns; i_++) {
+      rowLines.push(this.create('noun'))
+    }
+
+    tableLines.push(`| ${rowLines.join(' | ')} |`)
+  }
+
+
+  return `\n${tableLines.join('\n')}\n`
+}
+
+export const randomMarkdownCodeSpanString: MockFunction<string, []> = function() {
+  return `\`${this.create('noun')}\``
+}
+
+export const randomMarkdownCodeBlockString: MockFunction<string, [{ lines?: number }?]> = function({ lines = uniform(1, 5) } = {}) {
+  const codeLines: string[] = []
+
+  for (let i = 0; i < lines; i++) {
+    codeLines.push(this.create('sentence'))
+  }
+
+  return `\`\`\`\n${codeLines.join('\n')}\n\`\`\``
+}
+
+type MarkdownType = 'header' | 'quote' | 'content' | 'code' | 'table'
+const markdownTypes: MarkdownType[] = ['header', 'quote', 'content', 'code', 'table']
+type MarkdownLine = {
+  type: MarkdownType,
+  content: string,
+  level?: number,
+}
+
+export const randomMarkdownString: MockFunction<string, [{ sections?: number }?]> = function({ sections = 5 } = {}) {
+
+  const markdownLines: MarkdownLine[] = []
+
+  markdownLines.push({
+    type: 'header',
+    content: this.create('markdownHeaderString', [{ level: 1 }]),
+    level: 1,
+  })
+
+  for (let i = 0; i < sections; i++) {
+    const lastLine: MarkdownLine | undefined = markdownLines[markdownLines.length - 1]
+    const type = choice(markdownTypes)
+
+    if (type == 'header' && i < sections - 1) {
+      let headerLevel: number = 1
+
+      if (lastLine.type == 'header' && lastLine.level && lastLine.level < 6) {
+        headerLevel = lastLine.level + 1
+      } else {
+        headerLevel = uniform(2, 5)
+      }
+
+      markdownLines.push({
+        type: 'header',
+        content: this.create('markdownHeaderString', [{ level: headerLevel }]),
+        level: headerLevel,
+      })
+
+      continue
+    }
+
+
+    if (type == 'quote') {
+      markdownLines.push({
+        type: 'quote',
+        content: this.create('markdownQuoteString'),
+      })
+
+      continue
+    }
+
+    if (type == 'table') {
+      markdownLines.push({
+        type: 'table',
+        content: this.create('markdownTableString'),
+      })
+
+      continue
+    }
+
+    if (type == 'code') {
+      markdownLines.push({
+        type: 'content',
+        content: this.create('markdownCodeBlockString'),
+      })
+
+      continue
+    }
+
+    // Default to content
+    markdownLines.push({
+      type: 'content',
+      content: this.create('markdownContentString'),
+    })
+
+    continue
+  }
+
+  return markdownLines.map(mdl => mdl.content).join('\n\n')
+}

--- a/src/models/Artifact.ts
+++ b/src/models/Artifact.ts
@@ -6,6 +6,7 @@ export interface IArtifact {
   updated: Date,
   key: string,
   type: string,
+  description: string | null,
   data: ArtifactData,
   metadata: ArtifactData,
   flowRunId: string | null,
@@ -20,6 +21,7 @@ export class Artifact implements IArtifact {
   public readonly updated: Date
   public key: string
   public type: string
+  public description: string | null
   public data: ArtifactData
   public metadata: ArtifactData
 
@@ -29,6 +31,7 @@ export class Artifact implements IArtifact {
     this.updated = artifact.updated
     this.key = artifact.key
     this.type = artifact.type
+    this.description = artifact.description
     this.data = artifact.data
     this.metadata = artifact.metadata
     this.flowRunId = artifact.flowRunId

--- a/src/models/Artifact.ts
+++ b/src/models/Artifact.ts
@@ -4,7 +4,7 @@ export interface IArtifact {
   id: string,
   created: Date,
   updated: Date,
-  key: string,
+  key: string | null,
   type: string,
   description: string | null,
   data: ArtifactData,
@@ -15,11 +15,11 @@ export interface IArtifact {
 
 export class Artifact implements IArtifact {
   public readonly id: string
+  public readonly key: string | null
   public readonly flowRunId: string | null
   public readonly taskRunId: string | null
   public readonly created: Date
   public readonly updated: Date
-  public key: string
   public type: string
   public description: string | null
   public data: ArtifactData

--- a/src/models/Artifact.ts
+++ b/src/models/Artifact.ts
@@ -1,16 +1,49 @@
-export type ArtifactData = Record<string, unknown>
+export enum ArtifactType {
+  Result = 'result',
+  Markdown = 'markdown',
+  Table = 'table',
+  Unknown = 'unknown'
+}
+
+export type ResultArtifactData = Record<string, unknown>
+export type MarkdownArtifactData = string
+export type TableArtifactData = Record<string, unknown>[]
+export type UnknownArtifactData = unknown
+
+export type ArtifactData = ResultArtifactData | MarkdownArtifactData | TableArtifactData | UnknownArtifactData
+export type ArtifactMetadata = Record<string, string>
 
 export interface IArtifact {
   id: string,
   created: Date,
   updated: Date,
   key: string | null,
-  type: string,
+  type: ArtifactType,
   description: string | null,
   data: ArtifactData,
-  metadata: ArtifactData,
+  metadata: ArtifactMetadata,
   flowRunId: string | null,
   taskRunId: string | null,
+}
+
+export type ResultArtifact = IArtifact & {
+  type: ArtifactType.Result,
+  data: ResultArtifactData,
+}
+
+export type MarkdownArtifact = IArtifact & {
+  type: ArtifactType.Markdown,
+  data: MarkdownArtifactData,
+}
+
+export type TableArtifact = IArtifact & {
+  type: ArtifactType.Table,
+  data: TableArtifactData,
+}
+
+export type UnknownArtifact = IArtifact & {
+  type: ArtifactType.Unknown,
+  data: unknown,
 }
 
 export class Artifact implements IArtifact {
@@ -20,10 +53,10 @@ export class Artifact implements IArtifact {
   public readonly taskRunId: string | null
   public readonly created: Date
   public readonly updated: Date
-  public type: string
+  public type: ArtifactType
   public description: string | null
   public data: ArtifactData
-  public metadata: ArtifactData
+  public metadata: ArtifactMetadata
 
   public constructor(artifact: IArtifact) {
     this.id = artifact.id

--- a/src/models/Artifact.ts
+++ b/src/models/Artifact.ts
@@ -1,9 +1,11 @@
-export enum ArtifactType {
-  Result = 'result',
-  Markdown = 'markdown',
-  Table = 'table',
-  Unknown = 'unknown'
-}
+export const artifactTypes = [
+  'result',
+  'markdown',
+  'table',
+  'unknown',
+] as const
+
+export type ArtifactType = typeof artifactTypes[number]
 
 export type ResultArtifactData = Record<string, unknown>
 export type MarkdownArtifactData = string
@@ -27,22 +29,22 @@ export interface IArtifact {
 }
 
 export type ResultArtifact = IArtifact & {
-  type: ArtifactType.Result,
+  type: 'result',
   data: ResultArtifactData,
 }
 
 export type MarkdownArtifact = IArtifact & {
-  type: ArtifactType.Markdown,
+  type: 'markdown',
   data: MarkdownArtifactData,
 }
 
 export type TableArtifact = IArtifact & {
-  type: ArtifactType.Table,
+  type: 'table',
   data: TableArtifactData,
 }
 
 export type UnknownArtifact = IArtifact & {
-  type: ArtifactType.Unknown,
+  type: 'unknown',
   data: unknown,
 }
 

--- a/src/models/api/ArtifactResponse.ts
+++ b/src/models/api/ArtifactResponse.ts
@@ -6,6 +6,7 @@ export type ArtifactResponse = {
   updated: string,
   key: string,
   type: string,
+  description: string | null,
   data: ArtifactDataResponse,
   metadata_: ArtifactDataResponse,
   flow_run_id: string | null,

--- a/src/models/api/ArtifactResponse.ts
+++ b/src/models/api/ArtifactResponse.ts
@@ -1,4 +1,5 @@
-export type ArtifactDataResponse = Record<string, unknown>
+export type ArtifactDataResponse = unknown
+export type ArtifactMetadataResponse = Record<string, string>
 
 export type ArtifactResponse = {
   id: string,
@@ -8,7 +9,7 @@ export type ArtifactResponse = {
   type: string,
   description: string | null,
   data: ArtifactDataResponse,
-  metadata_: ArtifactDataResponse,
+  metadata_: ArtifactMetadataResponse,
   flow_run_id: string | null,
   task_run_id: string | null,
 }

--- a/src/services/WorkspaceArtifactsApi.ts
+++ b/src/services/WorkspaceArtifactsApi.ts
@@ -1,5 +1,5 @@
 import { Artifact, ArtifactResponse } from '@/models'
-import { ArtifactFilter } from '@/models/Filters'
+import { ArtifactsFilter } from '@/models/Filters'
 import { BatchProcessor } from '@/services/BatchProcessor'
 import { mapper } from '@/services/Mapper'
 import { WorkspaceApi } from '@/services/WorkspaceApi'
@@ -7,17 +7,17 @@ import { toMap } from '@/utilities'
 
 export interface IWorkspaceArtifactsApi {
   getArtifact: (id: string) => Promise<Artifact>,
-  getArtifacts: (filter: ArtifactFilter) => Promise<Artifact[]>,
-  getArtifactsCount: (filter: ArtifactFilter) => Promise<number>,
+  getArtifacts: (filter: ArtifactsFilter) => Promise<Artifact[]>,
+  getArtifactsCount: (filter: ArtifactsFilter) => Promise<number>,
   deleteArtifact: (id: string) => Promise<void>,
 }
 
 export class WorkspaceArtifactsApi extends WorkspaceApi implements IWorkspaceArtifactsApi {
 
-  protected override routePrefix = '/artifacts'
+  protected override routePrefix = '/experimental/artifacts'
 
   private readonly batcher = new BatchProcessor<string, Artifact>(async ids => {
-    const artifacts = await this.getArtifacts({ id: ids })
+    const artifacts = await this.getArtifacts({ artifacts: { id: ids } })
     return toMap(artifacts, 'id')
   }, { maxBatchSize: 200 })
 
@@ -25,14 +25,14 @@ export class WorkspaceArtifactsApi extends WorkspaceApi implements IWorkspaceArt
     return this.batcher.batch(id)
   }
 
-  public async getArtifacts(filter: ArtifactFilter = {}): Promise<Artifact[]> {
-    const request = mapper.map('ArtifactFilter', filter, 'ArtifactFilterRequest')
+  public async getArtifacts(filter: ArtifactsFilter = {}): Promise<Artifact[]> {
+    const request = mapper.map('ArtifactsFilter', filter, 'ArtifactsFilterRequest')
     const { data } = await this.post<ArtifactResponse[]>('filter', request)
     return mapper.map('ArtifactResponse', data, 'Artifact')
   }
 
-  public async getArtifactsCount(filter: ArtifactFilter = {}): Promise<number> {
-    const request = mapper.map('ArtifactFilter', filter, 'ArtifactFilterRequest')
+  public async getArtifactsCount(filter: ArtifactsFilter = {}): Promise<number> {
+    const request = mapper.map('ArtifactsFilter', filter, 'ArtifactsFilterRequest')
     const { data } = await this.post<number>('count', request)
     return data
   }

--- a/src/types/SortOptionTypes.ts
+++ b/src/types/SortOptionTypes.ts
@@ -12,6 +12,13 @@ export function isArtifactSortValue(value: MaybeRef<unknown>): value is MaybeRef
   return artifactSortValues.includes(valueRef.value as ArtifactSortValues)
 }
 
+export const artifactSortOptions = [
+  { label: 'Created', value: 'CREATED_DESC' },
+  { label: 'Updated', value: 'UPDATED_DESC' },
+  { label: 'A to Z', value: 'KEY_ASC' },
+  { label: 'Z to A', value: 'KEY_DESC' },
+]
+
 export const flowSortValues = ['CREATED_DESC', 'UPDATED_DESC', 'NAME_DESC', 'NAME_ASC'] as const
 export type FlowSortValues = typeof flowSortValues[number]
 export const defaultFlowSort: FlowSortValues = 'CREATED_DESC'

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -12,6 +12,10 @@ export function isTableArtifact(artifact: Artifact): artifact is TableArtifact {
   return artifact.type === ArtifactType.Table
 }
 
+export function isKnownArtifactType(type: string): type is ArtifactType {
+  return Object.values(ArtifactType).includes(type as ArtifactType)
+}
+
 export function isUnknownArtifact(artifact: Artifact): artifact is UnknownArtifact {
   return artifact.type === ArtifactType.Unknown
 }

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -1,23 +1,11 @@
-import { ArtifactType, ResultArtifact, ResultArtifactData, MarkdownArtifact, MarkdownArtifactData, UnknownArtifact, Artifact, ArtifactData, TableArtifact, TableArtifactData } from '@/models/Artifact'
+import { ArtifactType, artifactTypes, ResultArtifactData, MarkdownArtifactData, Artifact, ArtifactData, TableArtifactData } from '@/models/Artifact'
 
-export function isResultArtifact(artifact: Artifact): artifact is ResultArtifact {
-  return artifact.type === ArtifactType.Result
+export function isArtifactType<T extends ArtifactType>(artifact: Artifact, type: T): artifact is Artifact & { type: T } {
+  return artifact.type === type
 }
 
-export function isMarkdownArtifact(artifact: Artifact): artifact is MarkdownArtifact {
-  return artifact.type === ArtifactType.Markdown
-}
-
-export function isTableArtifact(artifact: Artifact): artifact is TableArtifact {
-  return artifact.type === ArtifactType.Table
-}
-
-export function isKnownArtifactType(type: string): type is ArtifactType {
-  return Object.values(ArtifactType).includes(type as ArtifactType)
-}
-
-export function isUnknownArtifact(artifact: Artifact): artifact is UnknownArtifact {
-  return artifact.type === ArtifactType.Unknown
+export function isKnownArtifactType(type: unknown): type is ArtifactType & Exclude<ArtifactType, 'unknown'> {
+  return typeof type === 'string' && artifactTypes.includes(type as ArtifactType) && type !== 'unknown'
 }
 
 export function isResultArtifactData(data: ArtifactData): data is ResultArtifactData {

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -1,4 +1,4 @@
-import { ArtifactType, ResultArtifact, ResultArtifactData, MarkdownArtifact, MarkdownArtifactData, UnknownArtifact, Artifact, ArtifactData, TableArtifact, TableArtifactData } from '@/models/artifact'
+import { ArtifactType, ResultArtifact, ResultArtifactData, MarkdownArtifact, MarkdownArtifactData, UnknownArtifact, Artifact, ArtifactData, TableArtifact, TableArtifactData } from '@/models/Artifact'
 
 export function isResultArtifact(artifact: Artifact): artifact is ResultArtifact {
   return artifact.type === ArtifactType.Result

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -1,0 +1,29 @@
+import { ArtifactType, ResultArtifact, ResultArtifactData, MarkdownArtifact, MarkdownArtifactData, UnknownArtifact, Artifact, ArtifactData, TableArtifact, TableArtifactData } from '@/models/artifact'
+
+export function isResultArtifact(artifact: Artifact): artifact is ResultArtifact {
+  return artifact.type === ArtifactType.Result
+}
+
+export function isMarkdownArtifact(artifact: Artifact): artifact is MarkdownArtifact {
+  return artifact.type === ArtifactType.Markdown
+}
+
+export function isTableArtifact(artifact: Artifact): artifact is TableArtifact {
+  return artifact.type === ArtifactType.Table
+}
+
+export function isUnknownArtifact(artifact: Artifact): artifact is UnknownArtifact {
+  return artifact.type === ArtifactType.Unknown
+}
+
+export function isResultArtifactData(data: ArtifactData): data is ResultArtifactData {
+  return typeof data === 'object'
+}
+
+export function isMarkdownArtifactData(data: ArtifactData): data is MarkdownArtifactData {
+  return typeof data === 'string'
+}
+
+export function isTableArtifactData(data: ArtifactData): data is TableArtifactData {
+  return Array.isArray(data)
+}

--- a/src/utilities/api.ts
+++ b/src/utilities/api.ts
@@ -4,6 +4,7 @@ import { CollectionsApi } from '@/services/CollectionsApi'
 import { HealthApi } from '@/services/HealthApi'
 import { UiApi } from '@/services/UiApi'
 import { WorkspaceApiConfig } from '@/services/WorkspaceApi'
+import { WorkspaceArtifactsApi } from '@/services/WorkspaceArtifactsApi'
 import { WorkspaceBlockCapabilitiesApi } from '@/services/WorkspaceBlockCapabilitiesApi'
 import { WorkspaceBlockDocumentsApi } from '@/services/WorkspaceBlockDocumentsApi'
 import { WorkspaceBlockSchemasApi } from '@/services/WorkspaceBlockSchemasApi'
@@ -25,6 +26,7 @@ import { WorkspaceWorkQueuesApi } from '@/services/WorkspaceWorkQueuesApi'
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createApi(workspaceConfig: WorkspaceApiConfig) {
   return {
+    artifacts: createActions(new WorkspaceArtifactsApi(workspaceConfig)),
     blockCapabilities: createActions(new WorkspaceBlockCapabilitiesApi(workspaceConfig)),
     blockDocuments: createActions(new WorkspaceBlockDocumentsApi(workspaceConfig)),
     blockSchemas: createActions(new WorkspaceBlockSchemasApi(workspaceConfig)),


### PR DESCRIPTION
This PR:
- adds support for 4 artifact types: `Result`, `Table`, `Markdown`, and `Unknown` (a catch-all for forwards/backwards compatibility)
- adds markdown mockers
- adds artifact mockers (including basic support for the data fields of known artifact types listed above)
- updates the experimental artifact api endpoint
- fixes filter references in the artifact api