### PR TITLE
Bugfix: Filter hotkey events on flow run timeline 

### DIFF
--- a/src/components/FlowRunTimeline.vue
+++ b/src/components/FlowRunTimeline.vue
@@ -83,6 +83,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { FlowRun, isValidTimelineNodeData } from '@/models'
   import { formatTimeNumeric, formatTimeShortNumeric, formatDate } from '@/utilities'
+  import { eventTargetIsInput } from '@/utilities/eventTarget'
 
   const props = defineProps<{
     flowRun: FlowRun,
@@ -131,6 +132,10 @@
   })
 
   function keyboardShortcutListener(event: KeyboardEvent): void {
+    if (eventTargetIsInput(event.target)) {
+      return
+    }
+
     switch (event.key) {
       case 'c':
         centerGraphViewport()

--- a/src/utilities/eventTarget.ts
+++ b/src/utilities/eventTarget.ts
@@ -1,0 +1,8 @@
+export function eventTargetIsInput(eventTarget: EventTarget | null): boolean {
+  if (!(eventTarget instanceof HTMLElement)) {
+    return false
+  }
+
+  const eventTargetTagName = eventTarget.tagName.toLowerCase()
+  return ['input', 'textarea'].includes(eventTargetTagName)
+}


### PR DESCRIPTION
This PR fixes an issue where html input keypresses were masked by flow run timeline shortcuts. 