### PR TITLE
Enhancement: Flow run results lists

### DIFF
--- a/demo/compositions/useFlowRunsMock.ts
+++ b/demo/compositions/useFlowRunsMock.ts
@@ -20,6 +20,7 @@ export function useFlowRunMock(override?: Partial<FlowRun>): FlowRun {
       type: 'result',
       taskRunId: null,
       flowRunId: flowRun.id,
+      description: `${mocker.create('adjective')} ${mocker.create('runName')} ${mocker.create('markdownCodeSpanString')}`,
     },
   ])
 

--- a/demo/compositions/useTaskRunsMock.ts
+++ b/demo/compositions/useTaskRunsMock.ts
@@ -27,6 +27,7 @@ export function useTaskRunMock(override?: Partial<TaskRun>): TaskRun {
       type: 'result',
       taskRunId: taskRun.id,
       flowRunId: flowRun.id,
+      description: `${mocker.create('adjective')} ${mocker.create('runName')} ${mocker.create('markdownCodeSpanString')}`,
     },
   ])
 

--- a/demo/sections/flowRuns/FlowRunResults.vue
+++ b/demo/sections/flowRuns/FlowRunResults.vue
@@ -5,6 +5,14 @@
     <template #no-results>
       <FlowRunResults :flow-run="flowRunNoResult" />
     </template>
+
+    <template #no-flow-run-results>
+      <FlowRunResults :flow-run="flowRunNoFlowRunResult" />
+    </template>
+
+    <template #no-task-run-results>
+      <FlowRunResults :flow-run="flowRunNoTaskRunResult" />
+    </template>
   </ComponentPage>
 </template>
 
@@ -18,7 +26,13 @@
 
   const demos: DemoSection[] = [
     {
-      title: 'No Results',
+      title: 'No results',
+    },
+    {
+      title: 'No flow run results',
+    },
+    {
+      title: 'No task run results',
     },
   ]
 
@@ -31,4 +45,15 @@
   if (artifact) {
     data.artifacts.delete(artifact.id)
   }
+
+  const flowRunNoFlowRunResult = useFlowRunMock()
+  const flowRunNoFlowRunResultArtifact = data.artifacts.find(artifact => artifact.flowRunId === flowRunNoFlowRunResult.id)
+
+  if (flowRunNoFlowRunResultArtifact) {
+    data.artifacts.delete(flowRunNoFlowRunResultArtifact.id)
+  }
+
+  useTaskRunsMock(10, { flowRunId: flowRunNoFlowRunResult.id })
+
+  const flowRunNoTaskRunResult = useFlowRunMock()
 </script>

--- a/demo/sections/flowRuns/FlowRunResults.vue
+++ b/demo/sections/flowRuns/FlowRunResults.vue
@@ -1,9 +1,5 @@
 <template>
   <ComponentPage title="FlowRunResults" :demos="demos">
-    <template #description>
-      <FlowRunResults :flow-run="flowRun" />
-    </template>
-
     <FlowRunResults :flow-run="flowRun" />
 
     <template #no-results>

--- a/demo/sections/flowRuns/FlowRunResults.vue
+++ b/demo/sections/flowRuns/FlowRunResults.vue
@@ -1,5 +1,9 @@
 <template>
   <ComponentPage title="FlowRunResults" :demos="demos">
+    <template #description>
+      <FlowRunResults :flow-run="flowRun" />
+    </template>
+
     <FlowRunResults :flow-run="flowRun" />
 
     <template #no-results>

--- a/demo/sections/general/ColorModeSelect.vue
+++ b/demo/sections/general/ColorModeSelect.vue
@@ -1,15 +1,15 @@
 <template>
   <ComponentPage title="ColorModeSelect">
     <div class="h-96">
-      <ColorModeSelect v-model:selected="selected" />
+      <ColorModeSelect v-model:selected="activeColorMode" />
     </div>
   </ComponentPage>
 </template>
 
 <script lang="ts" setup>
-  import { ref } from 'vue'
   import ColorModeSelect from '@/components/ColorModeSelect.vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
