### PR TITLE
Feature: `ArtifactCollectionTimeline` and `ArtifactCollectionTimelineItem` components

### DIFF
--- a/demo/sections/artifacts/ArtifactTimeline.vue
+++ b/demo/sections/artifacts/ArtifactTimeline.vue
@@ -1,6 +1,8 @@
 <template>
   <ComponentPage title="ArtifactTimeline">
-    <ArtifactTimeline :artifact-key="key" />
+    <template #description>
+      <ArtifactTimeline :artifact-key="key" />
+    </template>
   </ComponentPage>
 </template>
 
@@ -12,5 +14,5 @@
 
 
   const key = `${mocker.create('adjective')}-${mocker.create('noun')}`
-  useArtifactsMock(50, { key })
+  useArtifactsMock(100, { key })
 </script>

--- a/demo/sections/artifacts/ArtifactTimeline.vue
+++ b/demo/sections/artifacts/ArtifactTimeline.vue
@@ -1,0 +1,16 @@
+<template>
+  <ComponentPage title="ArtifactTimeline">
+    <ArtifactTimeline :artifact-key="key" />
+  </ComponentPage>
+</template>
+
+<script lang="ts" setup>
+  import ArtifactTimeline from '@/components/ArtifactTimeline.vue'
+  import ComponentPage from '@/demo/components/ComponentPage.vue'
+  import { useArtifactsMock } from '@/demo/compositions/useArtifactsMock'
+  import { mocker } from '@/services'
+
+
+  const key = `${mocker.create('adjective')}-${mocker.create('noun')}`
+  useArtifactsMock(50, { key })
+</script>

--- a/demo/sections/artifacts/index.ts
+++ b/demo/sections/artifacts/index.ts
@@ -1,6 +1,7 @@
 import { Section } from '@/demo/router/routeRecords'
 
 export const artifacts: Section = {
-  ArtifactDescription: () => import('./ArtifactDescription.vue'),
   ArtifactCard: () => import('./ArtifactCard.vue'),
+  ArtifactDescription: () => import('./ArtifactDescription.vue'),
+  ArtifactTimeline: () => import('./ArtifactTimeline.vue'),
 }

--- a/demo/services/KeyedDataStore.ts
+++ b/demo/services/KeyedDataStore.ts
@@ -11,7 +11,7 @@ export class DataStoreDataNotFound extends Error {
 // https://stackoverflow.com/questions/73732549/narrow-number-argument-of-function-to-be-literal-type?noredirect=1#comment130199140_73732549
 // eslint-disable-next-line @typescript-eslint/ban-types
 type NoInfer<T> = T & {}
-type KeyedDataStoreFindCallback<T> = (value: T) => boolean
+export type KeyedDataStoreFindCallback<T> = (value: T) => boolean
 type KeyedDataStoreHydrateMethod<T> = (value: T) => T
 type KeyedDataStoreOptions<T extends { id: K }, K extends string | number | symbol = T['id']> = {
   seeds?: T | T[],

--- a/demo/services/mockWorkspaceArtifactsApi.ts
+++ b/demo/services/mockWorkspaceArtifactsApi.ts
@@ -34,8 +34,25 @@ export class MockWorkspaceArtifactsApi extends MockApi implements IWorkspaceArti
   }
 
   public async getArtifacts(filter: ArtifactsFilter = {}): Promise<Artifact[]> {
-    const { limit = 200, offset = 0 } = filter
+    const { limit = 200, offset = 0, sort = 'CREATED_DESC' } = filter
     let artifacts = await this.artifacts.findAll(artifactsItemIntersectsFilter(filter))
+
+    switch (sort) {
+      /* eslint-disable id-length */
+      case 'CREATED_DESC':
+        artifacts = artifacts.sort((a, b) => b.created.getTime() - a.created.getTime())
+        break
+      case 'KEY_ASC':
+        artifacts = artifacts.sort((a, b) => a.key?.localeCompare(b.key ?? '') ?? 0)
+        break
+      case 'KEY_DESC':
+        artifacts = artifacts.sort((a, b) => b.key?.localeCompare(a.key ?? '') ?? 0)
+        break
+      default:
+        break
+      /* eslint-enable id-length */
+    }
+
     artifacts = artifacts.slice(offset, offset + limit)
 
     return artifacts

--- a/demo/services/mockWorkspaceArtifactsApi.ts
+++ b/demo/services/mockWorkspaceArtifactsApi.ts
@@ -9,7 +9,9 @@ export class MockWorkspaceArtifactsApi extends MockApi implements IWorkspaceArti
   }
 
   public async getArtifacts(filter: ArtifactsFilter = {}): Promise<Artifact[]> {
+    const { limit = 200, offset = 0 } = filter
     let artifacts = await this.artifacts.getAll()
+    console.log(`Artifacts: ${artifacts.length}, limit: ${limit}, offset: ${offset}`)
 
     if (filter.artifacts?.flowRunId?.length) {
       artifacts = artifacts.filter(artifact => artifact.flowRunId && filter.artifacts?.flowRunId?.includes(artifact.flowRunId))
@@ -21,11 +23,15 @@ export class MockWorkspaceArtifactsApi extends MockApi implements IWorkspaceArti
 
     if (filter.artifacts?.key?.length) {
       artifacts = artifacts.filter(artifact => artifact.key && filter.artifacts?.key?.includes(artifact.key))
+      console.log(`Length after key filter: ${artifacts.length}`)
     }
 
     if (filter.artifacts?.type?.length) {
       artifacts = artifacts.filter(artifact => filter.artifacts?.type?.includes(artifact.type))
     }
+
+    artifacts = artifacts.slice(offset, offset + limit)
+    console.log(`Length after slice: ${artifacts.length}, offset + limit: ${offset + limit}`)
 
     return artifacts
   }

--- a/demo/services/mockWorkspaceArtifactsApi.ts
+++ b/demo/services/mockWorkspaceArtifactsApi.ts
@@ -15,6 +15,18 @@ export class MockWorkspaceArtifactsApi extends MockApi implements IWorkspaceArti
       artifacts = artifacts.filter(artifact => artifact.flowRunId && filter.artifacts?.flowRunId?.includes(artifact.flowRunId))
     }
 
+    if (filter.artifacts?.taskRunId?.length) {
+      artifacts = artifacts.filter(artifact => artifact.taskRunId && filter.artifacts?.taskRunId?.includes(artifact.taskRunId))
+    }
+
+    if (filter.artifacts?.key?.length) {
+      artifacts = artifacts.filter(artifact => artifact.key && filter.artifacts?.key?.includes(artifact.key))
+    }
+
+    if (filter.artifacts?.type?.length) {
+      artifacts = artifacts.filter(artifact => filter.artifacts?.type?.includes(artifact.type))
+    }
+
     return artifacts
   }
 

