### PR TITLE
BugFix: Allow log messages to break long words to preserve container width

### DIFF
--- a/src/components/LogRow.vue
+++ b/src/components/LogRow.vue
@@ -53,7 +53,8 @@
 .log-row__content { @apply
   flex-1
   select-auto
-  whitespace-pre-wrap;
+  whitespace-pre-wrap
+  break-words
 }
 
 .log-row__trailing { @apply


### PR DESCRIPTION
# Description

Before
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/6200442/230941257-8e280cc2-0f23-4071-adee-107c1656e82f.png">

After
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/6200442/230941187-21bb2571-1f3d-476b-99fe-5ac6b5036aeb.png">
