### PR TITLE
Feature: VariablesWorkspaceAPI service

### DIFF
--- a/src/services/WorkspaceVariablesApi.ts
+++ b/src/services/WorkspaceVariablesApi.ts
@@ -1,0 +1,39 @@
+import { Variable, VariableCreate, VariableEdit } from '@/models'
+import { VariableResponse } from '@/models/api/VariableResponse'
+import { mapper } from '@/services'
+import { WorkspaceApi } from '@/services/WorkspaceApi'
+
+export interface IWorkspaceVariablesApi {
+  // TODO: Bulk route doesn't exist yet, will soon
+  // getVariables: (filter: VariablesFilter) => Promise<Variable[]>,
+  getVariable: (variableId: string) => Promise<Variable>,
+  createVariable: (body: VariableCreate) => Promise<Variable>,
+  editVariable: (variableId: string, body: VariableEdit) => Promise<Variable>,
+  deleteVariable: (variableId: string) => Promise<void>,
+}
+
+export class WorkspaceVariablesApi extends WorkspaceApi implements IWorkspaceVariablesApi {
+  protected override routePrefix = '/variables'
+
+  public async getVariable(variableId: string): Promise<Variable> {
+    const { data } = await this.get<VariableResponse>(`/${variableId}`)
+    return mapper.map('VariableResponse', data, 'Variable')
+  }
+
+  public async createVariable(body: VariableCreate): Promise<Variable> {
+    const requestBody = mapper.map('VariableCreate', body, 'VariableCreateRequest')
+    const { data } = await this.post<VariableResponse>('/', requestBody)
+    return mapper.map('VariableResponse', data, 'Variable')
+  }
+
+  public async editVariable(variableId: string, body: VariableEdit): Promise<Variable> {
+    const requestBody = mapper.map('VariableEdit', body, 'VariableEditRequest')
+    const { data } = await this.put<VariableResponse>(`/${variableId}`, requestBody)
+
+    return mapper.map('VariableResponse', data, 'Variable')
+  }
+
+  public deleteVariable(variableId: string): Promise<void> {
+    return this.delete(`/${variableId}`)
+  }
+}

--- a/src/services/WorkspaceVariablesApi.ts
+++ b/src/services/WorkspaceVariablesApi.ts
@@ -28,7 +28,7 @@ export class WorkspaceVariablesApi extends WorkspaceApi implements IWorkspaceVar
 
   public async editVariable(variableId: string, body: VariableEdit): Promise<Variable> {
     const requestBody = mapper.map('VariableEdit', body, 'VariableEditRequest')
-    const { data } = await this.put<VariableResponse>(`/${variableId}`, requestBody)
+    const { data } = await this.patch<VariableResponse>(`/${variableId}`, requestBody)
 
     return mapper.map('VariableResponse', data, 'Variable')
   }

--- a/src/services/WorkspaceVariablesApi.ts
+++ b/src/services/WorkspaceVariablesApi.ts
@@ -4,7 +4,8 @@ import { mapper } from '@/services'
 import { WorkspaceApi } from '@/services/WorkspaceApi'
 
 export interface IWorkspaceVariablesApi {
-  // TODO: Bulk route doesn't exist yet, will soon
+  // TODO: Bulk route doesn't exist yet, will implement
+  // when we know what the filters will be
   // getVariables: (filter: VariablesFilter) => Promise<Variable[]>,
   getVariable: (variableId: string) => Promise<Variable>,
   createVariable: (body: VariableCreate) => Promise<Variable>,


### PR DESCRIPTION
Implements the variables API as it (mostly) exists right now; note that the `delete` and `edit` services are subject to change since those aren't done yet but I don't think they will do so significantly. I didn't include the bulk get/filter route since that's also WIP and I don't want to implement the filter models until I've seen the API (we've agreed on one but that can change during implementation)