### PR TITLE
Flat FlowRunListItem, updated FlowRunDetails

### DIFF
--- a/demo/sections/flowRuns/FlowRunListItem.vue
+++ b/demo/sections/flowRuns/FlowRunListItem.vue
@@ -9,6 +9,10 @@
     <template #no-relations>
       <FlowRunListItem :flow-run="flowRunWithNoRelations" :selected="[]" class="color-mode-default" disabled />
     </template>
+
+    <template #flat>
+      <FlowRunListItem :flow-run="flowRun" :selected="[]" class="color-mode-default" flat />
+    </template>
   </ComponentPage>
 </template>
 
@@ -21,6 +25,7 @@
   const demos: DemoSection[] = [
     { title: 'Disabled', description: 'With selection disabled' },
     { title: 'No Relations', description: 'With no deployment or work queue' },
+    { title: 'Flat', description: 'With no container and no selection' },
   ]
 
   const flowRun = useFlowRunMock()

--- a/src/components/FlowRunBreadCrumbs.vue
+++ b/src/components/FlowRunBreadCrumbs.vue
@@ -5,22 +5,34 @@
         <p-icon icon="ChevronRightIcon" size="small" />
       </template>
     </FlowRouterLink>
-    <p-link :to="routes.flowRun(flowRun.id)" class="flow-run-bread-crumbs__flow-run-link">
-      <span>{{ flowRun.name }}</span>
-    </p-link>
+    <template v-if="isFlowRunRouteActive">
+      <strong class="flow-run-bread-crumbs__flow-run-name">{{ flowRun.name }}</strong>
+    </template>
+    <template v-else>
+      <p-link :to="routes.flowRun(flowRun.id)" class="flow-run-bread-crumbs__flow-run-link">
+        <span>{{ flowRun.name }}</span>
+      </p-link>
+    </template>
   </div>
 </template>
 
 <script lang="ts" setup>
+  import { computed } from 'vue'
+  import { useRoute } from 'vue-router'
   import FlowRouterLink from '@/components/FlowRouterLink.vue'
   import { useWorkspaceRoutes } from '@/compositions/useWorkspaceRoutes'
   import { FlowRun } from '@/models'
 
