### PR TITLE
Bugfix: Safari flow run results card height

### DIFF
--- a/src/components/FlowRunResults.vue
+++ b/src/components/FlowRunResults.vue
@@ -140,7 +140,6 @@
 .flow-run-results__artifact { @apply
   hover:border-primary
   focus:border-primary
-  h-full
 }
 
 .flow-run-results__none { @apply


### PR DESCRIPTION
Fixes an issue in safari where cards without siblings would expand their height incorrectly if they had a child description

Before:
<img width="1440" alt="Screenshot 2023-03-16 at 5 18 56 PM" src="https://user-images.githubusercontent.com/27291717/225755073-e2b52a67-3c3e-4005-b02c-9ea5f2e9219d.png">



After:
<img width="1440" alt="Screenshot 2023-03-16 at 5 18 46 PM" src="https://user-images.githubusercontent.com/27291717/225755086-048ca74a-b982-4c5b-bcc2-861a74247a20.png">


