### PR TITLE
Chore: Artifact collections

### DIFF
--- a/demo/compositions/useArtifactsMock.ts
+++ b/demo/compositions/useArtifactsMock.ts
@@ -1,5 +1,5 @@
 import { useSeeds } from './useSeeds'
-import { Artifact } from '@/models'
+import { Artifact, ArtifactCollection } from '@/models'
 import { mocker } from '@/services'
 import { coinflip, repeat } from '@/utilities'
 
@@ -29,8 +29,19 @@ export function useArtifactMock(override?: Partial<Artifact>, useTaskRun: boolea
     },
   ])
 
+  let artifactCollection: ArtifactCollection | undefined = undefined
+  if (artifact.key) {
+    artifactCollection = {
+      ...artifact,
+      // This seems necessary to infer that the key exists... the spread above doesn't seem to do it.
+      key: artifact.key,
+      latestId: artifact.id,
+    }
+  }
+
   useSeeds({
     artifacts: [artifact],
+    artifactCollections: artifactCollection ? [artifactCollection] : [],
     flows: [flow],
     deployments: [deployment],
     workQueues: [workQueue],

--- a/demo/compositions/useArtifactsMock.ts
+++ b/demo/compositions/useArtifactsMock.ts
@@ -70,7 +70,5 @@ export function useArtifactsMock(count: number, override?: Partial<Artifact>): A
     artifactCollections,
   })
 
-  console.log(artifactCollections)
-
   return artifacts
 }

--- a/demo/compositions/useSeeds.ts
+++ b/demo/compositions/useSeeds.ts
@@ -1,10 +1,11 @@
 import { onUnmounted } from 'vue'
 import { data } from '../utilities/data'
 import { FlowRunGraphMock } from '@/demo/types/flowRunGraphMock'
-import { Artifact, Flow, FlowRun, Deployment, WorkQueue, TaskRun, BlockDocument, BlockType, BlockSchema, ConcurrencyLimit, WorkPool, WorkPoolQueue, WorkPoolWorker } from '@/models'
+import { Artifact, Flow, FlowRun, Deployment, WorkQueue, TaskRun, BlockDocument, BlockType, BlockSchema, ConcurrencyLimit, WorkPool, WorkPoolQueue, WorkPoolWorker, ArtifactCollection } from '@/models'
 
 type Seeds = {
   artifacts?: Artifact[],
+  artifactCollections?: ArtifactCollection[],
   blockDocuments?: BlockDocument[],
   blockSchemaCapabilities?: string[],
   blockSchemas?: BlockSchema[],
@@ -60,6 +61,14 @@ export function useSeeds(seed: Seeds): void {
     const ids = artifacts.map(artifact => artifact.id)
 
     onUnmounted(() => data.artifacts.deleteAll(ids))
+  }
+
+  if (seed.artifactCollections) {
+    const artifactCollections = data.artifactCollections.createAll(seed.artifactCollections)
+
+    const keys = artifactCollections.map(artifactCollection => artifactCollection.key)
+
+    onUnmounted(() => data.artifactCollections.deleteAll(keys))
   }
 
   if (seed.deployments) {

--- a/demo/services/MockApi.ts
+++ b/demo/services/MockApi.ts
@@ -6,6 +6,10 @@ export class MockApi {
     return data.artifacts
   }
 
+  protected get artifactCollections() {
+    return data.artifactCollections
+  }
+
   protected get flows() {
     return data.flows
   }

--- a/demo/services/mockWorkspaceArtifactsApi.ts
+++ b/demo/services/mockWorkspaceArtifactsApi.ts
@@ -84,7 +84,13 @@ export class MockWorkspaceArtifactsApi extends MockApi implements IWorkspaceArti
   }
 
   public async getArtifactCollection(key: string): Promise<ArtifactCollection> {
-    return await this.artifactCollections.get(key)
+    const artifactCollection = await this.artifactCollections.find((artifactCollection: ArtifactCollection) => artifactCollection.key === key)
+
+    if (!artifactCollection) {
+      throw new Error(`Artifact collection with key ${key} not found`)
+    }
+
+    return artifactCollection
   }
 
   public async getArtifactCollectionsCount(filter: ArtifactsFilter): Promise<number> {

--- a/demo/services/mockWorkspaceArtifactsApi.ts
+++ b/demo/services/mockWorkspaceArtifactsApi.ts
@@ -1,6 +1,6 @@
 import { KeyedDataStoreFindCallback } from './KeyedDataStore'
 import { MockApi } from './MockApi'
-import { Artifact } from '@/models'
+import { Artifact, ArtifactCollection } from '@/models'
 import { ArtifactsFilter } from '@/models/Filters'
 import { IWorkspaceArtifactsApi } from '@/services/WorkspaceArtifactsApi'
 
@@ -54,14 +54,6 @@ export class MockWorkspaceArtifactsApi extends MockApi implements IWorkspaceArti
     }
 
     artifacts = artifacts.slice(offset, offset + limit)
-
-    if (filter.artifacts?.isLatest) {
-      artifacts = artifacts.filter(artifact => {
-        const otherArtifacts = artifacts.filter(otherArtifact => otherArtifact.key === artifact.key)
-        return otherArtifacts.length === 1 || otherArtifacts[0].created.getTime() <= artifact.created.getTime()
-      })
-    }
-
 
     return artifacts
   }

