### PR TITLE
Chore: Fix `StateNameSelect` and `StateSelect` eslint warnings

### DIFF
--- a/demo/sections/states/StateSelect.vue
+++ b/demo/sections/states/StateSelect.vue
@@ -1,13 +1,13 @@
 <template>
-  <ComponentPage title="StateNameSelect" :demos="demos">
+  <ComponentPage title="StateSelect" :demos="demos">
     <div class="h-96 color-mode-default">
-      <StateNameSelect v-model:selected="selected" />
+      <StateSelect v-model:selected="selected" />
       {{ selected }}
     </div>
 
     <template #multiple>
       <div class="h-96 color-mode-default">
-        <StateNameSelect v-model:selected="multiple" />
+        <StateSelect v-model:selected="multiple" />
         {{ multiple }}
       </div>
     </template>
@@ -16,12 +16,12 @@
 
 <script lang="ts" setup>
   import { ref } from 'vue'
-  import StateNameSelect from '@/components/StateNameSelect.vue'
+  import StateSelect from '@/components/StateSelect.vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
   import { DemoSection } from '@/demo/types/demoSection'
 
   const demos: DemoSection[] = [{ title: 'Multiple' }]
 
-  const selected = ref('Completed')
-  const multiple = ref(['Running'])
+  const selected = ref('scheduled')
+  const multiple = ref(['Failed', 'Crashed'])
 </script>

--- a/demo/sections/states/StateSelect.vue
+++ b/demo/sections/states/StateSelect.vue
@@ -23,5 +23,5 @@
   const demos: DemoSection[] = [{ title: 'Multiple' }]
 
   const selected = ref('scheduled')
-  const multiple = ref(['Failed', 'Crashed'])
+  const multiple = ref(['failed', 'crashed'])
 </script>

--- a/demo/sections/states/index.ts
+++ b/demo/sections/states/index.ts
@@ -1,5 +1,6 @@
 import { Section } from '@/demo/router/routeRecords'
 
 export const states: Section = {
-  StateNameSelect: () => import ('./StateNameSelect.vue'),
+  StateNameSelect: () => import('./StateNameSelect.vue'),
+  StateSelect: () => import('./StateSelect.vue'),
 }

--- a/src/components/StateBadge.vue
+++ b/src/components/StateBadge.vue
@@ -8,12 +8,12 @@
 <script lang="ts" setup>
   import { computed } from 'vue'
   import StateIcon from '@/components/StateIcon.vue'
-  import { StateType } from '@/models/StateType'
+  import { StateBadgeState } from '@/types/stateBadge'
   import { TailwindColor } from '@/types/tailwind'
   import { mapStateNameToStateType } from '@/utilities/state'
 
   const props = defineProps<{
-    state: { name: string, type: StateType | null } | null,
+    state: StateBadgeState | null,
     flat?: boolean,
     dismissible?: boolean,
   }>()

--- a/src/components/StateNameSelect.vue
+++ b/src/components/StateNameSelect.vue
@@ -4,15 +4,15 @@
       <template #option="{ option }">
         <StateBadge :state="getStateFromTagValue(option.value)" />
       </template>
-      <template v-if="multiple" #tag="{ value, dismiss }">
+      <template #tag="{ value, dismiss }">
         <StateBadge
           class="state-name-select__option state-name-select__option--multiple"
-          :state="getStateFromTagValue(value)"
+          :state="getStateFromTagValue(value.value)"
           dismissible
           @dismiss="dismiss"
         />
       </template>
-      <template v-else #default="{ value }">
+      <template #default="{ value }">
         <StateBadge
           class="state-name-select__option"
           :state="getStateFromTagValue(value)"
@@ -24,7 +24,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { isArray, PSelect, SelectOption, TagValue } from '@prefecthq/prefect-design'
+  import { isArray, PSelect, SelectOption } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import StateBadge from '@/components/StateBadge.vue'
   import { StateBadgeState } from '@/types/stateBadge'
@@ -68,7 +68,7 @@
     }
   }))
 
-  const getStateFromTagValue = ({ value }: TagValue): StateBadgeState | null => {
+  const getStateFromTagValue = (value: unknown): StateBadgeState | null => {
     if (typeof value == 'string') {
       return mapStateNameToStateType(value)
     }

--- a/src/components/StateNameSelect.vue
+++ b/src/components/StateNameSelect.vue
@@ -7,7 +7,7 @@
       <template #tag="{ value, dismiss }">
         <StateBadge
           class="state-name-select__option state-name-select__option--multiple"
-          :state="getStateFromTagValue(value.value)"
+          :state="getStateFromTagValue(value)"
           dismissible
           @dismiss="dismiss"
         />

--- a/src/components/StateNameSelect.vue
+++ b/src/components/StateNameSelect.vue
@@ -2,20 +2,20 @@
   <div class="state-name-select">
     <p-select v-model="internalValue" v-bind="{ options, multiple, emptyMessage }">
       <template #option="{ option }">
-        <StateBadge :state="{ name: option.label, type: option.value as StateType }" />
+        <StateBadge :state="getStateFromTagValue(option.value)" />
       </template>
-      <template v-if="multiple" #tag="{ label, value, dismiss }">
+      <template v-if="multiple" #tag="{ value, dismiss }">
         <StateBadge
           class="state-name-select__option state-name-select__option--multiple"
-          :state="{ name: label, type: value as StateType }"
+          :state="getStateFromTagValue(value)"
           dismissible
           @dismiss="dismiss"
         />
       </template>
-      <template v-else #default="{ label, value }">
+      <template v-else #default="{ value }">
         <StateBadge
           class="state-name-select__option"
-          :state="{ name: label, type: value as StateType }"
+          :state="getStateFromTagValue(value)"
           flat
         />
       </template>
@@ -24,10 +24,10 @@
 </template>
 
 <script lang="ts" setup>
-  import { isArray, PSelect, SelectOption } from '@prefecthq/prefect-design'
+  import { isArray, PSelect, SelectOption, TagValue } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import StateBadge from '@/components/StateBadge.vue'
-  import { StateType } from '@/models/StateType'
+  import { StateBadgeState } from '@/types/stateBadge'
   import { prefectStateNames } from '@/types/states'
   import { mapStateNameToStateType } from '@/utilities'
 
@@ -67,4 +67,12 @@
       type,
     }
   }))
