### PR TITLE
BugFix: Nested blocks not using the block document input

### DIFF
--- a/src/components/SchemaFormProperty.vue
+++ b/src/components/SchemaFormProperty.vue
@@ -18,6 +18,10 @@
   }>()
 
   const is = computed(() => {
+    if (props.property.type === 'block') {
+      return SchemaFormInput
+    }
+
     if (schemaHas(props.property, 'properties')) {
       return SchemaFormProperties
     }


### PR DESCRIPTION
# Description
This [PR](https://github.com/PrefectHQ/prefect-ui-library/pull/1222) introduced a bug where block references were being rendered as form inputs rather than a block document input. Fixing that by adding a check specifically for block properties. 

Closes [1229](https://github.com/PrefectHQ/prefect-ui-library/issues/1229)

Before
![image](https://user-images.githubusercontent.com/6200442/225992112-254d00fe-3fc6-46f8-b5d7-024b45edf323.png)

After
![image](https://user-images.githubusercontent.com/6200442/225991986-824f48b0-c881-4e27-bc9a-23334df33c6b.png)
