### PR TITLE
Enhancement: Expose subscription in useFlowRun and similar compositions

### DIFF
--- a/src/components/ArtifactResultCard.vue
+++ b/src/components/ArtifactResultCard.vue
@@ -27,8 +27,8 @@
   const flowRunId = computed(() => props.artifact.flowRunId)
   const taskRunId = computed(() => props.artifact.taskRunId)
 
-  const flowRun = useFlowRun(flowRunId)
-  const taskRun = useTaskRun(taskRunId)
+  const { flowRun } = useFlowRun(flowRunId)
+  const { taskRun } = useTaskRun(taskRunId)
 
   const hasRun = computed(() => !!props.artifact.flowRunId || !!props.artifact.taskRunId)
 

--- a/src/components/DeploymentIconText.vue
+++ b/src/components/DeploymentIconText.vue
@@ -20,6 +20,6 @@
   const can = useCan()
   const routes = useWorkspaceRoutes()
   const deploymentId = computed(() => props.deploymentId)
-  const deployment = useDeployment(deploymentId)
+  const { deployment } = useDeployment(deploymentId)
   const deploymentName = computed(() => deployment.value?.name)
 </script>

--- a/src/components/FlowIconText.vue
+++ b/src/components/FlowIconText.vue
@@ -19,6 +19,6 @@
   const can = useCan()
   const routes = useWorkspaceRoutes()
   const flowId = computed(() => props.flowId)
-  const flow = useFlow(flowId)
+  const { flow } = useFlow(flowId)
   const flowName = computed(() => flow.value?.name)
 </script>

--- a/src/components/FlowRouterLink.vue
+++ b/src/components/FlowRouterLink.vue
@@ -43,7 +43,7 @@
     return props.flowId
   })
 
-  const flow = useFlow(flowId)
+  const { flow } = useFlow(flowId)
   const flowName = computed(() => flow.value?.name ?? '')
 </script>
 

--- a/src/components/FlowRunDetails.vue
+++ b/src/components/FlowRunDetails.vue
@@ -116,7 +116,7 @@
   const heading = computed(() => props.alternate ? 6 : 5)
 
   const deploymentId = computed(() => props.flowRun.deploymentId)
-  const deployment = useDeployment(deploymentId)
+  const { deployment } = useDeployment(deploymentId)
   const showDeployment = computed(() => can.read.deployment && isDefined(deployment.value))
   const stateMessage = computed(() => props.flowRun.state?.message)
 

--- a/src/components/FlowRunIconText.vue
+++ b/src/components/FlowRunIconText.vue
@@ -7,16 +7,15 @@
 </template>
 
 <script lang="ts" setup>
-  import { useSubscription } from '@prefecthq/vue-compositions'
-  import { computed } from 'vue'
-  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import { computed, toRefs } from 'vue'
+  import { useFlowRun, useWorkspaceRoutes } from '@/compositions'
 
   const props = defineProps<{
     flowRunId: string,
   }>()
 
-  const api = useWorkspaceApi()
   const routes = useWorkspaceRoutes()
-  const flowRunSubscription = useSubscription(api.flowRuns.getFlowRun, [props.flowRunId])
-  const flowRunName = computed(() => flowRunSubscription.response?.name)
+  const { flowRunId } = toRefs(props)
+  const { flowRun } = useFlowRun(flowRunId)
+  const flowRunName = computed(() => flowRun.value?.name)
 </script>

--- a/src/components/FlowRunListItem.vue
+++ b/src/components/FlowRunListItem.vue
@@ -9,7 +9,7 @@
         <FlowRunStartTime :flow-run="flowRun" />
         <DurationIconText :duration="flowRun.duration" />
         <template v-if="visible && flowRun.stateType !== 'scheduled'">
-          <FlowRunTaskCount :tasks-count="tasksCount">
+          <FlowRunTaskCount :tasks-count="taskRunsCount">
             <template #default="{ count }">
               {{ count }} task {{ toPluralString('run', count) }}
             </template>
@@ -81,10 +81,10 @@
   const value = computed(() => props.flowRun.id)
 
   const flowRunId = computed(() => props.flowRun.id)
-  const tasksCount = useTaskRunsCount(flowRunId)
+  const { taskRunsCount } = useTaskRunsCount(flowRunId)
 
   const deploymentId = computed(() => props.flowRun.deploymentId)