+  import { activeColorMode } from '@/demo/utilities/colorMode'
 
-  const selected = ref(null)
+  // const { value: selected } = useColorTheme()
 </script>

--- a/demo/sections/general/ColorModeSelect.vue
+++ b/demo/sections/general/ColorModeSelect.vue
@@ -10,6 +10,4 @@
   import ColorModeSelect from '@/components/ColorModeSelect.vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
   import { activeColorMode } from '@/demo/utilities/colorMode'
-
-  // const { value: selected } = useColorTheme()
 </script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -65,7 +65,7 @@
       img-src 'self' data: https://picsum.photos https://i.picsum.photos; \
       media-src 'none'; \
       object-src 'none'; \
-      script-src 'self' 'unsafe-inline'; \
+      script-src 'self' 'unsafe-inline' 'unsafe-eval'; \
       worker-src 'self' blob:; \
       style-src 'self' 'unsafe-inline'; \
       """

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,6 +30,8 @@
     #   'self' - all connections to current origin are permitted
     # font-src
     #   'self' - all fonts from current origin are permitted
+    #   data: - fonts embedded inline are permitted
+    #
     # frame-ancestors
     #   'self' - allow embedding in current origin
     # frame-src
@@ -57,7 +59,7 @@
     Content-Security-Policy = """\
       default-src 'self'; \
       connect-src 'self'; \
-      font-src 'self'; \
+      font-src 'self' data:; \
       frame-ancestors 'self'; \
       frame-src 'self'; \
       img-src 'self' data: https://picsum.photos https://i.picsum.photos; \

--- a/netlify.toml
+++ b/netlify.toml
@@ -44,7 +44,13 @@
     #   'none' - no legacy objects are allowed; see
     #            https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src
     # script-src
-    #   'self' - all resources from current origin are permitted
+    #  'self' - all resources from current origin are permitted
+    #  'unsafe-inline' - Some prefect-design scripts are injected inline
+    #
+    # worker-src
+    #   'self' - all workers from current origin are permitted
+    #   blob: - workers from blob URLs are permitted
+    #
     # style-src
     #   'self' - all styles from current origin are permitted
     #   'unsafe-inline' - Tailwind styles are injected inline
@@ -57,8 +63,9 @@
       img-src 'self' data: https://picsum.photos https://i.picsum.photos; \
       media-src 'none'; \
       object-src 'none'; \
