### PR TITLE
Allow graceful handling of flow runs with deleted deployment IDs

### DIFF
--- a/src/components/FlowRunDetails.vue
+++ b/src/components/FlowRunDetails.vue
@@ -24,7 +24,7 @@
       </template>
     </p-key-value>
 
-    <p-key-value v-if="can.read.deployment && flowRun.deploymentId" label="Deployment" :alternate="alternate">
+    <p-key-value v-if="can.read.deployment && flowRun.deploymentId && deployment?.name" label="Deployment" :alternate="alternate">
       <template #value>
         <DeploymentIconText :deployment-id="flowRun.deploymentId" />
       </template>
@@ -101,6 +101,7 @@
   import { computed } from 'vue'
   import { WorkQueueIconText, FlowRunIconText, WorkQueueStatusIcon, RadarSmall, FlowRunTaskCount, FlowRunStartTime, FlowIconText, DurationIconText, DeploymentIconText } from '@/components'
   import { useTaskRunsCount, useWorkspaceApi, useWorkspaceRoutes, useCan } from '@/compositions'
+  import { useDeployment } from '@/compositions/useDeployment'
   import { FlowRun } from '@/models/FlowRun'
   import { formatDateTimeNumeric } from '@/utilities/dates'
 
@@ -117,6 +118,8 @@
 
   const flowRunId = computed(() => props.flowRun.id)
   const tasksCount = useTaskRunsCount(flowRunId)
+  const deploymentId = computed(() => props.flowRun.deploymentId)
+  const deployment = useDeployment(deploymentId)
 
   const flowRunFilter = computed<Parameters<typeof api.flowRuns.getFlowRuns> | null>(() => {
     if (props.flowRun.parentTaskRunId) {

--- a/src/components/FlowRunDetails.vue
+++ b/src/components/FlowRunDetails.vue
@@ -24,7 +24,7 @@
       </template>
     </p-key-value>
 
-    <p-key-value v-if="can.read.deployment && flowRun.deploymentId && deployment?.name" label="Deployment" :alternate="alternate">
+    <p-key-value v-if="flowRun.deploymentId && showDeployment" label="Deployment" :alternate="alternate">
       <template #value>
         <DeploymentIconText :deployment-id="flowRun.deploymentId" />
       </template>
@@ -103,6 +103,7 @@
   import { useTaskRunsCount, useWorkspaceApi, useWorkspaceRoutes, useCan } from '@/compositions'
   import { useDeployment } from '@/compositions/useDeployment'
   import { FlowRun } from '@/models/FlowRun'
+  import { isDefined } from '@/utilities'
   import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const api = useWorkspaceApi()
@@ -120,6 +121,7 @@
   const tasksCount = useTaskRunsCount(flowRunId)
   const deploymentId = computed(() => props.flowRun.deploymentId)
   const deployment = useDeployment(deploymentId)
+  const showDeployment = computed(() => can.read.deployment && isDefined(deployment.value))
 
   const flowRunFilter = computed<Parameters<typeof api.flowRuns.getFlowRuns> | null>(() => {
     if (props.flowRun.parentTaskRunId) {

--- a/src/components/FlowRunListItem.vue
+++ b/src/components/FlowRunListItem.vue
@@ -24,7 +24,7 @@
         </template>
       </template>
       <template v-if="visible && (flowRun.deploymentId || flowRun.workQueueName)" #relationships>
-        <template v-if="flowRun.deploymentId">
+        <template v-if="flowRun.deploymentId && deployment?.name">
           <div class="flow-run-list-item__relation">
             <span>Deployment</span> <DeploymentIconText :deployment-id="flowRun.deploymentId" />
           </div>
@@ -60,6 +60,7 @@
   import WorkPoolIconText from '@/components/WorkPoolIconText.vue'
   import WorkQueueIconText from '@/components/WorkQueueIconText.vue'
   import { useTaskRunsCount, useWorkspaceRoutes } from '@/compositions'
+  import { useDeployment } from '@/compositions/useDeployment'
   import { FlowRun } from '@/models/FlowRun'
   import { toPluralString } from '@/utilities'
 
@@ -89,6 +90,9 @@
 
   const flowRunId = computed(() => props.flowRun.id)
   const tasksCount = useTaskRunsCount(flowRunId)
+
+  const deploymentId = computed(() => props.flowRun.deploymentId)
+  const deployment = useDeployment(deploymentId)
 
   const visible = ref(false)
   const el = ref<HTMLDivElement>()


### PR DESCRIPTION
At some point we plan to remove cascading behavior between deployment deletion -> flow run table.  This means that we could end up with flow runs that have populated deployment IDs for deployments that no longer exist.

This PR adjusts the UI to handle that in a more robust way - to be clear, the UI was still working but this makes the display a bit cleaner.

Whoever reviews: I want to make sure that I haven't accidentally increased the number of lookups; I don't believe I have because we were already looking up deployment names for each individual flow run, but I wanted to still check!