### PR TITLE
BugFix: Timezone `dateFunctions` proxy incorrectly returning functions for simple values

### DIFF
--- a/src/utilities/timezone.ts
+++ b/src/utilities/timezone.ts
@@ -82,7 +82,11 @@ export function secondsFromEpoch(date?: Date | string): number {
 
 export const dateFunctions = new Proxy({ ...dateFns }, {
   get(target, prop, receiver) {
-    const method = Reflect.get(target, prop, receiver)
+    const property = Reflect.get(target, prop, receiver)
+
+    if (typeof property !== 'function') {
+      return property
+    }
 
     return (...args: unknown[]) => {
       const anyDateArgsUnapplied = args.map(arg => {
@@ -93,7 +97,7 @@ export const dateFunctions = new Proxy({ ...dateFns }, {
         return arg
       })
 
-      const value = method.apply(this, anyDateArgsUnapplied)
+      const value = property.apply(this, anyDateArgsUnapplied)
 
       if (!isDate(value)) {
         return value


### PR DESCRIPTION
# Description
The date-fns proxy that handles timezone conversions was incorrectly returning a function for every property it proxied. This meant that consts like `secondsInHour` were returning a function even though the types would say it was a number.