-  defineProps<{
+  const props = defineProps<{
     flowRun: FlowRun,
   }>()
 
   const routes = useWorkspaceRoutes()
+  const route = useRoute()
+
+  const isFlowRunRouteActive = computed(() => {
+    return routes.flowRun(props.flowRun.id).name === route.name
+  })
 </script>
 
 <style>
@@ -30,6 +42,11 @@
 
 .flow-run-bread-crumbs__flow-link { @apply
   font-semibold
+}
+
+.flow-run-bread-crumbs__flow-run-name { @apply
+  font-normal
+  text-foreground
 }
 
 .flow-run-bread-crumbs__flow-run-link { @apply

--- a/src/components/FlowRunDetails.vue
+++ b/src/components/FlowRunDetails.vue
@@ -1,54 +1,5 @@
 <template>
   <div class="flow-run-details">
-    <p-key-value label="Flow" :alternate="alternate">
-      <template #value>
-        <FlowIconText :flow-id="flowRun.flowId" />
-      </template>
-    </p-key-value>
-
-    <p-key-value v-if="flowRun.deploymentId && showDeployment" label="Deployment" :alternate="alternate">
-      <template #value>
-        <DeploymentIconText :deployment-id="flowRun.deploymentId" />
-      </template>
-    </p-key-value>
-
-    <template v-if="can.read.work_queue && flowRun.workQueueName">
-      <p-key-value label="Work Queue" :alternate="alternate">
-        <template #value>
-          <div class="flow-run-details__work-queue-value">
-            <WorkQueueIconText :work-queue-name="flowRun.workQueueName" />
-            <WorkQueueStatusIcon :work-queue-name="flowRun.workQueueName" />
-          </div>
-        </template>
-      </p-key-value>
-    </template>
-
-    <template v-if="parentFlowRunId">
-      <p-key-value label="Parent Flow Run" :alternate="alternate">
-        <template #value>
-          <FlowRunIconText :flow-run-id="parentFlowRunId" />
-        </template>
-      </p-key-value>
-    </template>
-
-    <p-divider />
-
-    <p-heading :heading="heading">
-      Flow Run
-    </p-heading>
-
-    <p-key-value label="Start Time" :alternate="alternate">
-      <template #value>
-        <FlowRunStartTime :flow-run="flowRun" />
-      </template>
-    </p-key-value>
-
-    <p-key-value label="Duration" :alternate="alternate">
-      <template #value>
-        <DurationIconText :duration="flowRun.duration" />
-      </template>
-    </p-key-value>
-
     <p-key-value label="Run Count" :value="flowRun.runCount ?? 0" :alternate="alternate" />
 
     <p-key-value label="Created" :value="formatDateTimeNumeric(flowRun.created)" :alternate="alternate" />
@@ -96,53 +47,17 @@
 
 <script lang="ts" setup>
   import { PKeyValue, PTags } from '@prefecthq/prefect-design'
-  import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
-  import { WorkQueueIconText, FlowRunIconText, WorkQueueStatusIcon, FlowRunStartTime, FlowIconText, DurationIconText, DeploymentIconText } from '@/components'
-  import { useWorkspaceApi, useCan } from '@/compositions'
-  import { useDeployment } from '@/compositions/useDeployment'
   import { FlowRun } from '@/models/FlowRun'
-  import { isDefined } from '@/utilities'
   import { formatDateTimeNumeric } from '@/utilities/dates'
-
-  const api = useWorkspaceApi()
 
   const props = defineProps<{
     flowRun: FlowRun,
     alternate?: boolean,
   }>()
 
-  const can = useCan()
   const heading = computed(() => props.alternate ? 6 : 5)
-
-  const deploymentId = computed(() => props.flowRun.deploymentId)
-  const { deployment } = useDeployment(deploymentId)
-  const showDeployment = computed(() => can.read.deployment && isDefined(deployment.value))
   const stateMessage = computed(() => props.flowRun.state?.message)
-
-  const flowRunFilter = computed<Parameters<typeof api.flowRuns.getFlowRuns> | null>(() => {
-    if (props.flowRun.parentTaskRunId) {
-      return [
-        {
-          taskRuns: {
-            id: [props.flowRun.parentTaskRunId],
-          },
-        },
-      ]
-    }
-    return null
-  })
-
-  const parentFlowRunListSubscription = useSubscriptionWithDependencies(api.flowRuns.getFlowRuns, flowRunFilter)
-  const parentFlowRunList = computed(() => parentFlowRunListSubscription.response ?? [])
-
-  const parentFlowRunId = computed(() => {
-    if (!parentFlowRunList.value.length) {
-      return
-    }
-    const [value] = parentFlowRunList.value
-    return value.id
-  })
 </script>
 
 <style>
@@ -153,24 +68,8 @@
   items-start
 }
 
-.flow-run-details__work-queue-value { @apply
-  flex
-  items-center
-  gap-1
-}
-
 .flow-run-details__tags { @apply
   mb-1
   mr-1
-}
-
-.flow-run-details .flow-run-details__small-radar { @apply
-  h-[250px]
-  w-[250px]
-}
-
-.flow-run-details__small-radar-link { @apply
-  cursor-pointer
-  inline-block
 }
 </style>

--- a/src/components/FlowRunListItem.vue
+++ b/src/components/FlowRunListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="el" class="flow-run-list-item">
-    <StateListItem v-model:selected="model" v-bind="{ value, disabled, tags, stateType }">
+    <StateListItem v-model:selected="model" v-bind="{ value, disabled, tags, stateType }" :flat="flat">
       <template #name>
         <FlowRunBreadCrumbs :flow-run="flowRun" />
       </template>
@@ -61,6 +61,7 @@
     selected: CheckboxModel | null,
     flowRun: FlowRun,
     disabled?: boolean,
+    flat?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/PageHeadingFlowRun.vue
+++ b/src/components/PageHeadingFlowRun.vue
@@ -1,9 +1,7 @@
 <template>
-  <page-heading v-if="flowRun" class="page-heading-flow-run" :crumbs="crumbs">
-    <template #after-crumbs>
-      <StateBadge :state="flowRun.state" />
-    </template>
-    <template #actions>
+  <header v-if="flowRun" class="page-heading-flow-run">
+    <FlowRunListItem class="page-heading-flow-run__list-item" :flow-run="flowRun" flat :selected="null" />
+    <div class="page-heading-flow-run__actions">
       <template v-if="media.sm">
         <FlowRunPauseButton :flow-run="flowRun" />
         <FlowRunResumeButton :flow-run="flowRun" />
@@ -11,36 +9,56 @@
         <FlowRunCancelButton :flow-run="flowRun" />
       </template>
       <FlowRunMenu :flow-run-id="flowRun.id" :show-all="!media.sm" @delete="emit('delete')" />
-    </template>
-  </page-heading>
+    </div>
+  </header>
 </template>
 
 <script lang="ts" setup>
   import { media } from '@prefecthq/prefect-design'
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
-  import { StateBadge, PageHeading, FlowRunRetryButton, FlowRunResumeButton, FlowRunCancelButton, FlowRunPauseButton, FlowRunMenu } from '@/components'
-  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import {
+    FlowRunListItem,
+    FlowRunRetryButton,
+    FlowRunResumeButton,
+    FlowRunCancelButton,
+    FlowRunPauseButton,
+    FlowRunMenu
+  } from '@/components'
+  import { useWorkspaceApi } from '@/compositions'
 
   const props = defineProps<{
     flowRunId: string,
   }>()
 
   const api = useWorkspaceApi()
-  const routes = useWorkspaceRoutes()
 
   const emit = defineEmits<{
     (event: 'delete'): void,
   }>()
 
-  // It doesn't seem like we should need to coalesce here but
-  // the flow run model dictates the flow run name can be null
-  const crumbs = computed(() => [
-    { text: 'Flow Runs', to: routes.flowRuns() },
-    { text: flowRun.value?.name ?? '' },
-  ])
-
   const flowRunId = computed(() => props.flowRunId)
   const flowRunSubscription = useSubscription(api.flowRuns.getFlowRun, [flowRunId], { interval: 30000 })
   const flowRun = computed(() => flowRunSubscription.response)
 </script>
+
+<style>
+.page-heading-flow-run { @apply
+  flex
+  gap-2
+  flex-col-reverse
+  md:flex-row
+}
+
+.page-heading-flow-run__list-item { @apply
+  flex-grow
+}
+
+.page-heading-flow-run__actions { @apply
+  flex
+  flex-wrap
+  items-center
+  gap-2
+  justify-end
+}
+</style>

--- a/src/components/StateListItem.vue
+++ b/src/components/StateListItem.vue
@@ -1,5 +1,12 @@
 <template>
-  <p-list-item-input v-model:selected="model" :value="value" class="state-list-item" :class="classes" disabled>
+  <component
+    :is="flat ? 'div' : 'p-list-item-input'"
+    v-model:selected="model"
+    :value="value"
+    class="state-list-item"
+    :class="classes"
+    disabled
+  >
     <div class="state-list-item__content">
       <div class="state-list-item__top-section">
         <div class="state-list-item__name">
@@ -22,7 +29,7 @@
         </div>
       </template>
     </div>
-  </p-list-item-input>
+  </component>
 </template>
 
 <script lang="ts" setup>
@@ -35,6 +42,7 @@
     value: unknown,
     stateType: StateType | null | undefined,
     tags?: string[] | null,
+    flat?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/models/StateType.ts
+++ b/src/models/StateType.ts
@@ -23,6 +23,13 @@ export const terminalStateType = [
   'crashed',
 ]
 
+export const pendingStateType = ['scheduled', 'pending']
+export type PendingStateType = typeof pendingStateType[number]
+
+export function isPendingStateType(value: unknown): value is PendingStateType {
+  return typeof value === 'string' && pendingStateType.includes(value as PendingStateType)
+}
+
 export type TerminalStateType = typeof terminalStateType[number]
 export type ServerTerminalStateType = Uppercase<TerminalStateType>
 


### PR DESCRIPTION
1. Create a `flat` variant of the FlowRunListItem
2. Remove information from the FlowRunDetails that is duplicate of what's found on the FlowRunListItem
3. Add a isPendingState function for checking if a flow run has not started yet

This is needed to allow the Flow Run page to remove the fixed well and be more full screen. Here's what it will look like (will need some minor updates in Nebula/OSS of course):

Before a flow has ran:
<img width="1495" alt="image" src="https://user-images.githubusercontent.com/6776415/232788606-f10b3fed-d9a9-427f-a274-07dbbccfedf4.png">

After a flow run has started:
<img width="1495" alt="image" src="https://user-images.githubusercontent.com/6776415/232788802-2e1c7d6f-9b9d-4d4e-8458-5552ac61be30.png">

This is helpful because next we'll be adding an Events visualization to the page, and both graphs will utilize pop outs to the right. This is also a step toward incorporating more into the visualizations and clarifying the page.