### PR TITLE
Enhancement: Artifact card default slot

### DIFF
--- a/demo/sections/artifacts/ArtifactCard.vue
+++ b/demo/sections/artifacts/ArtifactCard.vue
@@ -10,11 +10,23 @@
     <template #result>
       <ArtifactCard :artifact="result" :condense="condense" />
     </template>
+
     <template #markdown>
       <ArtifactCard :artifact="markdown" :condense="condense" />
     </template>
     <template #table>
       <ArtifactCard :artifact="table" :condense="condense" />
+    </template>
+
+    <template #custom-slot>
+      <ArtifactCard :artifact="markdown" :condense="condense">
+        <template #summary-label>
+          ID (custom)
+        </template>
+        <template #summary-value>
+          {{ markdown.id }}
+        </template>
+      </ArtifactCard>
     </template>
   </ComponentPage>
 </template>
@@ -40,6 +52,9 @@
     },
     {
       title: 'Unknown',
+    },
+    {
+      title: 'Custom slot',
     },
   ]
 

--- a/src/components/ArtifactCard.vue
+++ b/src/components/ArtifactCard.vue
@@ -10,26 +10,28 @@
         </div>
       </header>
 
-      <div class="artifact-card__summary-container" :class="classes.summaryContainer">
-        <div class="artifact-card__summary-item">
-          <span class="artifact-card__summary-item-label">
-            {{ localization.info.created }}
-          </span>
-          <span class="artifact-card__summary-item-value">
-            {{ formatDateTime(artifact.created) }}
-          </span>
+      <slot>
+        <div class="artifact-card__summary-container" :class="classes.summaryContainer">
+          <div class="artifact-card__summary-item">
+            <span class="artifact-card__summary-item-label">
+              <slot name="summary-label">
+                {{ localization.info.created }}
+              </slot>
+            </span>
+            <span class="artifact-card__summary-item-value">
+              <slot name="summary-value">
+                {{ formatDateTime(artifact.created) }}
+              </slot>
+            </span>
+          </div>
         </div>
-      </div>
-    </div>
-
-    <div v-if="slots.default" class="artifact-card__slot">
-      <slot />
+      </slot>
     </div>
   </p-card>
 </template>
 
 <script lang="ts" setup>
-  import { computed, useSlots } from 'vue'
+  import { computed } from 'vue'
   import { localization } from '@/localization'
   import { Artifact } from '@/models'
   import { formatDateTime } from '@/utilities'
@@ -39,7 +41,6 @@
     condense?: boolean,
   }>()
 
-  const slots = useSlots()
   const hasKey = computed(() => !!props.artifact.key)
 
   const classes = computed(() => {

--- a/src/components/ArtifactCollections.vue
+++ b/src/components/ArtifactCollections.vue
@@ -10,7 +10,14 @@
     <RowGridLayoutList v-if="artifactsLoaded" :items="artifacts">
       <template #default="{ item }: { item: ArtifactCollection }">
         <router-link :to="routes.artifactKey(item.key)">
-          <ArtifactCard :artifact="item" class="artifact-collections__artifact-card" />
+          <ArtifactCard :artifact="item" class="artifact-collections__artifact-card">
+            <template #summary-label>
+              {{ localization.info.lastUpdated }}
+            </template>
+            <template #summary-value>
+              {{ formatDateTime(item.updated) }}
+            </template>
+          </ArtifactCard>
         </router-link>
       </template>
 
@@ -32,6 +39,7 @@
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { ArtifactsFilter, ArtifactType, ArtifactCollection } from '@/models'
+  import { formatDateTime } from '@/utilities'
 
   const searchTerm = ref<string>('')
   const searchTermDebounced = useDebouncedRef(searchTerm, 1200)


### PR DESCRIPTION
This PR moves the default slot from the `ArtifactCard` component to instead wrap the existing summary item and adds additional slot for taking advantage of the summary row formatting. The default slot as previously implemented was a vestige of an earlier design and isn't used anywhere.