--- a/demo/services/mockWorkspaceArtifactsApi.ts
+++ b/demo/services/mockWorkspaceArtifactsApi.ts
@@ -36,7 +36,6 @@ export class MockWorkspaceArtifactsApi extends MockApi implements IWorkspaceArti
   public async getArtifacts(filter: ArtifactsFilter = {}): Promise<Artifact[]> {
     const { limit = 200, offset = 0 } = filter
     let artifacts = await this.artifacts.findAll(artifactsItemIntersectsFilter(filter))
-    console.log(`Artifacts: ${artifacts.length}, all: ${this.artifacts.count()}, limit: ${limit}, offset: ${offset}`)
     artifacts = artifacts.slice(offset, offset + limit)
 
     return artifacts

--- a/demo/utilities/data.ts
+++ b/demo/utilities/data.ts
@@ -22,7 +22,7 @@ function hydrateGraph({ id, graph }: FlowRunGraphMock): FlowRunGraphMock {
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createDataStores(seeds: ApiMockSeeds = {}) {
   return {
-    artifacts: new KeyedDataStore({ seeds: seeds.artifacts, hydrate: artifact => new Artifact(artifact) }),
+    artifacts: new KeyedDataStore({ seeds: seeds.artifacts, hydrate: artifact => new Artifact({ ...artifact, created: new Date(artifact.created), updated: new Date(artifact.updated) }) }),
     flows: new KeyedDataStore({ seeds: seeds.flows, hydrate: flow => new Flow(flow) }),
     flowRuns: new KeyedDataStore({ seeds: seeds.flowRuns, hydrate: flowRun => new FlowRun(flowRun) }),
     flowRunGraphs: new KeyedDataStore({ seeds: seeds.flowRunGraphs, hydrate: hydrateGraph }),

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -1,12 +1,18 @@
 <template>
-  <div class="artifact-timeline">
-    {{ artifacts }}
-  </div>
+  <p-virtual-scroller v-if="executed" :items="artifacts" :item-estimate-height="112" class="artifact-timeline" @bottom="fetchMore">
+    <template #default="{ item: artifact, index }">
+      <p-heading heading="3">
+        {{ index }} - {{ artifact.id }}
+      </p-heading>
+      <ArtifactTimelineItem v-bind="{ artifact }" />
+    </template>
+  </p-virtual-scroller>
 </template>
 
 <script lang="ts" setup>
   import { useSubscription } from '@prefecthq/vue-compositions'
-  import { computed } from 'vue'
+  import { computed, ref } from 'vue'
+  import ArtifactTimelineItem from '@/components/ArtifactTimelineItem.vue'
   import { useWorkspaceApi } from '@/compositions'
   import { ArtifactsFilter } from '@/models/Filters'
 
@@ -15,15 +21,29 @@
   }>()
 
   const api = useWorkspaceApi()
+  const artifactsFilterOffset = ref(0)
+  const artifactsFilterLimit = ref(10)
   const artifactsFilter = computed<ArtifactsFilter>(() => {
     return {
       artifacts: {
         key: [props.artifactKey],
       },
+      sort: 'CREATED_DESC',
+      offset: artifactsFilterOffset.value,
+      limit: artifactsFilterLimit.value,
     }
   })
   const artifactsSubscription = useSubscription(api.artifacts.getArtifacts, [artifactsFilter])
-  const artifacts = computed(() => artifactsSubscription.response ?? [])
+  const artifacts = computed(() => {
+    console.log(JSON.parse(JSON.stringify(artifactsSubscription.response ?? [])))
+    return artifactsSubscription.response ?? []
+  })
+  const executed = computed(() => artifactsSubscription.executed)
+
+  const fetchMore = (): void => {
+    console.log('fetchMore')
+    artifactsFilterOffset.value += artifactsFilterLimit.value
+  }
 </script>
 
 <style>

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -7,7 +7,12 @@
       @bottom="fetchMore"
     >
       <template #default="{ item: artifact }">
-        <ArtifactTimelineItem v-bind="{ artifact }" class="artifact-timeline__artifact-timeline-item" />
+        <ArtifactTimelineItem
+          v-bind="{ artifact }"
+          v-model:expanded="expanded"
+          :value="artifact.id"
+          class="artifact-timeline__artifact-timeline-item"
+        />
       </template>
     </p-virtual-scroller>
   </div>
@@ -69,6 +74,8 @@
   onBeforeMount(() => {
     getArtifacts()
   })
+
+  const expanded = ref<string[]>([])
 </script>
 
 <style>

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -1,12 +1,24 @@
 <template>
-  <p-virtual-scroller v-if="executed" :items="artifacts" :item-estimate-height="112" class="artifact-timeline" @bottom="fetchMore">
-    <template #default="{ item: artifact, index }">
-      <p-heading heading="3">
-        {{ index }} - {{ artifact.id }}
-      </p-heading>
-      <ArtifactTimelineItem v-bind="{ artifact }" />
-    </template>
-  </p-virtual-scroller>
+  <div>
+    <div>
+      {{ artifactsCount }}
+    </div>
+    <p-virtual-scroller
+      v-if="executed"
+      :items="artifacts"
+      :item-estimate-height="112"
+      class="artifact-timeline"
+      @top="fetchFewer"
+      @bottom="fetchMore"
+    >
+      <template #default="{ item: artifact, index }">
+        <p-heading heading="3">
+          {{ index }} - {{ artifact.id }}
+        </p-heading>
+        <ArtifactTimelineItem v-bind="{ artifact }" />
+      </template>
+    </p-virtual-scroller>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -34,6 +46,9 @@
     }
   })
   const artifactsSubscription = useSubscription(api.artifacts.getArtifacts, [artifactsFilter])
