### PR TITLE
Chore: Remove deprecated tailwind line clamp plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
             },
             "devDependencies": {
                 "@prefecthq/eslint-config": "1.0.25",
-                "@tailwindcss/line-clamp": "0.4.2",
                 "@types/lodash.camelcase": "4.3.7",
                 "@types/lodash.debounce": "4.0.7",
                 "@types/node": "^18.15.11",
@@ -1175,15 +1174,6 @@
             },
             "peerDependencies": {
                 "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
-            }
-        },
-        "node_modules/@tailwindcss/line-clamp": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz",
-            "integrity": "sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==",
-            "dev": true,
-            "peerDependencies": {
-                "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
             }
         },
         "node_modules/@tailwindcss/typography": {
@@ -7250,13 +7240,6 @@
             "requires": {
                 "mini-svg-data-uri": "^1.2.3"
             }
-        },
-        "@tailwindcss/line-clamp": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz",
-            "integrity": "sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==",
-            "dev": true,
-            "requires": {}
         },
         "@tailwindcss/typography": {
             "version": "0.5.9",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "types": "./dist/types/src/index.d.ts",
     "devDependencies": {
         "@prefecthq/eslint-config": "1.0.25",
-        "@tailwindcss/line-clamp": "0.4.2",
         "@types/lodash.camelcase": "4.3.7",
         "@types/lodash.debounce": "4.0.7",
         "@types/node": "^18.15.11",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,5 +39,5 @@ module.exports = {
       },
     },
   },
-  plugins: [prefectDesignPlugin, require('@tailwindcss/line-clamp')],
+  plugins: [prefectDesignPlugin],
 }


### PR DESCRIPTION
# Description
Tailwind 3.3.0 includes the line clamp utilities by default and deprecated this plugin. 

https://tailwindcss.com/blog/tailwindcss-v3-3#line-clamp-out-of-the-box