### PR TITLE
Bugfix: Sub schemas

### DIFF
--- a/src/components/SchemaFormProperty.vue
+++ b/src/components/SchemaFormProperty.vue
@@ -18,10 +18,6 @@
   }>()
 
   const is = computed(() => {
-    if (schemaHas(props.property, 'meta')) {
-      return SchemaFormInput
-    }
-
     if (schemaHas(props.property, 'properties')) {
       return SchemaFormProperties
     }

--- a/src/services/schemas/properties/SchemaPropertyObject.ts
+++ b/src/services/schemas/properties/SchemaPropertyObject.ts
@@ -9,10 +9,6 @@ import { parseUnknownJson, stringifyUnknownJson } from '@/utilities/json'
 export class SchemaPropertyObject extends SchemaPropertyService {
 
   protected override get component(): SchemaPropertyComponentWithProps {
-    if (this.isMaxLevel) {
-      return this.withProps(JsonInput)
-    }
-
     if (this.has('properties')) {
       return null
     }
@@ -21,10 +17,6 @@ export class SchemaPropertyObject extends SchemaPropertyService {
   }
 
   protected get default(): unknown {
-    if (this.isMaxLevel) {
-      return ''
-    }
-
     // some object properties don't have specific properties and a JsonInput is used
     if (!this.has('properties')) {
       return ''
@@ -34,10 +26,6 @@ export class SchemaPropertyObject extends SchemaPropertyService {
   }
 
   protected request(value: SchemaValue): unknown {
-    if (this.isMaxLevel) {
-      return this.maxLevelRequestValue(value)
-    }
-
     if (!this.has('properties')) {
       return parseUnknownJson(value)
     }
@@ -61,10 +49,6 @@ export class SchemaPropertyObject extends SchemaPropertyService {
   }
 
   protected response(value: SchemaValue): unknown {
-    if (this.isMaxLevel) {
-      return this.maxLevelResponseValue(value)
-    }
-
     // if there are no nested properties a JsonInput is used
     if (!this.has('properties')) {
       return stringifyUnknownJson(value)
@@ -81,25 +65,4 @@ export class SchemaPropertyObject extends SchemaPropertyService {
       return service.mapResponseValue(propertyValue)
     })
   }
-
-  private maxLevelRequestValue(value: SchemaValue): unknown {
-    const mapped = parseUnknownJson(value)
-
-    if (mapped === null || mapped === undefined) {
-      return this.invalid()
-    }
-
-    return mapped
-  }
-
-  private maxLevelResponseValue(value: SchemaValue): unknown {
-    const mapped = stringifyUnknownJson(value)
-
-    if (mapped === null || mapped === undefined) {
-      return this.invalid()
-    }
-
-    return mapped
-  }
-
 }

--- a/src/services/schemas/properties/SchemaPropertyService.ts
+++ b/src/services/schemas/properties/SchemaPropertyService.ts
@@ -1,6 +1,5 @@
 import { SelectOption } from '@prefecthq/prefect-design'
 import { InvalidSchemaValueError } from '@/models/InvalidSchemaValueError'
-import { MAX_SCHEMA_PROPERTY_LEVEL } from '@/services/schemas/constants'
 import { getSchemaPropertyAttrs, getSchemaPropertyComponentWithDefaultProps, getSchemaPropertyDefaultValidators, schemaPropertyComponentWithProps, SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { schemaHas, SchemaProperty, SchemaPropertyInputAttrs, SchemaPropertyMeta, SchemaValue } from '@/types/schemas'
 import { Require } from '@/types/utilities'
@@ -55,10 +54,6 @@ export abstract class SchemaPropertyService {
   protected property: SchemaProperty
   protected level: number
   protected withProps = schemaPropertyComponentWithProps
-
-  protected get isMaxLevel(): boolean {
-    return this.level > MAX_SCHEMA_PROPERTY_LEVEL
-  }
 
   public constructor({ property, level }: SchemaPropertyServiceSource) {
     this.property = property


### PR DESCRIPTION
This PR removes `maxLevel` considerations for schema properties and ignores meta-defined rendering in favor of a property-first version that falls back to the same component.

Closes https://github.com/PrefectHQ/prefect/issues/7816