### PR TITLE
Chore: Make vue-charts a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "dependencies": {
                 "@prefecthq/graphs": "1.0.2",
                 "@prefecthq/radar": "0.0.19",
-                "@prefecthq/vue-charts": "0.3.1",
                 "@types/lodash.isequal": "4.5.6",
                 "axios": "0.27.2",
                 "cronstrue": "^2.23.0",
@@ -42,6 +41,7 @@
             },
             "peerDependencies": {
                 "@prefecthq/prefect-design": "^1.4.0",
+                "@prefecthq/vue-charts": "^0.3.1",
                 "@prefecthq/vue-compositions": "^1.3.5",
                 "vee-validate": "^4.7.0",
                 "vue": "^3.2.45",
@@ -1069,6 +1069,7 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-0.3.1.tgz",
             "integrity": "sha512-yCj0ILeei2ZF4zMp/3Ejmn60IKfR/snnInYbLnYaXII7BByvfI26GOekAG7aoi1p5iQcqjZEGKSJm9WobZJHaw==",
+            "peer": true,
             "dependencies": {
                 "@prefecthq/vue-compositions": "1.4.0",
                 "d3": "7.8.2",
@@ -1084,6 +1085,7 @@
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.2.tgz",
             "integrity": "sha512-WXty7qOGSHb7HR7CfOzwN1Gw04MUOzN8qh9ZUsvwycIMb4DYMpY9xczZ6jUorGtO6bR9BPMPaueIKwiDxu9uiQ==",
+            "peer": true,
             "dependencies": {
                 "d3-array": "3",
                 "d3-axis": "3",
@@ -1124,6 +1126,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
             "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+            "peer": true,
             "dependencies": {
                 "d3-array": "^3.2.0"
             },
@@ -1135,6 +1138,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.4.0.tgz",
             "integrity": "sha512-ra3v8vr7fyzl+PtNt1SPljk570vXg5+OFEN4PzIGBPhxhD3Z7cBf3atk5ppkGd5zK9Aoz99FIUMW2fVOY15+eQ==",
+            "peer": true,
             "dependencies": {
                 "jsdom": "^21.0.0"
             },
@@ -1201,6 +1205,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1700,7 +1705,8 @@
         "node_modules/abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+            "peer": true
         },
         "node_modules/acorn": {
             "version": "8.8.2",
@@ -1717,6 +1723,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
             "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.1.0",
                 "acorn-walk": "^8.0.2"
@@ -1764,6 +1771,7 @@
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
             "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -1772,6 +1780,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "peer": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -2304,12 +2313,14 @@
         "node_modules/cssom": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-            "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
+            "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+            "peer": true
         },
         "node_modules/cssstyle": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
             "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+            "peer": true,
             "dependencies": {
                 "cssom": "~0.3.6"
             },
@@ -2320,7 +2331,8 @@
         "node_modules/cssstyle/node_modules/cssom": {
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+            "peer": true
         },
         "node_modules/csstype": {
             "version": "2.6.21",
@@ -2702,6 +2714,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
             "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+            "peer": true,
             "dependencies": {
                 "abab": "^2.0.6",
                 "whatwg-mimetype": "^3.0.0",
@@ -2756,7 +2769,8 @@
         "node_modules/decimal.js": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+            "peer": true
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -2892,6 +2906,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
             "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+            "peer": true,
             "dependencies": {
                 "webidl-conversions": "^7.0.0"
             },
@@ -3118,6 +3133,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
             "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+            "peer": true,
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -3139,6 +3155,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -3147,6 +3164,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
             "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
@@ -3159,6 +3177,7 @@
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
             "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "peer": true,
             "dependencies": {
                 "deep-is": "~0.1.3",
                 "fast-levenshtein": "~2.0.6",
@@ -3175,6 +3194,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
             "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -3183,6 +3203,7 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "~1.1.2"
             },
@@ -3536,6 +3557,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "peer": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -4116,6 +4138,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
             "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+            "peer": true,
             "dependencies": {
                 "whatwg-encoding": "^2.0.0"
             },
@@ -4127,6 +4150,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "peer": true,
             "dependencies": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -4140,6 +4164,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "peer": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -4403,7 +4428,8 @@
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "peer": true
         },
         "node_modules/is-regex": {
             "version": "1.1.4",
@@ -4538,6 +4564,7 @@
             "version": "21.1.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.0.tgz",
             "integrity": "sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==",
+            "peer": true,
             "dependencies": {
                 "abab": "^2.0.6",
                 "acorn": "^8.8.1",
@@ -4921,7 +4948,8 @@
         "node_modules/nwsapi": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-            "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
+            "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
+            "peer": true
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
@@ -5093,6 +5121,7 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
             "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+            "peer": true,
             "dependencies": {
                 "entities": "^4.4.0"
             },
@@ -5377,7 +5406,8 @@
         "node_modules/psl": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+            "peer": true
         },
         "node_modules/punycode": {
             "version": "2.3.0",
@@ -5399,7 +5429,8 @@
         "node_modules/querystringify": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "peer": true
         },
         "node_modules/queue-lit": {
             "version": "1.5.0",
@@ -5488,7 +5519,8 @@
         "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "peer": true
         },
         "node_modules/resolve": {
             "version": "1.22.1",
@@ -5610,6 +5642,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "peer": true,
             "dependencies": {
                 "xmlchars": "^2.2.0"
             },
@@ -5809,7 +5842,8 @@
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "peer": true
         },
         "node_modules/synckit": {
             "version": "0.8.4",
@@ -5919,6 +5953,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
             "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+            "peer": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -5933,6 +5968,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
             "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.1"
             },
@@ -6088,6 +6124,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
             "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -6140,6 +6177,7 @@
             "version": "1.5.10",
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "peer": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -6330,6 +6368,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
             "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+            "peer": true,
             "dependencies": {
                 "xml-name-validator": "^4.0.0"
             },
@@ -6341,6 +6380,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -6349,6 +6389,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
             "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+            "peer": true,
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -6360,6 +6401,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
             "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -6368,6 +6410,7 @@
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
             "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "peer": true,
             "dependencies": {
                 "tr46": "^3.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -6451,6 +6494,7 @@
             "version": "8.12.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
             "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -6478,7 +6522,8 @@
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "peer": true
         },
         "node_modules/xtend": {
             "version": "4.0.2",
@@ -7090,6 +7135,7 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-0.3.1.tgz",
             "integrity": "sha512-yCj0ILeei2ZF4zMp/3Ejmn60IKfR/snnInYbLnYaXII7BByvfI26GOekAG7aoi1p5iQcqjZEGKSJm9WobZJHaw==",
+            "peer": true,
             "requires": {
                 "@prefecthq/vue-compositions": "1.4.0",
                 "d3": "7.8.2",
@@ -7101,6 +7147,7 @@
                     "version": "7.8.2",
                     "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.2.tgz",
                     "integrity": "sha512-WXty7qOGSHb7HR7CfOzwN1Gw04MUOzN8qh9ZUsvwycIMb4DYMpY9xczZ6jUorGtO6bR9BPMPaueIKwiDxu9uiQ==",
+                    "peer": true,
                     "requires": {
                         "d3-array": "3",
                         "d3-axis": "3",
@@ -7138,6 +7185,7 @@
                     "version": "4.0.2",
                     "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
                     "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+                    "peer": true,
                     "requires": {
                         "d3-array": "^3.2.0"
                     }
@@ -7148,6 +7196,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.4.0.tgz",
             "integrity": "sha512-ra3v8vr7fyzl+PtNt1SPljk570vXg5+OFEN4PzIGBPhxhD3Z7cBf3atk5ppkGd5zK9Aoz99FIUMW2fVOY15+eQ==",
+            "peer": true,
             "requires": {
                 "jsdom": "^21.0.0"
             }
@@ -7190,7 +7239,8 @@
         "@tootallnate/once": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "peer": true
         },
         "@trysound/sax": {
             "version": "0.2.0",
@@ -7569,7 +7619,8 @@
         "abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+            "peer": true
         },
         "acorn": {
             "version": "8.8.2",
@@ -7580,6 +7631,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
             "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+            "peer": true,
             "requires": {
                 "acorn": "^8.1.0",
                 "acorn-walk": "^8.0.2"
@@ -7617,12 +7669,14 @@
         "acorn-walk": {
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "peer": true
         },
         "agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "peer": true,
             "requires": {
                 "debug": "4"
             }
@@ -7986,12 +8040,14 @@
         "cssom": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-            "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
+            "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+            "peer": true
         },
         "cssstyle": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
             "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+            "peer": true,
             "requires": {
                 "cssom": "~0.3.6"
             },
@@ -7999,7 +8055,8 @@
                 "cssom": {
                     "version": "0.3.8",
                     "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-                    "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+                    "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+                    "peer": true
                 }
             }
         },
@@ -8276,6 +8333,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
             "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+            "peer": true,
             "requires": {
                 "abab": "^2.0.6",
                 "whatwg-mimetype": "^3.0.0",
@@ -8310,7 +8368,8 @@
         "decimal.js": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+            "peer": true
         },
         "deep-is": {
             "version": "0.1.4",
@@ -8410,6 +8469,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
             "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+            "peer": true,
             "requires": {
                 "webidl-conversions": "^7.0.0"
             }
@@ -8584,6 +8644,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
             "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+            "peer": true,
             "requires": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -8595,12 +8656,14 @@
                 "estraverse": {
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+                    "peer": true
                 },
                 "levn": {
                     "version": "0.3.0",
                     "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
                     "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+                    "peer": true,
                     "requires": {
                         "prelude-ls": "~1.1.2",
                         "type-check": "~0.3.2"
@@ -8610,6 +8673,7 @@
                     "version": "0.8.3",
                     "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
                     "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+                    "peer": true,
                     "requires": {
                         "deep-is": "~0.1.3",
                         "fast-levenshtein": "~2.0.6",
@@ -8622,12 +8686,14 @@
                 "prelude-ls": {
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                    "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
+                    "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+                    "peer": true
                 },
                 "type-check": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                     "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+                    "peer": true,
                     "requires": {
                         "prelude-ls": "~1.1.2"
                     }
@@ -8901,7 +8967,8 @@
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "peer": true
         },
         "esquery": {
             "version": "1.4.2",
@@ -9316,6 +9383,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
             "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+            "peer": true,
             "requires": {
                 "whatwg-encoding": "^2.0.0"
             }
@@ -9324,6 +9392,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "peer": true,
             "requires": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -9334,6 +9403,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "peer": true,
             "requires": {
                 "agent-base": "6",
                 "debug": "4"
@@ -9510,7 +9580,8 @@
         "is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "peer": true
         },
         "is-regex": {
             "version": "1.1.4",
@@ -9605,6 +9676,7 @@
             "version": "21.1.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.0.tgz",
             "integrity": "sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==",
+            "peer": true,
             "requires": {
                 "abab": "^2.0.6",
                 "acorn": "^8.8.1",
@@ -9901,7 +9973,8 @@
         "nwsapi": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-            "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
+            "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
+            "peer": true
         },
         "object-assign": {
             "version": "4.1.1",
@@ -10019,6 +10092,7 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
             "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+            "peer": true,
             "requires": {
                 "entities": "^4.4.0"
             }
@@ -10203,7 +10277,8 @@
         "psl": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+            "peer": true
         },
         "punycode": {
             "version": "2.3.0",
@@ -10218,7 +10293,8 @@
         "querystringify": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "peer": true
         },
         "queue-lit": {
             "version": "1.5.0",
@@ -10272,7 +10348,8 @@
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "peer": true
         },
         "resolve": {
             "version": "1.22.1",
@@ -10351,6 +10428,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "peer": true,
             "requires": {
                 "xmlchars": "^2.2.0"
             }
@@ -10485,7 +10563,8 @@
         "symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "peer": true
         },
         "synckit": {
             "version": "0.8.4",
@@ -10572,6 +10651,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
             "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+            "peer": true,
             "requires": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -10583,6 +10663,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
             "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "peer": true,
             "requires": {
                 "punycode": "^2.1.1"
             }
@@ -10698,7 +10779,8 @@
         "universalify": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
+            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+            "peer": true
         },
         "update-browserslist-db": {
             "version": "1.0.10",
@@ -10739,6 +10821,7 @@
             "version": "1.5.10",
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "peer": true,
             "requires": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -10860,6 +10943,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
             "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+            "peer": true,
             "requires": {
                 "xml-name-validator": "^4.0.0"
             }
@@ -10867,12 +10951,14 @@
         "webidl-conversions": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "peer": true
         },
         "whatwg-encoding": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
             "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+            "peer": true,
             "requires": {
                 "iconv-lite": "0.6.3"
             }
@@ -10880,12 +10966,14 @@
         "whatwg-mimetype": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "peer": true
         },
         "whatwg-url": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
             "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "peer": true,
             "requires": {
                 "tr46": "^3.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -10948,6 +11036,7 @@
             "version": "8.12.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
             "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+            "peer": true,
             "requires": {}
         },
         "xml-name-validator": {
@@ -10958,7 +11047,8 @@
         "xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "peer": true
         },
         "xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     },
     "peerDependencies": {
         "@prefecthq/prefect-design": "^1.4.0",
+        "@prefecthq/vue-charts": "^0.3.1",
         "@prefecthq/vue-compositions": "^1.3.5",
         "vee-validate": "^4.7.0",
         "vue": "^3.2.45",
@@ -68,7 +69,6 @@
     "dependencies": {
         "@prefecthq/graphs": "1.0.2",
         "@prefecthq/radar": "0.0.19",
-        "@prefecthq/vue-charts": "0.3.1",
         "@types/lodash.isequal": "4.5.6",
         "axios": "0.27.2",
         "cronstrue": "^2.23.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,14 @@ export default defineConfig(({ mode }) => {
         name: 'prefect-ui-library',
       },
       rollupOptions: {
-        external: ['vue', 'vue-router', 'vee-validate', '@prefecthq/vue-compositions', '@prefecthq/prefect-design'],
+        external: [
+          'vue',
+          'vue-router',
+          'vee-validate',
+          '@prefecthq/vue-compositions',
+          '@prefecthq/prefect-design',
+          '@prefecthq/vue-charts',
+        ],
         output: {
           exports: 'named',
           // Provide vue as a global variable to use in the UMD build


### PR DESCRIPTION
# Description
nebula-ui has vue-charts as a dependency. Which means there can be version mis matches that cause things like css to not appear to be updating. Making vue-charts a peer would solve this and also reduce the bundle size by not bundling vue-charts twice. 

oss ui does not have vue-charts as a dependency and this change would require it to. But that shouldn't be an issue. 