### PR TITLE
prevent flow graph shortcuts when metakey

### DIFF
--- a/src/components/FlowRunTimeline.vue
+++ b/src/components/FlowRunTimeline.vue
@@ -146,7 +146,7 @@
   })
 
   function keyboardShortcutListener(event: KeyboardEvent): void {
-    if (eventTargetIsInput(event.target)) {
+    if (eventTargetIsInput(event.target) || event.metaKey) {
       return
     }
 


### PR DESCRIPTION
Resolves PrefectHQ/graphs#126

When holding `control+f` to 'find all', the graph was going full screen. This makes it so the keyboard shortcuts aren't fired if a meta key (control/command/etc) is also held.