-      script-src 'self'; \
-      style-src 'self' 'unsafe-inline' \
+      script-src 'self' 'unsafe-inline'; \
+      worker-src 'self' blob:; \
+      style-src 'self' 'unsafe-inline'; \
       """
 
     # Referrer-Policy controls the Referer header in requests.

--- a/src/components/ArtifactCard.vue
+++ b/src/components/ArtifactCard.vue
@@ -17,15 +17,6 @@
       <div class="artifact-card__summary-container" :class="classes.summaryContainer">
         <div class="artifact-card__summary-item">
           <span class="artifact-card__summary-item-label">
-            {{ localization.info.lastUpdated }}
-          </span>
-          <span class="artifact-card__summary-item-value">
-            {{ formatDateTime(artifact.updated) }}
-          </span>
-        </div>
-
-        <div class="artifact-card__summary-item">
-          <span class="artifact-card__summary-item-label">
             {{ localization.info.created }}
           </span>
           <span class="artifact-card__summary-item-value">
@@ -91,7 +82,6 @@
     return internalCrumbs
   })
 
-
   const classes = computed(() => {
     return {
       root: {
@@ -132,8 +122,6 @@
 .artifact-card__body { @apply
   flex
   flex-col
-  h-full
-  justify-between
   gap-y-2
 }
 

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -84,7 +84,7 @@
       },
     }
   })
-  const resultsSubscription = useSubscription(api.artifacts.getArtifacts, [resultsFilter])
+  const resultsSubscription = useSubscription(api.artifacts.getArtifacts, [resultsFilter], { interval: 5000 })
   const results = computed(() => resultsSubscription.response ?? [])
 
   const taskRunResults = computed(() => results.value.filter(result => !!result.taskRunId))

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -76,6 +76,8 @@
   ]
   const condense = computed(() => activeViewMode.value === 'rows')
 
+  console.log(activeViewMode.value)
+
   const api = useWorkspaceApi()
   const resultsFilter = computed<ArtifactsFilter>(() => {
     return {

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -119,6 +119,12 @@
   gap-4
 }
 
+.flow-run-results__list { @apply
+  flex
+  flex-col
+  gap-4
+}
+
 .flow-run-results__list--grid { @apply
   grid
   gap-4;

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -7,7 +7,7 @@
       </div>
 
       <p-heading heading="6" class="flow-run-results__subheading">
-        {{ localization.info.flowRunResults }}
+        {{ localization.info.flowRun }}
       </p-heading>
       <div class="flow-run-results__list" :class="classes.list">
         <template v-if="flowRunResults.length">
@@ -27,7 +27,7 @@
       <p-divider />
 
       <p-heading heading="6" class="flow-run-results__subheading">
-        {{ localization.info.taskRunResults }}
+        {{ localization.info.taskRuns }}
       </p-heading>
       <div class="flow-run-results__list" :class="classes.list">
         <template v-if="taskRunResults.length">

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -8,9 +8,7 @@
 
       <div class="flow-run-results__list" :class="classes.list">
         <template v-for="result in results" :key="result.id">
-          <router-link :to="routes.artifact(result.id)" class="flow-run-results__artifact-router-link">
-            <ArtifactCard :artifact="result" :condense="condense" class="flow-run-results__artifact" />
-          </router-link>
+          <ArtifactCard :artifact="result" :condense="condense" class="flow-run-results__artifact" />
         </template>
       </div>
     </template>
@@ -30,7 +28,7 @@
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed, ref } from 'vue'
   import ArtifactCard from '@/components/ArtifactCard.vue'
-  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { FlowRun } from '@/models'
   import { ArtifactsFilter } from '@/models/Filters'
@@ -40,8 +38,6 @@
     flowRun: FlowRun,
     view?: ViewOption,
   }>()
-
-  const routes = useWorkspaceRoutes()
 
   const view = ref<ViewOption>(props.view ?? 'grid')
   const viewOptions: ButtonGroupOption[] = [

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -77,7 +77,7 @@
   ]
 
   const { activeViewMode } = useActiveViewMode()
-  const condense = computed(() => activeViewMode.value === 'rows')
+  const condense = computed(() => activeViewMode.value !== 'grid')
 
   const api = useWorkspaceApi()
   const resultsFilter = computed<ArtifactsFilter>(() => {

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -3,7 +3,6 @@
     <template v-if="hasResults">
       <div class="flow-run-results__button-group-container">
         <slot name="actions" />
-        {{ activeViewMode }}
         <p-button-group v-model="activeViewMode" :options="viewOptions" />
       </div>
 

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -6,9 +6,27 @@
         <p-button-group v-model="view" :options="viewOptions" />
       </div>
 
+      <p-heading heading="6" class="flow-run-results__subheading">
+        {{ localization.info.flowRunResults }}
+      </p-heading>
       <div class="flow-run-results__list" :class="classes.list">
-        <template v-for="result in results" :key="result.id">
-          <ArtifactCard :artifact="result" :condense="condense" class="flow-run-results__artifact" />
+        <template v-for="result in flowRunResults" :key="result.id">
+          <ArtifactCard :artifact="result" :condense="condense" class="flow-run-results__artifact">
+            <p-markdown-renderer v-if="result.description" :text="result.description" />
+          </ArtifactCard>
+        </template>
+      </div>
+
+      <p-divider />
+
+      <p-heading heading="6" class="flow-run-results__subheading">
+        {{ localization.info.taskRunResults }}
+      </p-heading>
+      <div class="flow-run-results__list" :class="classes.list">
+        <template v-for="result in taskRunResults" :key="result.id">
+          <ArtifactCard :artifact="result" :condense="condense" class="flow-run-results__artifact">
+            <p-markdown-renderer v-if="result.description" :text="result.description" />
+          </ArtifactCard>
         </template>
       </div>
     </template>
@@ -56,6 +74,10 @@
   })
   const resultsSubscription = useSubscription(api.artifacts.getArtifacts, [resultsFilter])
   const results = computed(() => resultsSubscription.response ?? [])
+
+  const taskRunResults = computed(() => results.value.filter(result => !!result.taskRunId))
+  const flowRunResults = computed(() => results.value.filter(result => !!result.flowRunId && !result.taskRunId))
+
   const hasResults = computed(() => resultsSubscription.executed && results.value.length > 0)
 
   const classes = computed(() => {
@@ -99,5 +121,9 @@
   hover:border-primary
   focus:border-primary
   h-full
+}
+
+.flow-run-results__subheading { @apply
+  text-foreground-50
 }
 </style>

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -3,6 +3,7 @@
     <template v-if="hasResults">
       <div class="flow-run-results__button-group-container">
         <slot name="actions" />
+        {{ activeViewMode }}
         <p-button-group v-model="activeViewMode" :options="viewOptions" />
       </div>
 
@@ -75,8 +76,6 @@
     { label: '', value: 'rows', icon: 'ViewListIcon' },
   ]
   const condense = computed(() => activeViewMode.value === 'rows')
-
-  console.log(activeViewMode.value)
 
   const api = useWorkspaceApi()
   const resultsFilter = computed<ArtifactsFilter>(() => {

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -3,7 +3,7 @@
     <template v-if="hasResults">
       <div class="flow-run-results__button-group-container">
         <slot name="actions" />
-        <p-button-group v-model="view" :options="viewOptions" />
+        <p-button-group v-model="activeViewMode" :options="viewOptions" />
       </div>
 
       <p-heading heading="6" class="flow-run-results__subheading">
@@ -58,25 +58,23 @@
 <script lang="ts" setup>
   import { ButtonGroupOption } from '@prefecthq/prefect-design'
   import { useSubscription } from '@prefecthq/vue-compositions'
-  import { computed, ref } from 'vue'
+  import { computed } from 'vue'
   import ArtifactCard from '@/components/ArtifactCard.vue'
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { FlowRun } from '@/models'
   import { ArtifactsFilter } from '@/models/Filters'
+  import { activeViewMode } from '@/utilities/artifactsViewMode'
 
-  type ViewOption = 'grid' | 'rows'
   const props = defineProps<{
     flowRun: FlowRun,
-    view?: ViewOption,
   }>()
 
-  const view = ref<ViewOption>(props.view ?? 'grid')
   const viewOptions: ButtonGroupOption[] = [
     { label: '', value: 'grid', icon: 'ViewGridIcon' },
     { label: '', value: 'rows', icon: 'ViewListIcon' },
   ]
-  const condense = computed(() => view.value === 'rows')
+  const condense = computed(() => activeViewMode.value === 'rows')
 
   const api = useWorkspaceApi()
   const resultsFilter = computed<ArtifactsFilter>(() => {
@@ -97,8 +95,8 @@
   const classes = computed(() => {
     return {
       list: {
-        'flow-run-results__list--grid': view.value === 'grid',
-        'flow-run-results__list--rows': view.value === 'rows',
+        'flow-run-results__list--grid': activeViewMode.value === 'grid',
+        'flow-run-results__list--rows': activeViewMode.value === 'rows',
       },
     }
   })

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -137,10 +137,6 @@
   h-full
 }
 
-.flow-run-results__subheading { @apply
-  text-foreground-50
-}
-
 .flow-run-results__none { @apply
   text-foreground-50
 }

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -10,10 +10,17 @@
         {{ localization.info.flowRunResults }}
       </p-heading>
       <div class="flow-run-results__list" :class="classes.list">
-        <template v-for="result in flowRunResults" :key="result.id">
-          <ArtifactCard :artifact="result" :condense="condense" class="flow-run-results__artifact">
-            <p-markdown-renderer v-if="result.description" :text="result.description" />
-          </ArtifactCard>
+        <template v-if="flowRunResults.length">
+          <template v-for="result in flowRunResults" :key="result.id">
+            <ArtifactCard :artifact="result" :condense="condense" class="flow-run-results__artifact">
+              <p-markdown-renderer v-if="result.description" :text="result.description" />
+            </ArtifactCard>
+          </template>
+        </template>
+        <template v-else>
+          <div class="flow-run-results__none">
+            {{ localization.info.noResults }}
+          </div>
         </template>
       </div>
 
@@ -23,10 +30,17 @@
         {{ localization.info.taskRunResults }}
       </p-heading>
       <div class="flow-run-results__list" :class="classes.list">
-        <template v-for="result in taskRunResults" :key="result.id">
-          <ArtifactCard :artifact="result" :condense="condense" class="flow-run-results__artifact">
-            <p-markdown-renderer v-if="result.description" :text="result.description" />
-          </ArtifactCard>
+        <template v-if="taskRunResults.length">
+          <template v-for="result in taskRunResults" :key="result.id">
+            <ArtifactCard :artifact="result" :condense="condense" class="flow-run-results__artifact">
+              <p-markdown-renderer v-if="result.description" :text="result.description" />
+            </ArtifactCard>
+          </template>
+        </template>
+        <template v-else>
+          <div class="flow-run-results__none">
+            {{ localization.info.noResults }}
+          </div>
         </template>
       </div>
     </template>
@@ -124,6 +138,10 @@
 }
 
 .flow-run-results__subheading { @apply
+  text-foreground-50
+}
+
+.flow-run-results__none { @apply
   text-foreground-50
 }
 </style>

--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -65,7 +65,7 @@
   import { localization } from '@/localization'
   import { FlowRun } from '@/models'
   import { ArtifactsFilter } from '@/models/Filters'
-  import { activeViewMode } from '@/utilities/artifactsViewMode'
+  import { useActiveViewMode } from '@/utilities/artifactsViewMode'
 
   const props = defineProps<{
     flowRun: FlowRun,
@@ -75,6 +75,8 @@
     { label: '', value: 'grid', icon: 'ViewGridIcon' },
     { label: '', value: 'rows', icon: 'ViewListIcon' },
   ]
+
+  const { activeViewMode } = useActiveViewMode()
   const condense = computed(() => activeViewMode.value === 'rows')
 
   const api = useWorkspaceApi()

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -88,6 +88,8 @@ export const en = {
   info: {
     artifact: 'Artifact',
     noResults: 'No tracked results',
+    flowRunResults: 'Flow run',
+    taskRunResults: 'Task runs',
     created: 'Created',
     lastUpdated: 'Last Updated',
     deprecatedWorkQueue: 'This work queue uses a deprecated tag-based approach to matching flow runs; it will continue to work but you can\'t modify it',

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -88,8 +88,8 @@ export const en = {
   info: {
     artifact: 'Artifact',
     noResults: 'No tracked results',
-    flowRunResults: 'Flow run',
-    taskRunResults: 'Task runs',
+    flowRun: 'Flow run',
+    taskRuns: 'Task runs',
     created: 'Created',
     lastUpdated: 'Last Updated',
     deprecatedWorkQueue: 'This work queue uses a deprecated tag-based approach to matching flow runs; it will continue to work but you can\'t modify it',

--- a/src/types/flowRunResults.ts
+++ b/src/types/flowRunResults.ts
@@ -1,0 +1,1 @@
+export type ViewOption = 'grid' | 'rows'

--- a/src/utilities/artifactsViewMode.ts
+++ b/src/utilities/artifactsViewMode.ts
@@ -1,10 +1,10 @@
 import { useLocalStorage } from '@prefecthq/vue-compositions'
 import { computed, WritableComputedRef } from 'vue'
 import { ViewOption } from '@/types/flowRunResults'
+import { getCacheKey } from '@/utilities/cache'
 
-const viewModeLocalStorageKey = 'prefect-ui-library-artifacts-view-mode'
+const viewModeLocalStorageKey = getCacheKey('prefect-ui-library-artifacts-view-mode')
 const defaultValue: ViewOption = 'grid'
-
 
 export function useActiveViewMode(): { activeViewMode: WritableComputedRef<ViewOption> } {
   const { value: viewMode, set: setViewMode } = useLocalStorage<ViewOption>(viewModeLocalStorageKey, defaultValue)

--- a/src/utilities/artifactsViewMode.ts
+++ b/src/utilities/artifactsViewMode.ts
@@ -6,15 +6,15 @@ const viewModeLocalStorageKey = 'prefect-ui-library-artifacts-view-mode'
 const defaultValue: ViewOption = 'grid'
 
 
-export function useActiveViewMode(): { activeViewMode: WritableComputedRef<ViewOption | null> } {
-  const { value: viewMode, set: setViewMode } = useLocalStorage<ViewOption | null>(viewModeLocalStorageKey, defaultValue)
+export function useActiveViewMode(): { activeViewMode: WritableComputedRef<ViewOption> } {
+  const { value: viewMode, set: setViewMode } = useLocalStorage<ViewOption>(viewModeLocalStorageKey, defaultValue)
   console.log(viewModeLocalStorageKey, viewMode.value, localStorage.getItem(viewModeLocalStorageKey))
   const activeViewMode = computed({
     get() {
       console.log(viewMode.value)
       return viewMode.value
     },
-    set(value: ViewOption | null) {
+    set(value: ViewOption) {
       console.log('before', viewMode.value)
       setViewMode(value)
       console.log('after', viewMode.value)

--- a/src/utilities/artifactsViewMode.ts
+++ b/src/utilities/artifactsViewMode.ts
@@ -1,20 +1,28 @@
 import { useLocalStorage } from '@prefecthq/vue-compositions'
-import { computed } from 'vue'
+import { computed, WritableComputedRef } from 'vue'
 import { ViewOption } from '@/types/flowRunResults'
 
 const viewModeLocalStorageKey = 'prefect-ui-library-artifacts-view-mode'
 const defaultValue: ViewOption = 'grid'
 
-const { value: viewMode, set: setViewMode } = useLocalStorage<ViewOption | null>(viewModeLocalStorageKey, defaultValue)
 
-export const activeViewMode = computed({
-  get() {
-    console.log(viewMode.value)
-    return viewMode.value
-  },
-  set(value: ViewOption | null) {
-    console.log('before', viewMode.value)
-    setViewMode(value)
-    console.log('after', viewMode.value)
-  },
-})
+export function useActiveViewMode(): { activeViewMode: WritableComputedRef<ViewOption | null> } {
+  const { value: viewMode, set: setViewMode } = useLocalStorage<ViewOption | null>(viewModeLocalStorageKey, defaultValue)
+
+  const activeViewMode = computed({
+    get() {
+      console.log(viewMode.value)
+      return viewMode.value
+    },
+    set(value: ViewOption | null) {
+      console.log('before', viewMode.value)
+      setViewMode(value)
+      console.log('after', viewMode.value)
+    },
+  })
+
+
+  return {
+    activeViewMode,
+  }
+}

--- a/src/utilities/artifactsViewMode.ts
+++ b/src/utilities/artifactsViewMode.ts
@@ -8,7 +8,7 @@ const defaultValue: ViewOption = 'grid'
 
 export function useActiveViewMode(): { activeViewMode: WritableComputedRef<ViewOption | null> } {
   const { value: viewMode, set: setViewMode } = useLocalStorage<ViewOption | null>(viewModeLocalStorageKey, defaultValue)
-
+  console.log(viewModeLocalStorageKey, viewMode.value, localStorage.getItem(viewModeLocalStorageKey))
   const activeViewMode = computed({
     get() {
       console.log(viewMode.value)

--- a/src/utilities/artifactsViewMode.ts
+++ b/src/utilities/artifactsViewMode.ts
@@ -1,0 +1,17 @@
+import { useLocalStorage } from '@prefecthq/vue-compositions'
+import { computed } from 'vue'
+import { ViewOption } from '@/types/flowRunResults'
+
+const viewModeLocalStorageKey = 'prefect-ui-library-artifacts-view-mode'
+const defaultValue: ViewOption = 'grid'
+
+const { value: viewMode, set: setViewMode } = useLocalStorage<ViewOption | null>(viewModeLocalStorageKey, defaultValue)
+
+export const activeViewMode = computed({
+  get() {
+    return viewMode.value
+  },
+  set(value: ViewOption | null) {
+    setViewMode(value)
+  },
+})

--- a/src/utilities/artifactsViewMode.ts
+++ b/src/utilities/artifactsViewMode.ts
@@ -7,8 +7,8 @@ const defaultValue: ViewOption = 'grid'
 
 
 export function useActiveViewMode(): { activeViewMode: WritableComputedRef<ViewOption> } {
-  const { value: viewMode, set: setViewMode } = useLocalStorage<ViewOption>(viewModeLocalStorageKey, defaultValue)
-  console.log(viewModeLocalStorageKey, viewMode.value, localStorage.getItem(viewModeLocalStorageKey))
+  const { value: viewMode, set: setViewMode, initialValue } = useLocalStorage<ViewOption>(viewModeLocalStorageKey, defaultValue)
+  console.log(viewModeLocalStorageKey, viewMode.value, localStorage.getItem(viewModeLocalStorageKey), initialValue)
   const activeViewMode = computed({
     get() {
       console.log(viewMode.value)

--- a/src/utilities/artifactsViewMode.ts
+++ b/src/utilities/artifactsViewMode.ts
@@ -7,20 +7,16 @@ const defaultValue: ViewOption = 'grid'
 
 
 export function useActiveViewMode(): { activeViewMode: WritableComputedRef<ViewOption> } {
-  const { value: viewMode, set: setViewMode, initialValue } = useLocalStorage<ViewOption>(viewModeLocalStorageKey, defaultValue)
-  console.log(viewModeLocalStorageKey, viewMode.value, localStorage.getItem(viewModeLocalStorageKey), initialValue)
+  const { value: viewMode, set: setViewMode } = useLocalStorage<ViewOption>(viewModeLocalStorageKey, defaultValue)
+
   const activeViewMode = computed({
     get() {
-      console.log(viewMode.value)
       return viewMode.value
     },
     set(value: ViewOption) {
-      console.log('before', viewMode.value)
       setViewMode(value)
-      console.log('after', viewMode.value)
     },
   })
-
 
   return {
     activeViewMode,

--- a/src/utilities/artifactsViewMode.ts
+++ b/src/utilities/artifactsViewMode.ts
@@ -9,9 +9,12 @@ const { value: viewMode, set: setViewMode } = useLocalStorage<ViewOption | null>
 
 export const activeViewMode = computed({
   get() {
+    console.log(viewMode.value)
     return viewMode.value
   },
   set(value: ViewOption | null) {
+    console.log('before', viewMode.value)
     setViewMode(value)
+    console.log('after', viewMode.value)
   },
 })


### PR DESCRIPTION
This PR:

- improves mock flow run and task run results artifact description generation (they now more closely resemble action descriptions)
- breaks flow run and task run results into their own lists
- improves some `ArtifactCard` designs
- adds result descriptions to the default slot of `ArtifactCard`s 
- adds an interval to the artifact subscription so results update in real time
- persists a user's list vs grid preference (just using local storage right now but that seemed light enough)
- adds some new demo sections

![Screen Shot 2023-03-15 at 9 53 59 PM](https://user-images.githubusercontent.com/27291717/225489540-39da151f-48ef-4784-9ec3-1fff7d752cd0.png)

![Screen Shot 2023-03-15 at 9 54 08 PM](https://user-images.githubusercontent.com/27291717/225489538-22770d28-047d-4779-831f-7408a17d585f.png)