-  const deployment = useDeployment(deploymentId)
+  const { deployment } = useDeployment(deploymentId)
 
   const visible = ref(false)
   const el = ref<HTMLDivElement>()

--- a/src/components/LogRow.vue
+++ b/src/components/LogRow.vue
@@ -34,7 +34,7 @@
   }>()
 
   const taskRunId = computed(() => props.log.taskRunId)
-  const taskRun = useTaskRun(taskRunId)
+  const { taskRun } = useTaskRun(taskRunId)
   const taskRunName = computed(() => taskRun.value?.name)
 </script>
 

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -164,7 +164,7 @@
 
     return selectedBlockTypeId.value
   })
-  const blockSchemaForSelectedBlockType = useBlockSchemaForBlockType(blockTypeId)
+  const { blockSchema: blockSchemaForSelectedBlockType } = useBlockSchemaForBlockType(blockTypeId)
   const blockSchema = computed(() => {
     if (blockDocument.value && selectedBlockTypeId.value === blockDocument.value.blockTypeId) {
       return blockDocument.value.blockSchema

--- a/src/components/PageHeadingArtifact.vue
+++ b/src/components/PageHeadingArtifact.vue
@@ -24,8 +24,8 @@
   const flowRunId = computed(() => props.artifact.flowRunId)
   const taskRunId = computed(() => props.artifact.taskRunId)
 
-  const flowRun = useFlowRun(flowRunId)
-  const taskRun = useTaskRun(taskRunId)
+  const { flowRun } = useFlowRun(flowRunId)
+  const { taskRun } = useTaskRun(taskRunId)
 
   const hasRun = computed(() => !!props.artifact.flowRunId || !!props.artifact.taskRunId)
 

--- a/src/components/WorkQueueDetails.vue
+++ b/src/components/WorkQueueDetails.vue
@@ -67,7 +67,7 @@
     return num > 0 ? `${num} Deployments` : 'Deployments'
   })
 
-  const workQueueStatus = useWorkQueueStatus(props.workQueue.id)
+  const { workQueueStatus } = useWorkQueueStatus(props.workQueue.id)
 </script>
 
 <style>

--- a/src/components/WorkQueueLastPolled.vue
+++ b/src/components/WorkQueueLastPolled.vue
@@ -14,6 +14,6 @@
   }>()
 
   const workQueueId = computed(() => props.workQueueId)
-  const workQueueStatus = useWorkQueueStatus(workQueueId)
+  const { workQueueStatus } = useWorkQueueStatus(workQueueId)
   const lastPolled = computed(() => workQueueStatus.value?.lastPolled)
 </script>

--- a/src/components/WorkQueueLateIndicator.vue
+++ b/src/components/WorkQueueLateIndicator.vue
@@ -14,7 +14,7 @@
   }>()
 
   const workQueueId = computed(() => props.workQueueId)
-  const workQueueStatus = useWorkQueueStatus(workQueueId)
+  const { workQueueStatus } = useWorkQueueStatus(workQueueId)
   const lateRunsCount = computed(() => workQueueStatus.value?.lateRunsCount)
 </script>
 

--- a/src/components/WorkQueueStatusBadge.vue
+++ b/src/components/WorkQueueStatusBadge.vue
@@ -19,7 +19,7 @@
 
   const workQueueName = computed(() => props.workQueue.name)
   const workQueueId = computed(() => props.workQueue.id)