+  const artifactsCountSubscription = useSubscription(api.artifacts.getArtifactsCount, [artifactsFilter])
+
+  const artifactsCount = computed(() => artifactsCountSubscription.response ?? 0)
   const artifacts = computed(() => {
     console.log(JSON.parse(JSON.stringify(artifactsSubscription.response ?? [])))
     return artifactsSubscription.response ?? []
@@ -43,6 +58,19 @@
   const fetchMore = (): void => {
     console.log('fetchMore')
     artifactsFilterOffset.value += artifactsFilterLimit.value
+
+    if (artifactsFilterOffset.value > artifactsCount.value) {
+      artifactsFilterOffset.value = artifacts.value.length
+    }
+  }
+
+  const fetchFewer = (): void => {
+    console.log('fetchFewer')
+    artifactsFilterOffset.value -= artifactsFilterLimit.value
+
+    if (artifactsFilterOffset.value < 0) {
+      artifactsFilterOffset.value = 0
+    }
   }
 </script>
 

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="artifact-timeline">
+    {{ artifactKey }}
+  </div>
+</template>
+
+<script lang="ts" setup>
+  const props = defineProps<{
+    artifactKey: string,
+  }>()
+</script>
+
+<style>
+
+</style>

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -93,5 +93,6 @@
 .artifact-timeline__artifact-timeline-item { @apply
   max-w-full
   w-full
+  my-4
 }
 </style>

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -93,6 +93,6 @@
 .artifact-timeline__artifact-timeline-item { @apply
   max-w-full
   w-full
-  my-4
+  my-6
 }
 </style>

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -86,7 +86,7 @@
 }
 
 .artifact-timeline__virtual-scroller { @apply
-  -ml-4
+  -ml-5
   max-w-full
 }
 

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -1,8 +1,10 @@
 <template>
   <div>
-    <div>
-      {{ artifactsCount }}
-    </div>
+    <ResultsCount
+      :count="artifactsCount"
+      :label="localization.info.artifact"
+    />
+
     <p-virtual-scroller
       :items="artifacts"
       :item-estimate-height="112"
@@ -23,7 +25,9 @@
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed, ref, watch, onBeforeMount } from 'vue'
   import ArtifactTimelineItem from '@/components/ArtifactTimelineItem.vue'
