### PR TITLE
Chore: Make the empty message for a FlowRunFilteredList generic

### DIFF
--- a/src/components/FlowRunFilteredList.vue
+++ b/src/components/FlowRunFilteredList.vue
@@ -15,7 +15,7 @@
     <PEmptyResults v-if="empty">
       <template #message>
         <slot name="empty-message">
-          No runs from the last 7 days
+          No runs found
         </slot>
       </template>
       <template v-if="hasFilters" #actions>


### PR DESCRIPTION
# Description
Make the empty message generic so other projects can determine any more specific messaging or logic