-  const workQueueStatus = useWorkQueueStatus(workQueueId)
+  const { workQueueStatus } = useWorkQueueStatus(workQueueId)
   const healthy = computed(() => workQueueStatus.value?.healthy)
 
   const label = computed(() => {

--- a/src/components/WorkQueueStatusIcon.vue
+++ b/src/components/WorkQueueStatusIcon.vue
@@ -21,7 +21,7 @@
   const workQueue = computed(() => workQueuesSubscription.response)
 
   const workQueueId = computed(() => workQueue.value?.id)
-  const workQueueStatus = useWorkQueueStatus(workQueueId)
+  const { workQueueStatus } = useWorkQueueStatus(workQueueId)
   const healthy = computed(() => workQueueStatus.value?.healthy)
 
   const status = computed<{ name: string, icon: Icon }>(() => {

--- a/src/compositions/useBlockDocument.ts
+++ b/src/compositions/useBlockDocument.ts
@@ -1,10 +1,13 @@
 import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, ComputedRef, ref, Ref } from 'vue'
+import { computed, ref, Ref } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { BlockDocument } from '@/models/BlockDocument'
+import { WorkspaceBlockDocumentsApi } from '@/services/WorkspaceBlockDocumentsApi'
+import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export function useBlockDocument(blockDocumentId: string | Ref<string | null | null>): ComputedRef<BlockDocument | undefined> {
+export type UseBlockDocument = UseEntitySubscription<WorkspaceBlockDocumentsApi['getBlockDocument'], 'blockDocument'>
+
+export function useBlockDocument(blockDocumentId: string | Ref<string | null | null>): UseBlockDocument {
   const id = ref(blockDocumentId)
   const api = useWorkspaceApi()
   const can = useCan()
@@ -24,5 +27,8 @@ export function useBlockDocument(blockDocumentId: string | Ref<string | null | n
   const subscription = useSubscriptionWithDependencies(api.blockDocuments.getBlockDocument, parameters)
   const blockDocument = computed(() => subscription.response)
 
-  return blockDocument
+  return {
+    subscription,
+    blockDocument,
+  }
 }

--- a/src/compositions/useBlockSchema.ts
+++ b/src/compositions/useBlockSchema.ts
@@ -1,9 +1,12 @@
 import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, ComputedRef, ref, Ref } from 'vue'
+import { computed, ref, Ref } from 'vue'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { BlockSchema } from '@/models/BlockSchema'
+import { WorkspaceBlockSchemasApi } from '@/services/WorkspaceBlockSchemasApi'
+import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export function useBlockSchema(blockSchemaId: string | Ref<string | null | null>): ComputedRef<BlockSchema | undefined> {
+export type UseBlockSchema = UseEntitySubscription<WorkspaceBlockSchemasApi['getBlockSchema'], 'blockSchema'>
+
+export function useBlockSchema(blockSchemaId: string | Ref<string | null | null>): UseBlockSchema {
   const id = ref(blockSchemaId)
   const api = useWorkspaceApi()
   const parameters = computed<[string] | null>(() => {
@@ -17,10 +20,13 @@ export function useBlockSchema(blockSchemaId: string | Ref<string | null | null>
   const subscription = useSubscriptionWithDependencies(api.blockSchemas.getBlockSchema, parameters)
   const blockSchema = computed(() => subscription.response)
 
-  return blockSchema
+  return {
+    subscription,
+    blockSchema,
+  }
 }
 
-export function useBlockSchemaForBlockType(blockTypeId: string | Ref<string | null | null>): ComputedRef<BlockSchema | undefined> {
+export function useBlockSchemaForBlockType(blockTypeId: string | Ref<string | null | null>): UseBlockSchema {
   const id = ref(blockTypeId)
   const api = useWorkspaceApi()
   const parameters = computed<[string] | null>(() => {
@@ -34,5 +40,8 @@ export function useBlockSchemaForBlockType(blockTypeId: string | Ref<string | nu
   const subscription = useSubscriptionWithDependencies(api.blockSchemas.getBlockSchemaForBlockType, parameters)
   const blockSchema = computed(() => subscription.response)
 
-  return blockSchema
+  return {
+    subscription,
+    blockSchema,
+  }
 }

--- a/src/compositions/useBlockType.ts
+++ b/src/compositions/useBlockType.ts
@@ -1,9 +1,12 @@
 import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, ComputedRef, ref, Ref } from 'vue'
+import { computed, ref, Ref } from 'vue'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { BlockType } from '@/models/BlockType'
+import { WorkspaceBlockTypesApi } from '@/services/WorkspaceBlockTypesApi'
+import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export function useBlockType(blockTypeId: string | Ref<string | null | undefined>): ComputedRef<BlockType | undefined> {
+export type UseBlockType = UseEntitySubscription<WorkspaceBlockTypesApi['getBlockType'], 'blockType'>
+
+export function useBlockType(blockTypeId: string | Ref<string | null | undefined>): UseBlockType {
   const api = useWorkspaceApi()
   const slug = ref(blockTypeId)
 
@@ -18,10 +21,13 @@ export function useBlockType(blockTypeId: string | Ref<string | null | undefined
   const subscription = useSubscriptionWithDependencies(api.blockTypes.getBlockType, parameters)
   const blockType = computed(() => subscription.response)
 
-  return blockType
+  return {
+    subscription,
+    blockType,
+  }
 }
 
-export function useBlockTypeBySlug(blockTypeSlug: string | Ref<string | null | undefined>): ComputedRef<BlockType | undefined> {
+export function useBlockTypeBySlug(blockTypeSlug: string | Ref<string | null | undefined>): UseBlockType {
   const api = useWorkspaceApi()
   const slug = ref(blockTypeSlug)
 
@@ -36,5 +42,8 @@ export function useBlockTypeBySlug(blockTypeSlug: string | Ref<string | null | u
   const subscription = useSubscriptionWithDependencies(api.blockTypes.getBlockTypeBySlug, parameters)
   const blockType = computed(() => subscription.response)
 
-  return blockType
+  return {
+    subscription,
+    blockType,
+  }
 }

--- a/src/compositions/useDeployment.ts
+++ b/src/compositions/useDeployment.ts
@@ -1,10 +1,13 @@
 import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, ComputedRef, Ref, ref } from 'vue'
+import { computed, Ref, ref } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { Deployment } from '@/models/Deployment'
+import { WorkspaceDeploymentsApi } from '@/services/WorkspaceDeploymentsApi'
+import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export function useDeployment(deploymentId: string | Ref<string | null | undefined>): ComputedRef<Deployment | undefined> {
+export type UseDeployment = UseEntitySubscription<WorkspaceDeploymentsApi['getDeployment'], 'deployment'>
+
+export function useDeployment(deploymentId: string | Ref<string | null | undefined>): UseDeployment {
   const api = useWorkspaceApi()
   const can = useCan()
   const id = ref(deploymentId)
@@ -24,5 +27,8 @@ export function useDeployment(deploymentId: string | Ref<string | null | undefin
   const subscription = useSubscriptionWithDependencies(api.deployments.getDeployment, parameters)
   const deployment = computed(() => subscription.response)
 
-  return deployment
+  return {
+    subscription,
+    deployment,
+  }
 }

--- a/src/compositions/useFlow.ts
+++ b/src/compositions/useFlow.ts
@@ -1,10 +1,13 @@
 import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, ComputedRef, Ref, ref } from 'vue'
+import { computed, Ref, ref } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { Flow } from '@/models/Flow'
+import { WorkspaceFlowsApi } from '@/services/WorkspaceFlowsApi'
+import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export function useFlow(flowId: string | Ref<string | null | undefined>): ComputedRef<Flow | undefined> {
+export type UseFlow = UseEntitySubscription<WorkspaceFlowsApi['getFlow'], 'flow'>
+
+export function useFlow(flowId: string | Ref<string | null | undefined>): UseFlow {
   const api = useWorkspaceApi()
   const can = useCan()
   const id = ref(flowId)
@@ -24,5 +27,8 @@ export function useFlow(flowId: string | Ref<string | null | undefined>): Comput
   const subscription = useSubscriptionWithDependencies(api.flows.getFlow, parameters)
   const flow = computed(() => subscription.response)
 
-  return flow
+  return {
+    subscription,
+    flow,
+  }
 }

--- a/src/compositions/useFlowRun.ts
+++ b/src/compositions/useFlowRun.ts
@@ -5,7 +5,7 @@ import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
 import { WorkspaceFlowRunsApi } from '@/services'
 import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export type UseFlowRun = UseEntitySubscription<WorkspaceFlowRunsApi['getFlowRun']>
+export type UseFlowRun = UseEntitySubscription<WorkspaceFlowRunsApi['getFlowRun'], 'flowRun'>
 
 export function useFlowRun(flowRunId: string | Ref<string | null | undefined>): UseFlowRun {
   const api = useWorkspaceApi()

--- a/src/compositions/useFlowRun.ts
+++ b/src/compositions/useFlowRun.ts
@@ -1,10 +1,13 @@
 import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, ComputedRef, Ref, ref } from 'vue'
+import { computed, Ref, ref } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { FlowRun } from '@/models/FlowRun'
+import { WorkspaceFlowRunsApi } from '@/services'
+import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export function useFlowRun(flowRunId: string | Ref<string | null | undefined>): ComputedRef<FlowRun | undefined> {
+export type UseFlowRun = UseEntitySubscription<WorkspaceFlowRunsApi['getFlowRun']>
+
+export function useFlowRun(flowRunId: string | Ref<string | null | undefined>): UseFlowRun {
   const api = useWorkspaceApi()
   const can = useCan()
   const id = ref(flowRunId)
@@ -24,5 +27,8 @@ export function useFlowRun(flowRunId: string | Ref<string | null | undefined>): 
   const subscription = useSubscriptionWithDependencies(api.flowRuns.getFlowRun, parameters)
   const flowRun = computed(() => subscription.response)
 
-  return flowRun
+  return {
+    subscription,
+    flowRun,
+  }
 }

--- a/src/compositions/useTaskRun.ts
+++ b/src/compositions/useTaskRun.ts
@@ -1,10 +1,13 @@
 import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, ComputedRef, Ref, ref } from 'vue'
+import { computed, Ref, ref } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { TaskRun } from '@/models/TaskRun'
+import { WorkspaceTaskRunsApi } from '@/services/WorkspaceTaskRunsApi'
+import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export function useTaskRun(taskRunId: string | Ref<string | null | undefined>): ComputedRef<TaskRun | undefined> {
+export type UseTaskRun = UseEntitySubscription<WorkspaceTaskRunsApi['getTaskRun'], 'taskRun'>
+
+export function useTaskRun(taskRunId: string | Ref<string | null | undefined>): UseTaskRun {
   const api = useWorkspaceApi()
   const can = useCan()
   const id = ref(taskRunId)
@@ -24,5 +27,8 @@ export function useTaskRun(taskRunId: string | Ref<string | null | undefined>): 
   const subscription = useSubscriptionWithDependencies(api.taskRuns.getTaskRun, parameters)
   const taskRun = computed(() => subscription.response)
 
-  return taskRun
+  return {
+    subscription,
+    taskRun,
+  }
 }

--- a/src/compositions/useTaskRunsCount.ts
+++ b/src/compositions/useTaskRunsCount.ts
@@ -1,9 +1,12 @@
-/* eslint-disable camelcase */
 import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, ComputedRef, Ref, ref } from 'vue'
+import { computed, Ref, ref } from 'vue'
 import { useCan, useWorkspaceApi } from '@/compositions'
+import { WorkspaceTaskRunsApi } from '@/services/WorkspaceTaskRunsApi'
+import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export function useTaskRunsCount(flowRunId: string | Ref<string | null | undefined>): ComputedRef<number | undefined> {
+export type UseTaskRunsCount = UseEntitySubscription<WorkspaceTaskRunsApi['getTaskRunsCount'], 'taskRunsCount'>
+
+export function useTaskRunsCount(flowRunId: string | Ref<string | null | undefined>): UseTaskRunsCount {
   const api = useWorkspaceApi()
   const can = useCan()
   const id = ref(flowRunId)
@@ -29,8 +32,11 @@ export function useTaskRunsCount(flowRunId: string | Ref<string | null | undefin
     ]
   })
 
-  const taskRunsCountSubscription = useSubscriptionWithDependencies(api.taskRuns.getTaskRunsCount, tasksCountFilter)
-  const taskRunsCount = computed(() => taskRunsCountSubscription.response)
+  const subscription = useSubscriptionWithDependencies(api.taskRuns.getTaskRunsCount, tasksCountFilter)
+  const taskRunsCount = computed(() => subscription.response)
 
-  return taskRunsCount
+  return {
+    subscription,
+    taskRunsCount,
+  }
 }

--- a/src/compositions/useWorkPoolQueue.ts
+++ b/src/compositions/useWorkPoolQueue.ts
@@ -1,10 +1,13 @@
 import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, ComputedRef, Ref, ref } from 'vue'
+import { computed, Ref, ref } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { WorkPoolQueue } from '@/models/WorkPoolQueue'
+import { WorkspaceWorkQueuesApi } from '@/services/WorkspaceWorkQueuesApi'
+import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export function useWorkPoolQueue(workPoolQueueId: string | Ref<string | null | undefined>): ComputedRef<WorkPoolQueue | undefined> {
+export type UseWorkPoolQueue = UseEntitySubscription<WorkspaceWorkQueuesApi['getWorkQueue'], 'workPoolQueue'>
+
+export function useWorkPoolQueue(workPoolQueueId: string | Ref<string | null | undefined>): UseWorkPoolQueue {
   const api = useWorkspaceApi()
   const can = useCan()
   const id = ref(workPoolQueueId)
@@ -24,5 +27,8 @@ export function useWorkPoolQueue(workPoolQueueId: string | Ref<string | null | u
   const subscription = useSubscriptionWithDependencies(api.workQueues.getWorkQueue, parameters)
   const workPoolQueue = computed(() => subscription.response)
 
-  return workPoolQueue
+  return {
+    subscription,
+    workPoolQueue,
+  }
 }

--- a/src/compositions/useWorkQueueStatus.ts
+++ b/src/compositions/useWorkQueueStatus.ts
@@ -1,9 +1,12 @@
 import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, ComputedRef, Ref, ref } from 'vue'
+import { computed, Ref, ref } from 'vue'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { WorkQueueStatus } from '@/models/WorkQueueStatus'
+import { WorkspaceWorkQueuesApi } from '@/services/WorkspaceWorkQueuesApi'
+import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
-export function useWorkQueueStatus(workQueueId: string | Ref<string | null | undefined>): ComputedRef<WorkQueueStatus | undefined> {
+export type UseWorkQueueStatus = UseEntitySubscription<WorkspaceWorkQueuesApi['getWorkQueueStatus'], 'workQueueStatus'>
+
+export function useWorkQueueStatus(workQueueId: string | Ref<string | null | undefined>): UseWorkQueueStatus {
   const api = useWorkspaceApi()
   const id = ref(workQueueId)
 
@@ -18,5 +21,8 @@ export function useWorkQueueStatus(workQueueId: string | Ref<string | null | und
   const subscription = useSubscriptionWithDependencies(api.workQueues.getWorkQueueStatus, parameters)
   const workQueueStatus = computed(() => subscription.response)
 
-  return workQueueStatus
+  return {
+    subscription,
+    workQueueStatus,
+  }
 }

--- a/src/types/useEntitySubscription.ts
+++ b/src/types/useEntitySubscription.ts
@@ -1,0 +1,7 @@
+import { Action, UseSubscription } from '@prefecthq/vue-compositions'
+import { ComputedRef } from 'vue'
+
+export type UseEntitySubscription<T extends Action> = {
+  subscription: UseSubscription<T | (() => undefined)>,
+  flowRun: ComputedRef<UseSubscription<T | (() => undefined)>['response']>,
+}

--- a/src/types/useEntitySubscription.ts
+++ b/src/types/useEntitySubscription.ts
@@ -1,7 +1,6 @@
 import { Action, UseSubscription } from '@prefecthq/vue-compositions'
 import { ComputedRef } from 'vue'
 
-export type UseEntitySubscription<T extends Action> = {
-  subscription: UseSubscription<T | (() => undefined)>,
-  flowRun: ComputedRef<UseSubscription<T | (() => undefined)>['response']>,
+export type UseEntitySubscription<T extends Action, PropertyName extends string> = { subscription: UseSubscription<T | (() => undefined)> } & {
+  [ P in PropertyName ]: ComputedRef<UseSubscription<T | (() => undefined)>['response']>
 }

--- a/src/types/useEntitySubscription.ts
+++ b/src/types/useEntitySubscription.ts
@@ -1,6 +1,8 @@
 import { Action, UseSubscription } from '@prefecthq/vue-compositions'
 import { ComputedRef } from 'vue'
 
-export type UseEntitySubscription<T extends Action, PropertyName extends string> = { subscription: UseSubscription<T | (() => undefined)> } & {
+export type UseEntitySubscription<T extends Action, PropertyName extends string> = {
+  subscription: UseSubscription<T | (() => undefined)>,
+} & {
   [ P in PropertyName ]: ComputedRef<UseSubscription<T | (() => undefined)>['response']>
 }


### PR DESCRIPTION
# Description
This would be a breaking change and would require updating everywhere we currently do `const flowRun = useFlowRun(flowRunId)` to be `const { flowRun } = useFlowRun(flowRunId)`

The motivation for this change is currently there is no way to know if the api request actually succeed or failed. Exposing the underlying subscription allows the most flexibility at implementation. 