+  import ResultsCount from '@/components/ResultsCount.vue'
   import { useWorkspaceApi } from '@/compositions'
+  import { localization } from '@/localization'
   import { Artifact } from '@/models'
   import { ArtifactsFilter } from '@/models/Filters'
 

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -1,21 +1,13 @@
 <template>
-  <div>
-    <ResultsCount
-      :count="artifactsCount"
-      :label="localization.info.artifact"
-    />
-
+  <div class="artifact-timeline">
     <p-virtual-scroller
       :items="artifacts"
       :item-estimate-height="112"
-      class="artifact-timeline"
+      class="artifact-timeline__virtual-scroller"
       @bottom="fetchMore"
     >
-      <template #default="{ item: artifact, index }">
-        <p-heading heading="3">
-          {{ index }} - {{ artifact.id }}
-        </p-heading>
-        <ArtifactTimelineItem v-bind="{ artifact }" />
+      <template #default="{ item: artifact }">
+        <ArtifactTimelineItem v-bind="{ artifact }" class="artifact-timeline__artifact-timeline-item" />
       </template>
     </p-virtual-scroller>
   </div>
@@ -25,9 +17,7 @@
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed, ref, watch, onBeforeMount } from 'vue'
   import ArtifactTimelineItem from '@/components/ArtifactTimelineItem.vue'
-  import ResultsCount from '@/components/ResultsCount.vue'
   import { useWorkspaceApi } from '@/compositions'
-  import { localization } from '@/localization'
   import { Artifact } from '@/models'
   import { ArtifactsFilter } from '@/models/Filters'
 
@@ -82,5 +72,19 @@
 </script>
 
 <style>
+.artifact-timeline { @apply
+  border-l
+  border-foreground-100
+  pr-4
+}
 
+.artifact-timeline__virtual-scroller { @apply
+  -ml-4
+  max-w-full
+}
+
+.artifact-timeline__artifact-timeline-item { @apply
+  max-w-full
+  w-full
+}
 </style>

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -1,13 +1,29 @@
 <template>
   <div class="artifact-timeline">
-    {{ artifactKey }}
+    {{ artifacts }}
   </div>
 </template>
 
 <script lang="ts" setup>
+  import { useSubscription } from '@prefecthq/vue-compositions'
+  import { computed } from 'vue'
+  import { useWorkspaceApi } from '@/compositions'
+  import { ArtifactsFilter } from '@/models/Filters'
+
   const props = defineProps<{
     artifactKey: string,
   }>()
+
+  const api = useWorkspaceApi()
+  const artifactsFilter = computed<ArtifactsFilter>(() => {
+    return {
+      artifacts: {
+        key: [props.artifactKey],
+      },
+    }
+  })
+  const artifactsSubscription = useSubscription(api.artifacts.getArtifacts, [artifactsFilter])
+  const artifacts = computed(() => artifactsSubscription.response ?? [])
 </script>
 
 <style>

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="artifact-timeline-item" :class="classes.root">
-    <div class="artifact-timeline-item__icon-container">
-      <div class="artifact-timeline-item__icon" :class="classes.icon" />
+    <div class="artifact-timeline-item__point-container">
+      <div class="artifact-timeline-item__point" :class="classes.point" />
     </div>
 
     <p-card
@@ -11,15 +11,35 @@
       @keyup.self.enter="toggleExpanded"
     >
       <p-heading :class="classes.cardHeading" class="artifact-timeline-item__card-heading" heading="6" @click="toggleExpanded">
-        <span class="artifact-timeline-item__created" :title="formatDateTimeNumeric(artifact.created)">
-          {{ formatDate(artifact.created) }}
-        </span>
+        <div>
+          <div class="artifact-timeline-item__created" :title="formatDateTimeNumeric(artifact.created)">
+            {{ formatDate(artifact.created) }}
+          </div>
+          <div class="artifact-timeline-item__icon-texts-container">
+            <template v-if="artifact.flowRunId">
+              <div class="artifact-timeline-item__icon-text-container">
+                {{ localization.info.flowRun }}
+                <FlowRunIconText class="artifact-timeline-item__icon-text" :flow-run-id="artifact.flowRunId" />
+              </div>
+            </template>
+
+            <template v-if="artifact.taskRunId">
+              <div class="artifact-timeline-item__icon-text-container">
+                {{ localization.info.taskRun }}
+                <TaskRunIconText class="artifact-timeline-item__icon-text" :task-run-id="artifact.taskRunId" />
+              </div>
+            </template>
+          </div>
+        </div>
+
         <p-link :to="routes.artifact(artifact.id)" :title="artifact.id" @click.stop>
           {{ shortId }}
         </p-link>
       </p-heading>
 
       <template v-if="expanded">
+        <p-divider />
+
         <section class="artifact-timeline-item__card-body">
           <template v-if="artifact.description">
             <p-markdown-renderer :text="artifact.description" />