+
+  const getStateFromTagValue = ({ value }: TagValue): StateBadgeState | null => {
+    if (typeof value == 'string') {
+      return mapStateNameToStateType(value)
+    }
+
+    return null
+  }
 </script>

--- a/src/components/StateSelect.vue
+++ b/src/components/StateSelect.vue
@@ -2,20 +2,20 @@
   <div class="state-select">
     <p-select v-model="internalValue" :options="options" :empty-message="emptyMessage">
       <template #option="{ option }">
-        <StateBadge :state="{ name: option.label, type: option.value as StateType }" />
+        <StateBadge :state="getStateFromTagValue(option.value)" />
       </template>
-      <template v-if="multiple" #tag="{ label, value, dismiss }">
+      <template v-if="multiple" #tag="{ value, dismiss }">
         <StateBadge
           class="state-select__option state-select__option--multiple"
-          :state="{ name: label, type: value as StateType }"
+          :state="getStateFromTagValue(value)"
           dismissible
           @dismiss="dismiss"
         />
       </template>
-      <template v-else #default="{ label, value }">
+      <template v-else #default="{ value }">
         <StateBadge
           class="state-select__option"
-          :state="{ name: label, type: value as StateType }"
+          :state="getStateFromTagValue(value)"
         />
       </template>
     </p-select>
@@ -23,11 +23,12 @@
 </template>
 
 <script lang="ts" setup>
-  import { isArray, PSelect, SelectOption } from '@prefecthq/prefect-design'
+  import { isArray, PSelect, SelectOption, TagValue } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import StateBadge from '@/components/StateBadge.vue'
-  import { stateType, StateType, terminalStateType } from '@/models/StateType'
-  import { capitalize } from '@/utilities'
+  import { stateType, terminalStateType } from '@/models/StateType'
+  import { StateBadgeState } from '@/types/stateBadge'
+  import { capitalize, mapStateNameToStateType } from '@/utilities'
 
   const props = defineProps<{
     selected: string | string[] | null | undefined,
@@ -68,6 +69,14 @@
 
     return [...stateMap, { label: 'Late', value: 'late' }, { label: 'Cancelling', value: 'cancelling' }]
   })
+
+  const getStateFromTagValue = ({ value }: TagValue): StateBadgeState | null => {
+    if (typeof value == 'string') {
+      return mapStateNameToStateType(value)
+    }
+
+    return null
+  }
 </script>
 
 <style>

--- a/src/components/StateSelect.vue
+++ b/src/components/StateSelect.vue
@@ -7,7 +7,7 @@
       <template v-if="multiple" #tag="{ value, dismiss }">
         <StateBadge
           class="state-select__option state-select__option--multiple"
-          :state="getStateFromTagValue(value)"
+          :state="getStateFromTagValue(value.value)"
           dismissible
           @dismiss="dismiss"
         />
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { isArray, PSelect, SelectOption, TagValue } from '@prefecthq/prefect-design'
+  import { isArray, PSelect, SelectOption } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import StateBadge from '@/components/StateBadge.vue'
   import { stateType, terminalStateType } from '@/models/StateType'
@@ -70,7 +70,7 @@
     return [...stateMap, { label: 'Late', value: 'late' }, { label: 'Cancelling', value: 'cancelling' }]
   })
 
-  const getStateFromTagValue = ({ value }: TagValue): StateBadgeState | null => {
+  const getStateFromTagValue = (value: unknown): StateBadgeState | null => {
     if (typeof value == 'string') {
       return mapStateNameToStateType(value)
     }

--- a/src/components/StateSelect.vue
+++ b/src/components/StateSelect.vue
@@ -7,7 +7,7 @@
       <template v-if="multiple" #tag="{ value, dismiss }">
         <StateBadge
           class="state-select__option state-select__option--multiple"
-          :state="getStateFromTagValue(value.value)"
+          :state="getStateFromTagValue(value)"
           dismissible
           @dismiss="dismiss"
         />

--- a/src/types/stateBadge.ts
+++ b/src/types/stateBadge.ts
@@ -1,0 +1,3 @@
+import { StateType } from '@/models/StateType'
+
+export type StateBadgeState = { name: string, type: StateType | null }


### PR DESCRIPTION
Modifies the types for `StateNameSelect` and `StateSelect` to map select values more appropriately. Also creates an independent type for the state badge component