--- a/demo/services/mockWorkspaceArtifactsApi.ts
+++ b/demo/services/mockWorkspaceArtifactsApi.ts
@@ -58,6 +58,39 @@ export class MockWorkspaceArtifactsApi extends MockApi implements IWorkspaceArti
     return artifacts
   }
 
+  public async getArtifactCollections(filter: ArtifactsFilter = {}): Promise<ArtifactCollection[]> {
+    const { limit = 200, offset = 0, sort = 'CREATED_DESC' } = filter
+    let artifacts = await this.artifactCollections.findAll(artifactsItemIntersectsFilter(filter))
+
+    switch (sort) {
+      /* eslint-disable id-length */
+      case 'CREATED_DESC':
+        artifacts = artifacts.sort((a, b) => b.created.getTime() - a.created.getTime())
+        break
+      case 'KEY_ASC':
+        artifacts = artifacts.sort((a, b) => a.key.localeCompare(b.key))
+        break
+      case 'KEY_DESC':
+        artifacts = artifacts.sort((a, b) => b.key.localeCompare(a.key))
+        break
+      default:
+        break
+      /* eslint-enable id-length */
+    }
+
+    artifacts = artifacts.slice(offset, offset + limit)
+
+    return artifacts
+  }
+
+  public async getArtifactCollection(key: string): Promise<ArtifactCollection> {
+    return await this.artifactCollections.get(key)
+  }
+
+  public async getArtifactCollectionsCount(filter: ArtifactsFilter): Promise<number> {
+    return await this.artifactCollections.count(artifactsItemIntersectsFilter(filter))
+  }
+
   public async getArtifactsCount(filter: ArtifactsFilter = {}): Promise<number> {
     return await this.artifacts.count(artifactsItemIntersectsFilter(filter))
   }

--- a/demo/utilities/api.ts
+++ b/demo/utilities/api.ts
@@ -15,12 +15,13 @@ import { MockWorkspaceWorkPoolsApi } from '../services/mockWorkspaceWorkPoolsApi
 import { MockWorkspaceWorkPoolWorkerApi } from '../services/mockWorkspaceWorkPoolWorkerApi'
 import { MockWorkspaceWorkQueuesApi } from '../services/mockWorkspaceWorkQueuesApi'
 import { FlowRunGraphMock } from '@/demo/types/flowRunGraphMock'