@@ -38,7 +58,10 @@
   import { isArray } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import ArtifactDataView from '@/components/ArtifactDataView.vue'
+  import FlowRunIconText from '@/components/FlowRunIconText.vue'
+  import TaskRunIconText from '@/components/TaskRunIconText.vue'
   import { useWorkspaceRoutes } from '@/compositions'
+  import { localization } from '@/localization'
   import { Artifact } from '@/models'
   import { formatDate, formatDateTimeNumeric, isNullish } from '@/utilities'
 
@@ -107,8 +130,8 @@
     cardHeading: {
       'artifact-timeline-item__card-heading--expanded': expanded.value,
     },
-    icon: {
-      'artifact-timeline-item__icon--expanded': expanded.value,
+    point: {
+      'artifact-timeline-item__point--expanded': expanded.value,
     },
   }))
 </script>
@@ -126,7 +149,7 @@
   mt-6
 }
 
-.artifact-timeline-item__icon-container { @apply
+.artifact-timeline-item__point-container { @apply
   flex
   h-6
   items-center
@@ -137,7 +160,7 @@
   w-10
 }
 
-.artifact-timeline-item__icon { @apply
+.artifact-timeline-item__point { @apply
   bg-foreground-200
   border
   border-background
@@ -150,12 +173,26 @@
   transform-origin: center;
 }
 
-.artifact-timeline-item__icon--expanded {
+.artifact-timeline-item__icon-texts-container { @apply
+  mt-1
+  gap-1
+  flex
+  flex-col
+}
+
+.artifact-timeline-item__icon-text-container { @apply
+  flex
+  gap-1
+  text-xs
+  font-normal
+}
+
+.artifact-timeline-item__point--expanded {
   transform: scale(1.5);
 }
 
-.artifact-timeline-item:hover .artifact-timeline-item__icon:not(.artifact-timeline-item__icon--expanded) {
-  transform: scale(1.3);
+.artifact-timeline-item:hover .artifact-timeline-item__point:not(.artifact-timeline-item__point--expanded) {
+  transform: scale(1.5);
 }
 
 .artifact-timeline-item__card { @apply
@@ -195,7 +232,7 @@
 }
 
 .artifact-timeline-item__created { @apply
-  text-foreground-300
+  text-foreground-400
   text-sm
 }
 </style>

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -10,12 +10,12 @@
       tabindex="0"
       @keyup.self.enter="toggleExpanded"
     >
-      <p-heading :class="classes.cardHeading" class="artifact-timeline-item__card-heading" heading="6" @click.self="toggleExpanded">
-        <span>
-          {{ formatDateTimeRelative(artifact.created) }}
+      <p-heading :class="classes.cardHeading" class="artifact-timeline-item__card-heading" heading="6" @click="toggleExpanded">
+        <span class="artifact-timeline-item__created" :title="formatDateTimeNumeric(artifact.created)">
+          {{ formatDate(artifact.created) }}
         </span>
-        <p-link :to="routes.artifact(artifact.id)">
-          {{ id }}
+        <p-link :to="routes.artifact(artifact.id)" :title="artifact.id" @click.stop>
+          {{ shortId }}
         </p-link>
       </p-heading>
 
@@ -40,7 +40,7 @@
   import ArtifactDataView from '@/components/ArtifactDataView.vue'
   import { useWorkspaceRoutes } from '@/compositions'
   import { Artifact } from '@/models'
-  import { formatDateTimeRelative, isNullish } from '@/utilities'
+  import { formatDate, formatDateTimeNumeric, isNullish } from '@/utilities'
 
   type Expanded = boolean | unknown[] | undefined
 
@@ -95,7 +95,7 @@
     expandedModel.value = !expandedModel.value
   }
 
-  const id = computed(() => expanded.value ? props.artifact.id : props.artifact.id.slice(0, 8))
+  const shortId = computed(() => props.artifact.id.slice(0, 8))
 
   const classes = computed(() => ({
     root: {
@@ -116,6 +116,8 @@
 <style>
 .artifact-timeline-item { @apply
   flex
+  items-start
+  justify-start
   h-auto
   transition-all
 }
@@ -129,6 +131,8 @@
   h-6
   items-center
   justify-center
+  grow-0
+  shrink-0
   relative
   w-10
 }
@@ -159,6 +163,7 @@
   focus:outline-none
   max-w-full
   p-0
+  shrink
   transition-all
   w-full
 }
@@ -172,6 +177,7 @@
   flex
   justify-between
   transition-all
+  text-sm
 }
 
 .artifact-timeline-item__card-heading--expanded { @apply
@@ -186,5 +192,10 @@
   bg-transparent
   border-none
   shadow-none
+}
+
+.artifact-timeline-item__created { @apply
+  text-foreground-300
+  text-sm
 }
 </style>

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -1,22 +1,31 @@
 <template>
   <div class="artifact-timeline-item" :class="classes.root">
     <div class="artifact-timeline-item__icon-container">
-      <div class="artifact-timeline-item__icon" />
+      <div class="artifact-timeline-item__icon" :class="classes.icon" />
     </div>
 
-    <p-card class="artifact-timeline-item__card" :class="classes.card">
-      <p-heading heading="6" @click="toggleExpanded">
-        {{ id }}
+    <p-card
+      class="artifact-timeline-item__card"
+      :class="classes.card"
+      tabindex="0"
+      @keyup.self.enter="toggleExpanded"
+    >
+      <p-heading :class="classes.cardHeading" class="artifact-timeline-item__card-heading" heading="6" @click.self="toggleExpanded">
+        <p-link :to="routes.artifact(artifact.id)">
+          {{ id }}
+        </p-link>
       </p-heading>
 
       <template v-if="expanded">
-        <template v-if="artifact.description">
-          <p-markdown-renderer :text="artifact.description" />
+        <section class="artifact-timeline-item__card-body">
+          <template v-if="artifact.description">
+            <p-markdown-renderer :text="artifact.description" />
 
-          <p-divider />
-        </template>
+            <p-divider />
+          </template>
 
-        <ArtifactDataView :artifact="artifact" />
+          <ArtifactDataView :artifact="artifact" />
+        </section>
       </template>
     </p-card>
   </div>
@@ -26,6 +35,7 @@
   import { isArray } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import ArtifactDataView from '@/components/ArtifactDataView.vue'
+  import { useWorkspaceRoutes } from '@/compositions'
   import { Artifact } from '@/models'
   import { isNullish } from '@/utilities'
 
@@ -36,6 +46,8 @@
     expanded?: Expanded | null,
     value?: unknown,
   }>()
+
+  const routes = useWorkspaceRoutes()
 
   const emit = defineEmits<{
     (event: 'update:expanded', value: Expanded): void,
@@ -89,13 +101,22 @@
     card: {
       'artifact-timeline-item__card--expanded': expanded.value,
     },
+    cardHeading: {
+      'artifact-timeline-item__card-heading--expanded': expanded.value,
+    },
+    icon: {
+      'artifact-timeline-item__icon--expanded': expanded.value,
+    },
   }))
 </script>
 
 <style>
 .artifact-timeline-item { @apply
   flex
-  pt-2
+}
+
+.artifact-timeline-item--expanded { @apply
+  mt-4
 }
 
 .artifact-timeline-item__icon-container { @apply
@@ -103,8 +124,6 @@
   h-full
   items-start
   justify-center
-  pt-1
-  px-2
 }
 
 .artifact-timeline-item__icon { @apply
@@ -115,20 +134,48 @@
   max-w-full
   overflow-auto
   rounded-full
+  transition-all
   w-4
 }
 
+.artifact-timeline-item__icon--expanded { @apply
+  h-5
+  w-5
+}
+
 .artifact-timeline-item__card { @apply
+  outline-none
   focus:outline-none
   max-w-full
+  p-0
   transition-all
   w-full
 }
 
+.artifact-timeline-item__card--expanded { @apply
+  -mt-4
+}
+
+.artifact-timeline-item__card-heading { @apply
+  cursor-pointer
+  flex
+  justify-between
+  transition-all
+}
+
+.artifact-timeline-item__card-heading--expanded { @apply
+  p-4
+}
+
+.artifact-timeline-item__card-body { @apply
+  p-4
+}
+
 .artifact-timeline-item__card:not(.artifact-timeline-item__card--expanded) { @apply
-  p-0
   bg-transparent
   border-none
   shadow-none
+  focus:bg-background-900
+  hover:bg-background-900
 }
 </style>

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -11,6 +11,9 @@
       @keyup.self.enter="toggleExpanded"
     >
       <p-heading :class="classes.cardHeading" class="artifact-timeline-item__card-heading" heading="6" @click.self="toggleExpanded">
+        <span>
+          {{ formatDateTimeRelative(artifact.created) }}
+        </span>
         <p-link :to="routes.artifact(artifact.id)">
           {{ id }}
         </p-link>
@@ -37,7 +40,7 @@
   import ArtifactDataView from '@/components/ArtifactDataView.vue'
   import { useWorkspaceRoutes } from '@/compositions'
   import { Artifact } from '@/models'
-  import { isNullish } from '@/utilities'
+  import { formatDateTimeRelative, isNullish } from '@/utilities'
 
   type Expanded = boolean | unknown[] | undefined
 
@@ -117,17 +120,17 @@
   transition-all
 }
 
