### PR TITLE
BugFix: Reject batch process promises if value is undefined

### DIFF
--- a/src/models/BatchLookupError.ts
+++ b/src/models/BatchLookupError.ts
@@ -1,0 +1,5 @@
+export class BatchLookupError extends Error {
+  public constructor(id: unknown) {
+    super(`Batch lookup failed for id: ${JSON.stringify(id)}`)
+  }
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,6 @@
 export * from './api'
 export * from './Artifact'
+export * from './BatchLookupError'
 export * from './BlockDocument'
 export * from './BlockDocumentCreate'
 export * from './BlockDocumentUpdate'

--- a/src/services/BatchProcessor/BatchProcessor.ts
+++ b/src/services/BatchProcessor/BatchProcessor.ts
@@ -1,3 +1,4 @@
+import { BatchLookupError } from '@/index'
 import { MaybePromise } from '@/types'
 
 export type BatchCallbackLookup<V, R> = (value: V) => MaybePromise<R>
@@ -126,8 +127,15 @@ export class BatchProcessor<V, R> {
   }
 
   private resolveBatchUsingMap(batch: BatchQueue<V, R>, map: Map<V, R>): void {
-    batch.forEach(({ resolve }, id) => {
-      resolve(map.get(id)!)
+    batch.forEach(({ resolve, reject }, id) => {
+      const value = map.get(id)
+
+      if (value === undefined) {
+        reject(new BatchLookupError(id))
+        return
+      }
+
+      resolve(value)
     })
   }
 


### PR DESCRIPTION
# Description
Adds a new BatchLookupError that is used to reject batch process calls if the value is undefined. Previously the return type from the map was being ignored with a `!`. Which meant in our api services if the `/filter` endpoint didn't return a value for an id the batch processes would incorrectly resolve as successful but with an `undefined` value. 