-import { Artifact, BlockDocument, BlockSchema, BlockType, Deployment, Flow, FlowRun, TaskRun, WorkPool, WorkPoolQueue, WorkQueue, WorkPoolWorker } from '@/models'
+import { Artifact, BlockDocument, BlockSchema, BlockType, Deployment, Flow, FlowRun, TaskRun, WorkPool, WorkPoolQueue, WorkQueue, WorkPoolWorker, ArtifactCollection } from '@/models'
 import { ConcurrencyLimit } from '@/models/ConcurrencyLimit'
 import { CreateApi, workspaceApiKey } from '@/utilities'
 
 export type ApiMockSeeds = {
   artifacts?: Artifact[],
+  artifactCollections?: ArtifactCollection[],
   flows?: Flow[],
   flowRuns?: FlowRun[],
   flowRunGraphs?: FlowRunGraphMock[],

--- a/demo/utilities/data.ts
+++ b/demo/utilities/data.ts
@@ -23,6 +23,7 @@ function hydrateGraph({ id, graph }: FlowRunGraphMock): FlowRunGraphMock {
 export function createDataStores(seeds: ApiMockSeeds = {}) {
   return {
     artifacts: new KeyedDataStore({ seeds: seeds.artifacts, hydrate: artifact => new Artifact({ ...artifact, created: new Date(artifact.created), updated: new Date(artifact.updated) }) }),
+    artifactCollections: new KeyedDataStore({ seeds: seeds.artifactCollections, hydrate: artifactCollection => artifactCollection }),
     flows: new KeyedDataStore({ seeds: seeds.flows, hydrate: flow => new Flow(flow) }),
     flowRuns: new KeyedDataStore({ seeds: seeds.flowRuns, hydrate: flowRun => new FlowRun(flowRun) }),
     flowRunGraphs: new KeyedDataStore({ seeds: seeds.flowRunGraphs, hydrate: hydrateGraph }),

--- a/demo/utilities/data.ts
+++ b/demo/utilities/data.ts
@@ -2,7 +2,7 @@ import { KeyedDataStore } from '../services/KeyedDataStore'
 import { SimpleDataStore } from '../services/SimpleDataStore'
 import { ApiMockSeeds } from './api'
 import { FlowRunGraphMock } from '@/demo/types/flowRunGraphMock'
-import { Flow, FlowRun, BlockDocument, BlockSchema, TaskRun, Deployment, WorkQueue, BlockType, WorkPool, WorkPoolQueue, WorkPoolWorker, GraphNode, Artifact } from '@/models'
+import { Flow, FlowRun, BlockDocument, BlockSchema, TaskRun, Deployment, WorkQueue, BlockType, WorkPool, WorkPoolQueue, WorkPoolWorker, GraphNode, Artifact, ArtifactCollection } from '@/models'
 import { resolveSchema } from '@/services/schemas/resolvers/schemas'
 
 function hydrateBlockSchema(blockSchema: BlockSchema): BlockSchema {
@@ -23,7 +23,7 @@ function hydrateGraph({ id, graph }: FlowRunGraphMock): FlowRunGraphMock {
 export function createDataStores(seeds: ApiMockSeeds = {}) {
   return {
     artifacts: new KeyedDataStore({ seeds: seeds.artifacts, hydrate: artifact => new Artifact({ ...artifact, created: new Date(artifact.created), updated: new Date(artifact.updated) }) }),
-    artifactCollections: new KeyedDataStore({ seeds: seeds.artifactCollections, hydrate: artifactCollection => artifactCollection }),
+    artifactCollections: new KeyedDataStore({ seeds: seeds.artifactCollections, hydrate: artifactCollection => new ArtifactCollection({ ...artifactCollection, created: new Date(artifactCollection.created), updated: new Date(artifactCollection.updated) }) }),
     flows: new KeyedDataStore({ seeds: seeds.flows, hydrate: flow => new Flow(flow) }),
     flowRuns: new KeyedDataStore({ seeds: seeds.flowRuns, hydrate: flowRun => new FlowRun(flowRun) }),
     flowRunGraphs: new KeyedDataStore({ seeds: seeds.flowRunGraphs, hydrate: hydrateGraph }),

--- a/src/components/ArtifactCollections.vue
+++ b/src/components/ArtifactCollections.vue
@@ -9,7 +9,7 @@
 
     <RowGridLayoutList v-if="artifactsLoaded" :items="artifacts">
       <template #default="{ item }: { item: ArtifactCollection }">
-        <router-link :to="routes.artifactKey(item.id)">
+        <router-link :to="routes.artifactKey(item.key)">
           <ArtifactCard :artifact="item" class="artifact-collections__artifact-card" />
         </router-link>
       </template>

--- a/src/components/ArtifactCollections.vue
+++ b/src/components/ArtifactCollections.vue
@@ -8,7 +8,7 @@
     </div>
 
     <RowGridLayoutList v-if="artifactsLoaded" :items="artifacts">
-      <template #default="{ item }: { item: Artifact }">
+      <template #default="{ item }: { item: ArtifactCollection }">
         <router-link :to="routes.artifactKey(item.id)">
           <ArtifactCard :artifact="item" class="artifact-collections__artifact-card" />
         </router-link>
@@ -31,7 +31,7 @@
   import ViewModeButtonGroup from '@/components/ViewModeButtonGroup.vue'
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
-  import { ArtifactsFilter, ArtifactType, Artifact } from '@/models'
+  import { ArtifactsFilter, ArtifactType, ArtifactCollection } from '@/models'
 
   const searchTerm = ref<string>('')
   const searchTermDebounced = useDebouncedRef(searchTerm, 1200)
@@ -43,22 +43,20 @@
 
   const artifactsFilter = computed<ArtifactsFilter>(() => {
     const keyLike = searchTermDebounced.value ? searchTermDebounced.value : undefined
-    const isLatest = true
     const keyExists = true
     const type = selectedType.value ? [selectedType.value] : undefined
 
     return {
       artifacts: {
         keyExists,
-        isLatest,
         keyLike,
         type,
       },
     }
   })
 
-  const artifactsSubscription = useSubscription(api.artifacts.getArtifacts, [artifactsFilter])
-  const artifactsCountSubscription = useSubscription(api.artifacts.getArtifactsCount, [artifactsFilter])
+  const artifactsSubscription = useSubscription(api.artifacts.getArtifactCollections, [artifactsFilter])
+  const artifactsCountSubscription = useSubscription(api.artifacts.getArtifactCollectionsCount, [artifactsFilter])
   const artifactsLoaded = computed(() => artifactsSubscription.executed)
   const artifacts = computed(() => artifactsSubscription.response ?? [])
   const artifactsCount = computed(() => artifactsCountSubscription.response)

--- a/src/components/ArtifactKeyIconText.vue
+++ b/src/components/ArtifactKeyIconText.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-link :to="routes.artifactKey(artifactId)" class="flow-run-icon-text">
+  <p-link v-if="artifactKey" :to="routes.artifactKey(artifactKey)" class="flow-run-icon-text">
     <p-icon-text :icon="icon">
       <span>{{ artifactKey }}</span>
     </p-icon-text>

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -74,18 +74,10 @@
     }
   })
 
-  const artifactsLatestFilter = computed<ArtifactsFilter>(() => {
-    return {
-      artifacts: {
-        key: [props.artifactKey],
-        isLatest: true,
-      },
-    }
-  })
-  const artifactsLatestSubscription = useSubscription(api.artifacts.getArtifacts, [artifactsLatestFilter], { interval: 30000 })
+  const artifactsLatestSubscription = useSubscription(api.artifacts.getArtifactCollection, [props.artifactKey], { interval: 30000 })
   const latestArtifactId = computed(() => {
-    const [latestArtifact = null] = artifactsLatestSubscription.response ?? []
-    return latestArtifact?.id
+    const latestArtifact = artifactsLatestSubscription.response
+    return latestArtifact?.latestId
   })
 
   const artifactsCountFilter = computed<ArtifactsFilter>(() => {

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -110,8 +110,9 @@
   watch(latestArtifactId, (val, oldVal) => {
     if (val && !oldVal) {
       expanded.value = [val]
+    } else {
+      getArtifacts()
     }
-    getArtifacts()
   }, { immediate: true })
 
   watch(artifactsFilterOffset, getOffsetArtifacts)

--- a/src/components/ArtifactTimeline.vue
+++ b/src/components/ArtifactTimeline.vue
@@ -55,6 +55,7 @@
   }>()
 
   const api = useWorkspaceApi()
+  const expanded = ref<string[]>([])
 
   const artifactsFilter = computed<ArtifactsFilter>(() => {
     return {
@@ -111,7 +112,8 @@
       expanded.value = [val]
     }
     getArtifacts()
-  })
+  }, { immediate: true })
+
   watch(artifactsFilterOffset, getOffsetArtifacts)
 
   const fetchMore = (): void => {
@@ -125,7 +127,6 @@
     getArtifacts()
   })
 
-  const expanded = ref<string[]>([])
 
   type ArtifactTimelineItem = TimelineItem & {
     icon?: Icon,

--- a/src/components/PageHeadingArtifact.vue
+++ b/src/components/PageHeadingArtifact.vue
@@ -48,7 +48,7 @@
     } else if (props.artifact.key) {
       internalCrumbs.push({
         text: props.artifact.key,
-        to: routes.artifactKey(props.artifact.id),
+        to: routes.artifactKey(props.artifact.key),
       })
     }
 

--- a/src/maps/artifact.ts
+++ b/src/maps/artifact.ts
@@ -1,11 +1,29 @@
+import { ArtifactCollectionResponse } from '@/models/api/ArtifactCollectionResponse'
 import { ArtifactResponse } from '@/models/api/ArtifactResponse'
 import { Artifact } from '@/models/Artifact'
+import { ArtifactCollection } from '@/models/ArtifactCollection'
 import { MapFunction } from '@/services/Mapper'
 import { isKnownArtifactType } from '@/types/artifact'
 
 export const mapArtifactResponseToArtifact: MapFunction<ArtifactResponse, Artifact> = function(source) {
   return new Artifact({
     id: source.id,
+    created: this.map('string', source.created, 'Date'),
+    updated: this.map('string', source.updated, 'Date'),
+    description: source.description,
+    key: source.key,
+    type: isKnownArtifactType(source.type) ? source.type : 'unknown',
+    data: source.data,
+    metadata: source.metadata_,
+    flowRunId: source.flow_run_id,
+    taskRunId: source.task_run_id,
+  })
+}
+
+export const mapArtifactCollectionResponseToArtifactCollection: MapFunction<ArtifactCollectionResponse, ArtifactCollection> = function(source) {
+  return new ArtifactCollection({
+    id: source.id,
+    latestId: source.latest_id,
     created: this.map('string', source.created, 'Date'),
     updated: this.map('string', source.updated, 'Date'),
     description: source.description,

--- a/src/maps/filters.ts
+++ b/src/maps/filters.ts
@@ -89,14 +89,6 @@ function toExists(value?: boolean): Exists | undefined {
   return { exists_: value }
 }
 
-function toLatest(value?: boolean): { is_latest: Latest } | undefined {
-  if (typeof value === 'undefined') {
-    return value
-  }
-
-  return { is_latest: { is_latest: value } }
-}
-
 function toEquals(value?: boolean): Equals | undefined {
   if (typeof value === 'undefined') {
     return value
@@ -274,7 +266,6 @@ export const mapArtifactFilter: MapFunction<ArtifactFilter, ArtifactFilterReques
     },
     flow_run_id: toAny(source.flowRunId),
     task_run_id: toAny(source.taskRunId),
-    ...toLatest(source.isLatest),
   }
 }
 

--- a/src/maps/index.ts
+++ b/src/maps/index.ts
@@ -1,4 +1,4 @@
-import { mapArtifactResponseToArtifact } from '@/maps/artifact'
+import { mapArtifactCollectionResponseToArtifactCollection, mapArtifactResponseToArtifact } from '@/maps/artifact'
 import { mapBlockDocumentResponseToBlockDocument, mapBlockDocumentToSelectOption } from '@/maps/blockDocument'
 import { mapBlockDocumentCreateToBlockDocumentCreateRequest } from '@/maps/blockDocumentCreate'
 import { mapBlockDocumentResponseReferencesToBlockDocumentReferences } from '@/maps/blockDocumentReferences'
@@ -55,6 +55,7 @@ import { mapWorkQueueStatusResponseToWorkQueueStatus } from '@/maps/workQueueSta
 export const maps = {
   ArtifactFilter: { ArtifactFilterRequest: mapArtifactFilter },
   ArtifactResponse: { Artifact: mapArtifactResponseToArtifact },
+  ArtifactCollectionResponse: { ArtifactCollection: mapArtifactCollectionResponseToArtifactCollection },
   ArtifactsFilter: { ArtifactsFilterRequest: mapArtifactsFilter },
   BlockDocument: { SelectOption: mapBlockDocumentToSelectOption },
   BlockDocumentCreate: { BlockDocumentCreateRequest: mapBlockDocumentCreateToBlockDocumentCreateRequest },

--- a/src/models/ArtifactCollection.ts
+++ b/src/models/ArtifactCollection.ts
@@ -1,17 +1,8 @@
-import { ArtifactData, ArtifactMetadata, ArtifactType } from '@/models/Artifact'
+import { ArtifactData, ArtifactMetadata, ArtifactType, IArtifact } from '@/models/Artifact'
 
-export interface IArtifactCollection {
-  id: string,
+export interface IArtifactCollection extends IArtifact {
   latestId: string,
-  created: Date,
-  updated: Date,
   key: string,
-  type: ArtifactType,
-  description: string | null,
-  data: ArtifactData,
-  metadata: ArtifactMetadata,
-  flowRunId: string | null,
-  taskRunId: string | null,
 }
 
 export class ArtifactCollection implements IArtifactCollection {

--- a/src/models/ArtifactCollection.ts
+++ b/src/models/ArtifactCollection.ts
@@ -1,0 +1,43 @@
+import { ArtifactData, ArtifactMetadata, ArtifactType } from '@/models/Artifact'
+
+export interface IArtifactCollection {
+  id: string,
+  latestId: string,
+  created: Date,
+  updated: Date,
+  key: string,
+  type: ArtifactType,
+  description: string | null,
+  data: ArtifactData,
+  metadata: ArtifactMetadata,
+  flowRunId: string | null,
+  taskRunId: string | null,
+}
+
+export class ArtifactCollection implements IArtifactCollection {
+  public readonly id: string
+  public readonly latestId: string
+  public readonly key: string
+  public readonly flowRunId: string | null
+  public readonly taskRunId: string | null
+  public readonly created: Date
+  public readonly updated: Date
+  public type: ArtifactType
+  public description: string | null
+  public data: ArtifactData
+  public metadata: ArtifactMetadata
+
+  public constructor(artifact: IArtifactCollection) {
+    this.id = artifact.id
+    this.latestId = artifact.latestId
+    this.created = artifact.created
+    this.updated = artifact.updated
+    this.key = artifact.key
+    this.type = artifact.type
+    this.description = artifact.description
+    this.data = artifact.data
+    this.metadata = artifact.metadata
+    this.flowRunId = artifact.flowRunId
+    this.taskRunId = artifact.taskRunId
+  }
+}

--- a/src/models/Filters.ts
+++ b/src/models/Filters.ts
@@ -71,7 +71,6 @@ export type ArtifactFilter = {
   key?: string[],
   keyLike?: string,
   keyExists?: boolean,
-  isLatest?: boolean,
   type?: string[],
   notType?: string[],
   flowRunId?: string[],

--- a/src/models/api/ArtifactCollectionResponse.ts
+++ b/src/models/api/ArtifactCollectionResponse.ts
@@ -1,15 +1,6 @@
-import { ArtifactDataResponse, ArtifactMetadataResponse } from '@/models/api/ArtifactResponse'
+import { ArtifactResponse } from '@/models/api/ArtifactResponse'
 
-export type ArtifactCollectionResponse = {
-  id: string,
+export type ArtifactCollectionResponse = ArtifactResponse & {
   latest_id: string,
-  created: string,
-  updated: string,
   key: string,
-  type: string,
-  description: string | null,
-  data: ArtifactDataResponse,
-  metadata_: ArtifactMetadataResponse,
-  flow_run_id: string | null,
-  task_run_id: string | null,
 }

--- a/src/models/api/ArtifactCollectionResponse.ts
+++ b/src/models/api/ArtifactCollectionResponse.ts
@@ -1,0 +1,15 @@
+import { ArtifactDataResponse, ArtifactMetadataResponse } from '@/models/api/ArtifactResponse'
+
+export type ArtifactCollectionResponse = {
+  id: string,
+  latest_id: string,
+  created: string,
+  updated: string,
+  key: string,
+  type: string,
+  description: string | null,
+  data: ArtifactDataResponse,
+  metadata_: ArtifactMetadataResponse,
+  flow_run_id: string | null,
+  task_run_id: string | null,
+}

--- a/src/models/api/Filters.ts
+++ b/src/models/api/Filters.ts
@@ -135,7 +135,6 @@ export type ArtifactFilterRequest = {
   type?: Any & NotAny,
   flow_run_id?: Any,
   task_run_id?: Any,
-  is_latest?: Latest,
 }
 
 export type ArtifactsFilterRequest = {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,6 @@
 export * from './api'
 export * from './Artifact'
+export * from './ArtifactCollection'
 export * from './BatchLookupError'
 export * from './BlockDocument'
 export * from './BlockDocumentCreate'

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -260,7 +260,7 @@ export function createWorkspaceRouteRecords(components: Partial<WorkspaceRouteCo
         },
         {
           name: 'workspace.artifacts.artifact.key',
-          path: 'key/:artifactId',
+          path: 'key/:artifactKey',
           component: components.artifactKey,
         },
         {

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -7,7 +7,7 @@ type CreateWorkspaceRoutesConfig = {
 export function createWorkspaceRoutes(config?: CreateWorkspaceRoutesConfig) {
   return {
     artifact: (artifactId: string) => ({ name: 'workspace.artifacts.artifact', params: { artifactId, ...config } }) as const,
-    artifactKey: (artifactId: string) => ({ name: 'workspace.artifacts.artifact.key', params: { artifactId, ...config } }) as const,
+    artifactKey: (artifactKey: string) => ({ name: 'workspace.artifacts.artifact.key', params: { artifactKey, ...config } }) as const,
     artifacts: () => ({ name: 'workspace.artifacts', params: { ...config } }) as const,
     flowRuns: () => ({ name: 'workspace.flow-runs', params: { ...config } }) as const,
     flowRun: (flowRunId: string) => ({ name: 'workspace.flow-runs.flow-run', params: { flowRunId, ...config } }) as const,

--- a/src/services/WorkspaceArtifactsApi.ts
+++ b/src/services/WorkspaceArtifactsApi.ts
@@ -10,6 +10,7 @@ import { toMap } from '@/utilities'
 export interface IWorkspaceArtifactsApi {
   getArtifact: (id: string) => Promise<Artifact>,
   getArtifacts: (filter: ArtifactsFilter) => Promise<Artifact[]>,
+  getArtifactCollection: (key: string) => Promise<ArtifactCollection>,
   getArtifactCollections: (filter: ArtifactsFilter) => Promise<ArtifactCollection[]>,
   getArtifactsCount: (filter: ArtifactsFilter) => Promise<number>,
   getArtifactCollectionsCount: (filter: ArtifactsFilter) => Promise<number>,
@@ -25,8 +26,17 @@ export class WorkspaceArtifactsApi extends WorkspaceApi implements IWorkspaceArt
     return toMap(artifacts, 'id')
   }, { maxBatchSize: 200 })
 
+  private readonly keyBatcher = new BatchProcessor<string, ArtifactCollection>(async keys => {
+    const collections = await this.getArtifactCollections({ artifacts: { key: keys } })
+    return toMap(collections, 'key')
+  }, { maxBatchSize: 200 })
+
   public getArtifact(id: string): Promise<Artifact> {
     return this.batcher.batch(id)
+  }
+
+  public getArtifactCollection(key: string): Promise<ArtifactCollection> {
+    return this.keyBatcher.batch(key)
   }
 
   public async getArtifacts(filter: ArtifactsFilter = {}): Promise<Artifact[]> {

--- a/src/services/WorkspaceArtifactsApi.ts
+++ b/src/services/WorkspaceArtifactsApi.ts
@@ -1,4 +1,6 @@
 import { Artifact, ArtifactResponse } from '@/models'
+import { ArtifactCollectionResponse } from '@/models/api/ArtifactCollectionResponse'
+import { ArtifactCollection } from '@/models/ArtifactCollection'
 import { ArtifactsFilter } from '@/models/Filters'
 import { BatchProcessor } from '@/services/BatchProcessor'
 import { mapper } from '@/services/Mapper'
@@ -8,6 +10,7 @@ import { toMap } from '@/utilities'
 export interface IWorkspaceArtifactsApi {
   getArtifact: (id: string) => Promise<Artifact>,
   getArtifacts: (filter: ArtifactsFilter) => Promise<Artifact[]>,
+  getArtifactCollections: (filter: ArtifactsFilter) => Promise<ArtifactCollection[]>,
   getArtifactsCount: (filter: ArtifactsFilter) => Promise<number>,
   deleteArtifact: (id: string) => Promise<void>,
 }
@@ -35,6 +38,12 @@ export class WorkspaceArtifactsApi extends WorkspaceApi implements IWorkspaceArt
     const request = mapper.map('ArtifactsFilter', filter, 'ArtifactsFilterRequest')
     const { data } = await this.post<number>('count', request)
     return data
+  }
+
+  public async getArtifactCollections(filter: ArtifactsFilter = {}): Promise<ArtifactCollection[]> {
+    const request = mapper.map('ArtifactsFilter', filter, 'ArtifactsFilterRequest')
+    const { data } = await this.post<ArtifactCollectionResponse[]>('latest/filter', request)
+    return mapper.map('ArtifactCollectionResponse', data, 'ArtifactCollection')
   }
 
   public deleteArtifact(id: string): Promise<void> {

--- a/src/services/WorkspaceArtifactsApi.ts
+++ b/src/services/WorkspaceArtifactsApi.ts
@@ -12,6 +12,7 @@ export interface IWorkspaceArtifactsApi {
   getArtifacts: (filter: ArtifactsFilter) => Promise<Artifact[]>,
   getArtifactCollections: (filter: ArtifactsFilter) => Promise<ArtifactCollection[]>,
   getArtifactsCount: (filter: ArtifactsFilter) => Promise<number>,
+  getArtifactCollectionsCount: (filter: ArtifactsFilter) => Promise<number>,
   deleteArtifact: (id: string) => Promise<void>,
 }
 
@@ -44,6 +45,12 @@ export class WorkspaceArtifactsApi extends WorkspaceApi implements IWorkspaceArt
     const request = mapper.map('ArtifactsFilter', filter, 'ArtifactsFilterRequest')
     const { data } = await this.post<ArtifactCollectionResponse[]>('latest/filter', request)
     return mapper.map('ArtifactCollectionResponse', data, 'ArtifactCollection')
+  }
+
+  public async getArtifactCollectionsCount(filter: ArtifactsFilter = {}): Promise<number> {
+    const request = mapper.map('ArtifactsFilter', filter, 'ArtifactsFilterRequest')
+    const { data } = await this.post<number>('latest/count', request)
+    return data
   }
 
   public deleteArtifact(id: string): Promise<void> {


### PR DESCRIPTION
This PR adds more explicit support for artifact collections (containing objects for the `latest` artifact of a given key) and drops support for `is_latest` in the artifacts filter route. Updates all relevant components to use the new route