### PR TITLE
BugFix: Logs overflow container

### DIFF
--- a/src/components/LogRow.vue
+++ b/src/components/LogRow.vue
@@ -40,13 +40,12 @@
 
 <style>
 .log-row { @apply
-  flex
-  w-full
+  grid
   py-2;
+  grid-template-columns: 84px minmax(0, 1fr) 150px;
 }
 
 .log-row__leading { @apply
-  w-[84px]
   select-none;
 }
 
@@ -63,7 +62,6 @@
   shrink-0
   text-right
   pl-1
-  max-w-[15%]
 }
 
 .log-row__logger { @apply


### PR DESCRIPTION
# Description
Follow up from https://github.com/PrefectHQ/prefect-ui-library/pull/1334 which didn't quite address the issue. Was able to reproduce thanks to https://github.com/PrefectHQ/prefect-ui-library/issues/1341

Closes https://github.com/PrefectHQ/prefect-ui-library/issues/1341

Before
<img width="678" alt="image" src="https://user-images.githubusercontent.com/6200442/231599844-cf6c1729-5b23-4af1-9c2a-70f4c35e37c2.png">

After
<img width="665" alt="image" src="https://user-images.githubusercontent.com/6200442/231599886-9dcd8c2c-a0b3-4e20-9e92-ac2f9afb19b3.png">
