### PR TITLE
BugFix: Schema form incorrectly marking reference objects as optional

### DIFF
--- a/src/components/SchemaFormProperties.vue
+++ b/src/components/SchemaFormProperties.vue
@@ -18,7 +18,7 @@
     property: SchemaProperty,
   }>()
 
-  const label = computed(() => props.property.required ? props.property.title : `${props.property.title} (Optional)`)
+  const label = computed(() => props.property.meta?.required ? props.property.title : `${props.property.title} (Optional)`)
 </script>
 
 <style>

--- a/src/services/schemas/properties/SchemaPropertyService.ts
+++ b/src/services/schemas/properties/SchemaPropertyService.ts
@@ -114,13 +114,7 @@ export abstract class SchemaPropertyService {
   }
 
   public getMeta(required: boolean): SchemaPropertyMeta | null {
-    const serviceComponent = this.getComponent()
-
-    if (serviceComponent == null) {
-      return null
-    }
-
-    const { component, props } = serviceComponent
+    const { component, props } = this.getComponent() ?? {}
 
     return {
       component,

--- a/src/services/schemas/resolvers/meta.ts
+++ b/src/services/schemas/resolvers/meta.ts
@@ -23,11 +23,11 @@ function resolveSchemaPropertyMeta(property: SchemaProperty, required: boolean, 
   const resolved: SchemaProperty = rest
 
   if (allOf) {
-    resolved.allOf = allOf.map(value => resolveSchemaPropertyMeta(value, false, level))
+    resolved.allOf = allOf.map(value => resolveSchemaPropertyMeta(value, required, level))
   }
 
   if (anyOf) {
-    resolved.anyOf = anyOf.map(value => resolveSchemaPropertyMeta(value, false, level))
+    resolved.anyOf = anyOf.map(value => resolveSchemaPropertyMeta(value, required, level))
   }
 
   if (items) {

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -39,7 +39,7 @@ export type SchemaPropertyMetaOptions = {
   required?: boolean,
 }
 
-export type SchemaPropertyMeta = SchemaPropertyComponentWithProps & SchemaPropertyMetaOptions
+export type SchemaPropertyMeta = Partial<SchemaPropertyComponentWithProps> & SchemaPropertyMetaOptions
 
 export type SchemaProperty = {
   // prefect specific properties


### PR DESCRIPTION
# Description
Fixes two issues with schema resolving
- Object properties were only considered required if they had required child properties. This is incorrect and required should always be determined by the parent property
- `allOf` and `anyOf` references should inherit the required value of the property they are associated with. Was previously hard coded to `false`

Need to do some more regression testing on this. 

Closes https://github.com/PrefectHQ/prefect/issues/9055