### PR TITLE
Enhancement: Account for block document references with default values when resolving schemas

### DIFF
--- a/src/components/WorkPoolDetails.vue
+++ b/src/components/WorkPoolDetails.vue
@@ -28,7 +28,7 @@
   import { SchemaPropertiesKeyValues } from '@/components'
   import { useCan, useWorkspaceApi } from '@/compositions'
   import { WorkPool } from '@/models'
-  import { getSchemaDefaults } from '@/utilities'
+  import { getSchemaDefaultValues, mapper } from '@/services'
   import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
@@ -50,9 +50,9 @@
 
     return properties && Object.keys(properties).length > 0
   })
-  const schema = computed(() => props.workPool.baseJobTemplate.variables ?? {})
+  const schema = computed(() => mapper.map('SchemaResponse', props.workPool.baseJobTemplate.variables ?? {}, 'Schema'))
   const showBaseJobTemplateDetails = computed(() => props.workPool.type && schemaHasProperties.value && can.access.workers)
-  const baseJobTemplateVariablesDefaults = getSchemaDefaults(props.workPool.baseJobTemplate.variables ?? {})
+  const baseJobTemplateVariablesDefaults = computed(() => getSchemaDefaultValues(schema.value))
 </script>
 
 <style>

--- a/src/models/WorkPool.ts
+++ b/src/models/WorkPool.ts
@@ -11,7 +11,7 @@ export interface IWorkPool {
   isPaused: boolean,
   defaultQueueId: string,
   concurrencyLimit: number | null,
-  baseJobTemplate: Record<string, unknown>,
+  baseJobTemplate: BaseJobTemplateRequest,
 }
 
 export class WorkPool implements IWorkPool {

--- a/src/services/schemas/properties/SchemaPropertyAny.ts
+++ b/src/services/schemas/properties/SchemaPropertyAny.ts
@@ -8,6 +8,10 @@ import { parseUnknownJson, stringifyUnknownJson } from '@/utilities/json'
 
 export class SchemaPropertyAny extends SchemaPropertyService {
   protected get default(): unknown {
+    if (this.has('default')) {
+      return this.property.default
+    }
+
     if (this.componentIs(JsonInput)) {
       return ''
     }

--- a/src/services/schemas/properties/SchemaPropertyBlock.ts
+++ b/src/services/schemas/properties/SchemaPropertyBlock.ts
@@ -1,5 +1,5 @@
 import BlockDocumentInput from '@/components/BlockDocumentInput.vue'
-import { BlockDocumentReferenceValue, BlockDocumentValue, isBlockDocumentValue } from '@/models/api/BlockDocumentCreateRequest'
+import { BlockDocumentReferenceValue, BlockDocumentValue, isBlockDocumentReferenceValue, isBlockDocumentValue } from '@/models/api/BlockDocumentCreateRequest'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue } from '@/types/schemas'
@@ -8,7 +8,7 @@ export class SchemaPropertyBlock extends SchemaPropertyService {
 
   protected readonly default: BlockDocumentValue = {
     blockTypeSlug: this.property.blockTypeSlug!,
-    blockDocumentId: null,
+    blockDocumentId: this.getDefaultBlockDocumentId(),
   }
 
   protected override get component(): SchemaPropertyComponentWithProps {
@@ -41,6 +41,14 @@ export class SchemaPropertyBlock extends SchemaPropertyService {
     }
 
     this.invalid()
+  }
+
+  private getDefaultBlockDocumentId(): string | null {
+    if (isBlockDocumentReferenceValue(this.property.default)) {
+      return this.property.default.$ref.block_document_id
+    }
+
+    return null
   }
 
 }

--- a/src/services/schemas/resolvers/blockReferenceDefaults.ts
+++ b/src/services/schemas/resolvers/blockReferenceDefaults.ts
@@ -4,24 +4,24 @@ import { getSchemaValueDefinition } from '@/services/schemas/utilities'
 import { Schema, SchemaProperties, SchemaProperty } from '@/types'
 import { mapValues } from '@/utilities/object'
 
-export const schemaDefaultValuesResolver: SchemaResolver = (schema: Schema): Schema => {
+export const schemaBlockReferenceDefaultValuesResolver: SchemaResolver = (schema: Schema): Schema => {
   const { properties, ...rest } = schema
   const resolved: Schema = rest
 
-  resolved.properties = resolveSchemaPropertyDefaultValues(properties)
+  resolved.properties = resolveSchemaPropertyBlockReferenceDefaultValues(properties)
 
   return resolved
 }
 
-export function resolveSchemaPropertyDefaultValues(properties: SchemaProperties | undefined): SchemaProperties | undefined {
+function resolveSchemaPropertyBlockReferenceDefaultValues(properties: SchemaProperties | undefined): SchemaProperties | undefined {
   if (!properties) {
     return undefined
   }
 
-  return mapValues(properties, (key, property) => resolveSchemaPropertyDefaultValue(property))
+  return mapValues(properties, (key, property) => resolveSchemaPropertyBlockReferenceDefaultValue(property))
 }
 
-export function resolveSchemaPropertyDefaultValue(property: SchemaProperty | undefined): SchemaProperty | undefined {
+function resolveSchemaPropertyBlockReferenceDefaultValue(property: SchemaProperty | undefined): SchemaProperty | undefined {
   if (!property) {
     return undefined
   }

--- a/src/services/schemas/resolvers/defaults.ts
+++ b/src/services/schemas/resolvers/defaults.ts
@@ -1,0 +1,44 @@
+import { isBlockDocumentReferenceValue } from '@/models/api/BlockDocumentCreateRequest'
+import { SchemaResolver } from '@/services/schemas/resolvers/schemas'
+import { getSchemaValueDefinition } from '@/services/schemas/utilities'
+import { Schema, SchemaProperties, SchemaProperty } from '@/types'
+import { mapValues } from '@/utilities/object'
+
+export const schemaDefaultValuesResolver: SchemaResolver = (schema: Schema): Schema => {
+  const { properties, ...rest } = schema
+  const resolved: Schema = rest
+
+  resolved.properties = resolveSchemaPropertyDefaultValues(properties)
+
+  return resolved
+}
+
+export function resolveSchemaPropertyDefaultValues(properties: SchemaProperties | undefined): SchemaProperties | undefined {
+  if (!properties) {
+    return undefined
+  }
+
+  return mapValues(properties, (key, property) => resolveSchemaPropertyDefaultValue(property))
+}
+
+export function resolveSchemaPropertyDefaultValue(property: SchemaProperty | undefined): SchemaProperty | undefined {
+  if (!property) {
+    return undefined
+  }
+
+  const resolved: SchemaProperty = { ...property }
+
+  if (isBlockDocumentReferenceValue(property.default)) {
+    const definition = getSchemaValueDefinition(property, property.default)
+
+    if (definition) {
+      resolved.default = {
+        blockDocumentId: property.default.$ref.block_document_id,
+        blockTypeSlug: definition.blockTypeSlug,
+      }
+    }
+  }
+
+  return resolved
+
+}

--- a/src/services/schemas/resolvers/definitions.ts
+++ b/src/services/schemas/resolvers/definitions.ts
@@ -92,16 +92,3 @@ function resolveDefinition(ref: string, definitions: SchemaDefinitions): SchemaP
 
   return schema
 }
-
-function flattenPropertyWithDefinition(property: SchemaProperty, definition: Schema): SchemaProperty {
-  const flattened = {
-    ...definition,
-    ...property,
-  }
-
-  // if the property doesn't have a title or description try using the title and description from first reference
-  flattened.title = property.title ?? definition.title
-  flattened.description = property.description ?? definition.description
-
-  return flattened
-}

--- a/src/services/schemas/resolvers/schemas.ts
+++ b/src/services/schemas/resolvers/schemas.ts
@@ -1,4 +1,4 @@
-import { schemaDefaultValuesResolver } from '@/services/schemas/resolvers/defaults'
+import { schemaBlockReferenceDefaultValuesResolver } from '@/services/schemas/resolvers/blockReferenceDefaults'
 import { schemaDefinitionsResolver } from '@/services/schemas/resolvers/definitions'
 import { schemaMetaResolver } from '@/services/schemas/resolvers/meta'
 import { resolve, ResolverCallback } from '@/services/schemas/utilities'
@@ -9,7 +9,7 @@ export type SchemaResolver = ResolverCallback<Schema>
 /*
  * Resolvers that need to be run on a Schema before it can consumed by the UI. ORDER IS IMPORTANT
  */
-const resolvers = [schemaDefinitionsResolver, schemaDefaultValuesResolver, schemaMetaResolver]
+const resolvers = [schemaDefinitionsResolver, schemaBlockReferenceDefaultValuesResolver, schemaMetaResolver]
 
 /*
  * Run all resolvers that need to be run on a Schema before it can be consumed by the UI

--- a/src/services/schemas/resolvers/schemas.ts
+++ b/src/services/schemas/resolvers/schemas.ts
@@ -1,3 +1,4 @@
+import { schemaDefaultValuesResolver } from '@/services/schemas/resolvers/defaults'
 import { schemaDefinitionsResolver } from '@/services/schemas/resolvers/definitions'
 import { schemaMetaResolver } from '@/services/schemas/resolvers/meta'
 import { resolve, ResolverCallback } from '@/services/schemas/utilities'
@@ -8,7 +9,7 @@ export type SchemaResolver = ResolverCallback<Schema>
 /*
  * Resolvers that need to be run on a Schema before it can consumed by the UI. ORDER IS IMPORTANT
  */
-const resolvers = [schemaDefinitionsResolver, schemaMetaResolver]
+const resolvers = [schemaDefinitionsResolver, schemaDefaultValuesResolver, schemaMetaResolver]
 
 /*
  * Run all resolvers that need to be run on a Schema before it can be consumed by the UI

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -1,5 +1,6 @@
+import { de } from 'date-fns/locale'
 import { JsonInput } from '@/components'
-import { isBlockDocumentValue } from '@/models'
+import { isBlockDocumentReferenceValue, isBlockDocumentValue } from '@/models'
 import { schemaPropertyServiceFactory } from '@/services/schemas/properties'
 import { SchemaProperty, SchemaPropertyInputAttrs, Schema, SchemaValues, SchemaValue, schemaHas, SchemaPropertyAnyOf, SchemaPropertyAllOf } from '@/types/schemas'
 import { withPropsWithoutExcludedFactory } from '@/utilities/components'
@@ -224,6 +225,10 @@ export function getSchemaValueAllOfDefinitionIndex({ allOf: definitions }: Schem
 }
 
 export function getSchemaValueDefinitionIndex(definitions: Schema[], value: SchemaValue): number | null {
+  if (isBlockDocumentReferenceValue(value)) {
+    return definitions.findIndex(definition => definition.type === 'block')
+  }
+
   switch (typeof value) {
     case 'number':
       return definitions.findIndex(definition => definition.type == 'number' || definition.type === 'integer')

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -21,6 +21,9 @@ export function getSchemaValuesWithDefaultsJson(
   return stringify(defaultValues)
 }
 
+/*
+ * @deprecated use `getSchemaDefaultValues` instead
+ */
 export function getSchemaDefaults(schema: Schema): SchemaValues {
   const values: SchemaValues = {}
 


### PR DESCRIPTION
# Description
Adds a new resolver for schemas that resolved default values properties that have block document references. As well as accounts for properties that are type `block` that might have a default value. 

Supersedes: https://github.com/PrefectHQ/prefect-ui-library/pull/1324