### PR TITLE
Enhancement: Batch block document get requests

### DIFF
--- a/src/compositions/filters.ts
+++ b/src/compositions/filters.ts
@@ -1,4 +1,4 @@
-import { BooleanRouteParam, DateRouteParam, NumberRouteParam, RouteQueryParamsSchema, StringRouteParam, useRouteQueryParams } from '@prefecthq/vue-compositions'
+import { BooleanRouteParam, DateRouteParam, NullableBooleanRouteParam, NumberRouteParam, RouteQueryParamsSchema, StringRouteParam, useRouteQueryParams } from '@prefecthq/vue-compositions'
 import debounce from 'lodash.debounce'
 import isEqual from 'lodash.isequal'
 import { Ref, reactive, ComputedRef, toRef, computed, toRefs, isReactive, watch } from 'vue'
@@ -367,7 +367,7 @@ export function useBlockDocumentFilter(defaultValue: MaybeReactive<BlockDocument
 const blockDocumentFilterSchema: RouteQueryParamsSchema<BlockDocumentFilter> = {
   operator: OperatorRouteParam,
   id: [StringRouteParam],
-  isAnonymous: BooleanRouteParam,
+  isAnonymous: NullableBooleanRouteParam,
   blockTypeId: [StringRouteParam],
   name: [StringRouteParam],
 }

--- a/src/maps/filters.ts
+++ b/src/maps/filters.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { asArray } from '@prefecthq/prefect-design'
-import { Any, Like, All, IsNull, OperatorRequest, TagFilterRequest, FlowFilterRequest, FlowRunFilterRequest, NotAny, StateFilterRequest, Before, After, TaskRunFilterRequest, Exists, DeploymentFilterRequest, Equals, FlowsFilterRequest, FlowRunsFilterRequest, TaskRunsFilterRequest, DeploymentsFilterRequest, BlockTypeFilterRequest, BlockSchemaFilterRequest, BlockDocumentFilterRequest, NotificationsFilterRequest, SavedSearchesFilterRequest, LogsFilterRequest, GreaterThan, LessThan, ConcurrencyLimitsFilterRequest, BlockTypesFilterRequest, BlockSchemasFilterRequest, BlockDocumentsFilterRequest, WorkQueuesFilterRequest, StartsWith, WorkPoolFilterRequest, WorkPoolsFilterRequest, WorkPoolQueueFilterRequest, FlowRunsHistoryFilterRequest, WorkPoolWorkersFilterRequest, WorkPoolQueuesFilterRequest, ArtifactsFilterRequest, ArtifactFilterRequest } from '@/models/api/Filters'
+import { Any, Like, All, IsNull, OperatorRequest, TagFilterRequest, FlowFilterRequest, FlowRunFilterRequest, NotAny, StateFilterRequest, Before, After, TaskRunFilterRequest, Exists, DeploymentFilterRequest, Equals, FlowsFilterRequest, FlowRunsFilterRequest, TaskRunsFilterRequest, DeploymentsFilterRequest, BlockTypeFilterRequest, BlockSchemaFilterRequest, BlockDocumentFilterRequest, NotificationsFilterRequest, SavedSearchesFilterRequest, LogsFilterRequest, GreaterThan, LessThan, ConcurrencyLimitsFilterRequest, BlockTypesFilterRequest, BlockSchemasFilterRequest, BlockDocumentsFilterRequest, WorkQueuesFilterRequest, StartsWith, WorkPoolFilterRequest, WorkPoolsFilterRequest, WorkPoolQueueFilterRequest, FlowRunsHistoryFilterRequest, WorkPoolWorkersFilterRequest, WorkPoolQueuesFilterRequest, ArtifactsFilterRequest, ArtifactFilterRequest, NullableEquals } from '@/models/api/Filters'
 import { FlowFilter, FlowRunFilter, Operation, StateFilter, TagFilter, TaskRunFilter, DeploymentFilter, FlowsFilter, FlowRunsFilter, TaskRunsFilter, DeploymentsFilter, BlockTypeFilter, BlockSchemaFilter, BlockDocumentFilter, NotificationsFilter, SavedSearchesFilter, LogsFilter, ConcurrencyLimitsFilter, BlockTypesFilter, BlockSchemasFilter, BlockDocumentsFilter, WorkQueuesFilter, WorkPoolFilter, WorkPoolsFilter, WorkPoolQueueFilter, FlowRunsHistoryFilter, WorkPoolWorkersFilter, WorkPoolQueuesFilter, ArtifactsFilter, ArtifactFilter } from '@/models/Filters'
 import { MapFunction } from '@/services'
 import { removeEmptyObjects } from '@/utilities'
@@ -90,6 +90,14 @@ function toExists(value?: boolean): Exists | undefined {
 }
 
 function toEquals(value?: boolean): Equals | undefined {
+  if (typeof value === 'undefined') {
+    return value
+  }
+
+  return { eq_: value }
+}
+
+function toNullableEquals(value?: boolean | null): NullableEquals | undefined {
   if (typeof value === 'undefined') {
     return value
   }
@@ -355,7 +363,7 @@ export const mapBlockDocumentFilter: MapFunction<BlockDocumentFilter, BlockDocum
   return {
     ...toOperator(source.operator),
     id: toAny(source.id),
-    is_anonymous: toEquals(source.isAnonymous),
+    is_anonymous: toNullableEquals(source.isAnonymous),
     block_type_id: toAny(source.blockTypeId),
     name: toAny(source.name),
   }

--- a/src/models/Filters.ts
+++ b/src/models/Filters.ts
@@ -136,7 +136,7 @@ export type BlockSchemaFilter = {
 export type BlockDocumentFilter = {
   operator?: Operation,
   id?: string[],
-  isAnonymous?: boolean,
+  isAnonymous?: boolean | null,
   blockTypeId?: string[],
   name?: string[],
 }

--- a/src/models/api/Filters.ts
+++ b/src/models/api/Filters.ts
@@ -13,6 +13,7 @@ export type NotAny = { not_any_?: string[] }
 
 /** Matches on boolean equality */
 export type Equals = { eq_?: boolean }
+export type NullableEquals = { eq_?: boolean | null }
 
 /** Matches on boolean equality */
 export type Exists = { exists_?: boolean }
@@ -115,7 +116,7 @@ export type BlockSchemaFilterRequest = {
 export type BlockDocumentFilterRequest = {
   operator?: OperationRequest,
   id?: Any,
-  is_anonymous?: Equals,
+  is_anonymous?: NullableEquals,
   block_type_id?: Any,
   name?: Any,
 }


### PR DESCRIPTION
# Description
Enables request batching for individual block document requests. Something to note is the `isAnonymous: null` part of the filter. This ensures that both anonymous and non anonymous blocks are returned. 