-.artifact-timeline-item--expanded { @apply
-  mt-4
+.artifact-timeline-item.artifact-timeline-item--expanded { @apply
+  mt-6
 }
 
 .artifact-timeline-item__icon-container { @apply
   flex
-  h-8
+  h-6
   items-center
   justify-center
   relative
-  w-8
+  w-10
 }
 
 .artifact-timeline-item__icon { @apply
@@ -156,13 +159,12 @@
   focus:outline-none
   max-w-full
   p-0
-  pt-1
   transition-all
   w-full
 }
 
 .artifact-timeline-item__card--expanded { @apply
-  -mt-4
+  -mt-3
 }
 
 .artifact-timeline-item__card-heading { @apply

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -113,6 +113,8 @@
 <style>
 .artifact-timeline-item { @apply
   flex
+  h-auto
+  transition-all
 }
 
 .artifact-timeline-item--expanded { @apply
@@ -121,9 +123,11 @@
 
 .artifact-timeline-item__icon-container { @apply
   flex
-  h-full
-  items-start
+  h-8
+  items-center
   justify-center
+  relative
+  w-8
 }
 
 .artifact-timeline-item__icon { @apply
@@ -132,15 +136,15 @@
   border-background
   h-4
   max-w-full
-  overflow-auto
   rounded-full
   transition-all
-  w-4
+  w-4;
+
+  transform-origin: center;
 }
 
-.artifact-timeline-item__icon--expanded { @apply
-  h-5
-  w-5
+.artifact-timeline-item__icon--expanded {
+  transform: scale(1.5);
 }
 
 .artifact-timeline-item__card { @apply

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -1,21 +1,85 @@
 <template>
   <div class="artifact-timeline-item">
-    {{ artifact.key }}
-    {{ artifact.description }}
+    <div class="artifact-timeline-item__icon-container">
+      <div class="artifact-timeline-item__icon" />
+    </div>
+
+    <p-card class="artifact-timeline__card" tabindex="0" @focus="handleFocusIn" @blur="handleFocusOut">
+      <p-heading heading="6">
+        {{ id }}
+      </p-heading>
+
+      <template v-if="focused">
+        <template v-if="artifact.description">
+          <p-markdown-renderer :text="artifact.description" />
+
+          <p-divider />
+        </template>
+
+        <ArtifactDataView :artifact="artifact" />
+      </template>
+    </p-card>
   </div>
 </template>
 
 <script lang="ts" setup>
+  import { computed, ref } from 'vue'
+  import ArtifactDataView from '@/components/ArtifactDataView.vue'
   import { Artifact } from '@/models'
 
   const props = defineProps<{
     artifact: Artifact,
   }>()
+
+  const focused = ref(false)
+
+  const id = computed(() => focused.value ? props.artifact.id : props.artifact.id.slice(0, 8))
+
+  const handleFocusIn = (): void => {
+    focused.value = true
+  }
+
+  const handleFocusOut = (): void => {
+    focused.value = false
+  }
 </script>
 
 <style>
 .artifact-timeline-item { @apply
-  max-h-28
-  overflow-hidden
+  flex
+  pt-2
+}
+
+.artifact-timeline-item__icon-container { @apply
+  flex
+  h-full
+  items-start
+  justify-center
+  pt-1
+  px-2
+}
+
+.artifact-timeline-item__icon { @apply
+  bg-foreground-200
+  border
+  border-background
+  h-4
+  max-w-full
+  overflow-auto
+  rounded-full
+  w-4
+}
+
+.artifact-timeline__card { @apply
+  max-w-full
+  transition-all
+  w-full
+}
+
+.artifact-timeline-item:not(:focus-within) .artifact-timeline__card { @apply
+  p-0
+  bg-transparent
+  border-none
+  shadow-none
 }
 </style>

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="artifact-timeline">
+    {{ artifactKey }}
+  </div>
+</template>
+
+<script lang="ts" setup>
+  const props = defineProps<{
+    artifactKey: string,
+  }>()
+</script>
+
+<style>
+
+</style>

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -149,6 +149,11 @@
   mt-6
 }
 
+/* Note that this won't be necessary once https://github.com/PrefectHQ/prefect-design/pull/698 is released */
+.artifact-timeline-item.artifact-timeline-item--expanded .p-divider { @apply
+  bg-foreground-50
+}
+
 .artifact-timeline-item__point-container { @apply
   flex
   h-6

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -1,15 +1,21 @@
 <template>
-  <div class="artifact-timeline">
-    {{ artifactKey }}
+  <div class="artifact-timeline-item">
+    {{ artifact.key }}
+    {{ artifact.description }}
   </div>
 </template>
 
 <script lang="ts" setup>
+  import { Artifact } from '@/models'
+
   const props = defineProps<{
-    artifactKey: string,
+    artifact: Artifact,
   }>()
 </script>
 
 <style>
-
+.artifact-timeline-item { @apply
+  max-h-28
+  overflow-hidden
+}
 </style>

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -147,6 +147,10 @@
   transform: scale(1.5);
 }
 
+.artifact-timeline-item:hover .artifact-timeline-item__icon:not(.artifact-timeline-item__icon--expanded) {
+  transform: scale(1.3);
+}
+
 .artifact-timeline-item__card { @apply
   outline-none
   focus:outline-none
@@ -179,7 +183,5 @@
   bg-transparent
   border-none
   shadow-none
-  focus:bg-background-900
-  hover:bg-background-900
 }
 </style>

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -162,8 +162,9 @@
 
 .artifact-timeline-item__point { @apply
   bg-foreground-200
-  border
-  border-background
+  border-2
+  border-background-600
+  dark:border-background-300
   h-4
   max-w-full
   rounded-full
@@ -187,10 +188,7 @@
   font-normal
 }
 
-.artifact-timeline-item__point--expanded {
-  transform: scale(1.5);
-}
-
+.artifact-timeline-item__point--expanded,
 .artifact-timeline-item:hover .artifact-timeline-item__point:not(.artifact-timeline-item__point--expanded) {
   transform: scale(1.5);
 }
@@ -217,10 +215,7 @@
   text-sm
 }
 
-.artifact-timeline-item__card-heading--expanded { @apply
-  p-4
-}
-
+.artifact-timeline-item__card-heading--expanded,
 .artifact-timeline-item__card-body { @apply
   p-4
 }

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -1,15 +1,15 @@
 <template>
-  <div class="artifact-timeline-item">
+  <div class="artifact-timeline-item" :class="classes.root">
     <div class="artifact-timeline-item__icon-container">
       <div class="artifact-timeline-item__icon" />
     </div>
 
-    <p-card class="artifact-timeline__card" tabindex="0" @focus="handleFocusIn" @blur="handleFocusOut">
-      <p-heading heading="6">
+    <p-card class="artifact-timeline-item__card" :class="classes.card" tabindex="0" @focus="handleFocusIn" @blur="handleFocusOut">
+      <p-heading heading="6" @click="toggleExpanded">
         {{ id }}
       </p-heading>
 
-      <template v-if="focused">
+      <template v-if="expanded">
         <template v-if="artifact.description">
           <p-markdown-renderer :text="artifact.description" />
 
@@ -31,17 +31,30 @@
     artifact: Artifact,
   }>()
 
-  const focused = ref(false)
+  const expanded = ref(false)
 
-  const id = computed(() => focused.value ? props.artifact.id : props.artifact.id.slice(0, 8))
+  const id = computed(() => expanded.value ? props.artifact.id : props.artifact.id.slice(0, 8))
 
   const handleFocusIn = (): void => {
-    focused.value = true
+    expanded.value = true
   }
 
   const handleFocusOut = (): void => {
-    focused.value = false
+    expanded.value = false
   }
+
+  const toggleExpanded = (): void => {
+    expanded.value = !expanded.value
+  }
+
+  const classes = computed(() => ({
+    root: {
+      'artifact-timeline-item--expanded': expanded.value,
+    },
+    card: {
+      'artifact-timeline-item__card--expanded': expanded.value,
+    },
+  }))
 </script>
 
 <style>
@@ -70,13 +83,14 @@
   w-4
 }
 
-.artifact-timeline__card { @apply
+.artifact-timeline-item__card { @apply
+  focus:outline-none
   max-w-full
   transition-all
   w-full
 }
 
-.artifact-timeline-item:not(:focus-within) .artifact-timeline__card { @apply
+.artifact-timeline-item__card:not(.artifact-timeline-item__card--expanded) { @apply
   p-0
   bg-transparent
   border-none

--- a/src/components/ArtifactTimelineItem.vue
+++ b/src/components/ArtifactTimelineItem.vue
@@ -156,6 +156,7 @@
   focus:outline-none
   max-w-full
   p-0
+  pt-1
   transition-all
   w-full
 }

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -90,6 +90,7 @@ export const en = {
     artifact: 'Artifact',
     noResults: 'No tracked results, enable [result persistence](https://docs.prefect.io/concepts/results/#persisting-results) to track results.',
     flowRun: 'Flow run',
+    taskRun: 'Task run',
     taskRuns: 'Task runs',
     created: 'Created',
     lastUpdated: 'Last Updated',

--- a/src/mocks/artifact.ts
+++ b/src/mocks/artifact.ts
@@ -25,7 +25,7 @@ export const randomArtifact: MockFunction<Artifact, [Partial<Artifact>?]> = func
   }
 
   return new Artifact({
-    id: this.create('string'),
+    id: this.create('id'),
     created: this.create('date'),
     updated: this.create('date'),
     key: choice([null, this.create('noun')]),

--- a/src/models/Filters.ts
+++ b/src/models/Filters.ts
@@ -70,6 +70,7 @@ export type ArtifactFilter = {
   id?: string[],
   key?: string[],
   keyLike?: string,
+  type?: string[],
   flowRunId?: string[],
   taskRunId?: string[],
 }


### PR DESCRIPTION
Introduces 2 WIP components we'll be using for showing lineage-type data for artifacts. The `ArtifactCollectionTimelineItem` I expect to change/evolve quite a bit in the next week so I've intentionally not spent much time cleaning it up. I also took a crack at filters for the artifacts mock api that should work nicely for gets and counts