### PR TITLE
update FlowRunPageHeader and FlowRunDetails for full page layout

### DIFF
--- a/src/components/FlowRunDeployment.vue
+++ b/src/components/FlowRunDeployment.vue
@@ -1,0 +1,16 @@
+<template>
+  <div v-if="deployment?.name" class="flow-run-list-item__relation">
+    <span>Deployment</span> <DeploymentIconText :deployment-id="deploymentId" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import DeploymentIconText from '@/components/DeploymentIconText.vue'
+  import { useDeployment } from '@/compositions'
+
+  const props = defineProps<{
+    deploymentId: string,
+  }>()
+
+  const { deployment } = useDeployment(props.deploymentId)
+</script>

--- a/src/components/FlowRunDetails.vue
+++ b/src/components/FlowRunDetails.vue
@@ -1,54 +1,5 @@
 <template>
   <div class="flow-run-details">
-    <p-key-value label="Flow" :alternate="alternate">
-      <template #value>
-        <FlowIconText :flow-id="flowRun.flowId" />
-      </template>
-    </p-key-value>
-
-    <p-key-value v-if="flowRun.deploymentId && showDeployment" label="Deployment" :alternate="alternate">
-      <template #value>
-        <DeploymentIconText :deployment-id="flowRun.deploymentId" />
-      </template>
-    </p-key-value>
-
-    <template v-if="can.read.work_queue && flowRun.workQueueName">
-      <p-key-value label="Work Queue" :alternate="alternate">
-        <template #value>
-          <div class="flow-run-details__work-queue-value">
-            <WorkQueueIconText :work-queue-name="flowRun.workQueueName" />
-            <WorkQueueStatusIcon :work-queue-name="flowRun.workQueueName" />
-          </div>
-        </template>
-      </p-key-value>
-    </template>
-
-    <template v-if="parentFlowRunId">
-      <p-key-value label="Parent Flow Run" :alternate="alternate">
-        <template #value>
-          <FlowRunIconText :flow-run-id="parentFlowRunId" />
-        </template>
-      </p-key-value>
-    </template>
-
-    <p-divider />
-
-    <p-heading :heading="heading">
-      Flow Run
-    </p-heading>
-
-    <p-key-value label="Start Time" :alternate="alternate">
-      <template #value>
-        <FlowRunStartTime :flow-run="flowRun" />
-      </template>
-    </p-key-value>
-
-    <p-key-value label="Duration" :alternate="alternate">
-      <template #value>
-        <DurationIconText :duration="flowRun.duration" />
-      </template>
-    </p-key-value>
-
     <p-key-value label="Run Count" :value="flowRun.runCount ?? 0" :alternate="alternate" />
 
     <p-key-value label="Created" :value="formatDateTimeNumeric(flowRun.created)" :alternate="alternate" />
@@ -96,53 +47,18 @@
 
 <script lang="ts" setup>
   import { PKeyValue, PTags } from '@prefecthq/prefect-design'
-  import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
-  import { WorkQueueIconText, FlowRunIconText, WorkQueueStatusIcon, FlowRunStartTime, FlowIconText, DurationIconText, DeploymentIconText } from '@/components'
-  import { useWorkspaceApi, useCan } from '@/compositions'
-  import { useDeployment } from '@/compositions/useDeployment'
   import { FlowRun } from '@/models/FlowRun'
-  import { isDefined } from '@/utilities'
   import { formatDateTimeNumeric } from '@/utilities/dates'
-
-  const api = useWorkspaceApi()
 
   const props = defineProps<{
     flowRun: FlowRun,
     alternate?: boolean,
   }>()
 
-  const can = useCan()
   const heading = computed(() => props.alternate ? 6 : 5)
 
-  const deploymentId = computed(() => props.flowRun.deploymentId)
-  const { deployment } = useDeployment(deploymentId)
-  const showDeployment = computed(() => can.read.deployment && isDefined(deployment.value))
   const stateMessage = computed(() => props.flowRun.state?.message)
-
-  const flowRunFilter = computed<Parameters<typeof api.flowRuns.getFlowRuns> | null>(() => {
-    if (props.flowRun.parentTaskRunId) {
-      return [
-        {
-          taskRuns: {
-            id: [props.flowRun.parentTaskRunId],
-          },
-        },
-      ]
-    }
-    return null
-  })
-
-  const parentFlowRunListSubscription = useSubscriptionWithDependencies(api.flowRuns.getFlowRuns, flowRunFilter)
-  const parentFlowRunList = computed(() => parentFlowRunListSubscription.response ?? [])
-
-  const parentFlowRunId = computed(() => {
-    if (!parentFlowRunList.value.length) {
-      return
-    }
-    const [value] = parentFlowRunList.value
-    return value.id
-  })
 </script>
 
 <style>

--- a/src/components/FlowRunListItem.vue
+++ b/src/components/FlowRunListItem.vue
@@ -9,31 +9,17 @@
         <FlowRunStartTime :flow-run="flowRun" />
         <DurationIconText :duration="flowRun.duration" />
         <template v-if="visible && flowRun.stateType !== 'scheduled'">
-          <FlowRunTaskCount :tasks-count="taskRunsCount">
-            <template #default="{ count }">
-              {{ count }} task {{ toPluralString('run', count) }}
-            </template>
-          </FlowRunTaskCount>
+          <FlowRunTaskCount :tasks-count="taskRunsCount" />
         </template>
       </template>
       <template v-if="visible && (flowRun.deploymentId || flowRun.workQueueName)" #relationships>
-        <template v-if="flowRun.deploymentId && deployment?.name">
-          <div class="flow-run-list-item__relation">
-            <span>Deployment</span> <DeploymentIconText :deployment-id="flowRun.deploymentId" />
-          </div>
-        </template>
-
-        <template v-if="flowRun.workPoolName">
-          <div class="flow-run-list-item__relation">
-            <span>Work Pool</span> <WorkPoolIconText :work-pool-name="flowRun.workPoolName" />
-          </div>
-        </template>
-
-        <template v-if="flowRun.workQueueName">
-          <div class="flow-run-list-item__relation">
-            <span>Work Queue</span> <WorkQueueIconText :work-queue-name="flowRun.workQueueName" :work-pool-name="flowRun.workPoolName" />
-          </div>
-        </template>
+        <FlowRunDeployment v-if="flowRun.deploymentId" :deployment-id="flowRun.deploymentId" />
+        <FlowRunWorkPool v-if="flowRun.workPoolName" :work-pool-name="flowRun.workPoolName" />
+        <FlowRunWorkQueue
+          v-if="flowRun.workQueueName"
+          :work-queue-name="flowRun.workQueueName"
+          :work-pool-name="flowRun.workPoolName"
+        />
       </template>
     </StateListItem>
   </div>
@@ -43,19 +29,17 @@
   import { CheckboxModel } from '@prefecthq/prefect-design'
   import { useIntersectionObserver } from '@prefecthq/vue-compositions'
   import { computed, onMounted, ref } from 'vue'
-  import DeploymentIconText from '@/components/DeploymentIconText.vue'
   import DurationIconText from '@/components/DurationIconText.vue'
   import FlowRunBreadCrumbs from '@/components/FlowRunBreadCrumbs.vue'
+  import FlowRunDeployment from '@/components/FlowRunDeployment.vue'
   import FlowRunStartTime from '@/components/FlowRunStartTime.vue'
   import FlowRunTaskCount from '@/components/FlowRunTaskCount.vue'
+  import FlowRunWorkPool from '@/components/FlowRunWorkPool.vue'
+  import FlowRunWorkQueue from '@/components/FlowRunWorkQueue.vue'
   import StateBadge from '@/components/StateBadge.vue'
   import StateListItem from '@/components/StateListItem.vue'
-  import WorkPoolIconText from '@/components/WorkPoolIconText.vue'
-  import WorkQueueIconText from '@/components/WorkQueueIconText.vue'
   import { useTaskRunsCount } from '@/compositions'
-  import { useDeployment } from '@/compositions/useDeployment'
   import { FlowRun } from '@/models/FlowRun'
-  import { toPluralString } from '@/utilities'
 
   const props = defineProps<{
     selected: CheckboxModel | null,
@@ -82,9 +66,6 @@
 
   const flowRunId = computed(() => props.flowRun.id)
   const { taskRunsCount } = useTaskRunsCount(flowRunId)
-
-  const deploymentId = computed(() => props.flowRun.deploymentId)
-  const { deployment } = useDeployment(deploymentId)
 
   const visible = ref(false)
   const el = ref<HTMLDivElement>()

--- a/src/components/FlowRunTaskCount.vue
+++ b/src/components/FlowRunTaskCount.vue
@@ -1,19 +1,20 @@
 <template>
-  <p-icon-text v-if="tasksCount" icon="Task" class="flow-run-task-count">
-    <slot v-bind="{ count }">
-      {{ label }}
-    </slot>
+  <p-icon-text icon="Task" class="flow-run-task-count">
+    {{ label }}
   </p-icon-text>
 </template>
 
 <script lang="ts" setup>
   import { computed } from 'vue'
+  import { toPluralString } from '@/utilities'
 
   const props = defineProps<{
     tasksCount: number | undefined,
   }>()
 
-  const count = computed(() => props.tasksCount)
-
-  const label = computed(() => !count.value || count.value == 0 ? 'None' : count.value)
+  const label = computed(() => {
+    return props.tasksCount && props.tasksCount > 0
+      ? `${props.tasksCount} task ${toPluralString('run', props.tasksCount)}`
+      : 'None'
+  })
 </script>

--- a/src/components/FlowRunWorkPool.vue
+++ b/src/components/FlowRunWorkPool.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="flow-run-list-item__relation">
+    <span>Work Pool</span> <WorkPoolIconText :work-pool-name="workPoolName" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import WorkPoolIconText from '@/components/WorkPoolIconText.vue'
+
+  defineProps<{
+    workPoolName: string,
+  }>()
+</script>

--- a/src/components/FlowRunWorkQueue.vue
+++ b/src/components/FlowRunWorkQueue.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="flow-run-list-item__relation">
+    <span>Work Queue</span> <WorkQueueIconText :work-queue-name="workQueueName" :work-pool-name="workPoolName" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { defineProps } from 'vue'
+  import WorkQueueIconText from '@/components/WorkQueueIconText.vue'
+
+  defineProps<{
+    workQueueName: string,
+    workPoolName?: string | null,
+  }>()
+</script>

--- a/src/components/PageHeadingFlowRun.vue
+++ b/src/components/PageHeadingFlowRun.vue
@@ -1,26 +1,77 @@
 <template>
-  <page-heading v-if="flowRun" class="page-heading-flow-run" :crumbs="crumbs">
-    <template #after-crumbs>
-      <StateBadge :state="flowRun.state" />
-    </template>
-    <template #actions>
-      <template v-if="media.sm">
-        <FlowRunPauseButton :flow-run="flowRun" />
-        <FlowRunResumeButton :flow-run="flowRun" />
-        <FlowRunRetryButton :flow-run="flowRun" />
-        <FlowRunCancelButton :flow-run="flowRun" />
+  <div v-if="flowRun" class="page-heading-flow-run">
+    <page-heading class="page-heading-flow-run__heading" :crumbs="crumbs">
+      <template #after-crumbs>
+        <div v-if="flowRun.tags && flowRun.tags.length > 0" class="state-list-item__tags">
+          <p-tag-wrapper v-bind="{ tags: flowRun.tags }" />
+        </div>
       </template>
-      <FlowRunMenu :flow-run-id="flowRun.id" :show-all="!media.sm" @delete="emit('delete')" />
-    </template>
-  </page-heading>
+      <template #actions>
+        <template v-if="media.sm">
+          <FlowRunPauseButton :flow-run="flowRun" />
+          <FlowRunResumeButton :flow-run="flowRun" />
+          <FlowRunRetryButton :flow-run="flowRun" />
+          <FlowRunCancelButton :flow-run="flowRun" />
+        </template>
+        <FlowRunMenu :flow-run-id="flowRun.id" :show-all="!media.sm" @delete="emit('delete')" />
+      </template>
+    </page-heading>
+    <div class="page-heading-flow-run__meta">
+      <StateBadge :state="flowRun.state" />
+      <FlowRunStartTime :flow-run="flowRun" />
+      <DurationIconText :duration="flowRun.duration" />
+      <template v-if="!isPending">
+        <FlowRunTaskCount :tasks-count="taskRunsCount">
+          <template #default="{ count }">
+            {{ count }} task {{ toPluralString('run', count) }}
+          </template>
+        </FlowRunTaskCount>
+      </template>
+    </div>
+    <div class="page-heading-flow-run__relationships">
+      <template v-if="flowRun.deploymentId && deployment?.name">
+        <div class="flow-run-list-item__relation">
+          <span>Deployment</span> <DeploymentIconText :deployment-id="flowRun.deploymentId" />
+        </div>
+      </template>
+
+      <template v-if="flowRun.workPoolName">
+        <div class="flow-run-list-item__relation">
+          <span>Work Pool</span> <WorkPoolIconText :work-pool-name="flowRun.workPoolName" />
+        </div>
+      </template>
+
+      <template v-if="flowRun.workQueueName">
+        <div class="flow-run-list-item__relation">
+          <span>Work Queue</span> <WorkQueueIconText :work-queue-name="flowRun.workQueueName" :work-pool-name="flowRun.workPoolName" />
+        </div>
+      </template>
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
   import { media } from '@prefecthq/prefect-design'
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
-  import { StateBadge, PageHeading, FlowRunRetryButton, FlowRunResumeButton, FlowRunCancelButton, FlowRunPauseButton, FlowRunMenu } from '@/components'
-  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import {
+    StateBadge,
+    PageHeading,
+    FlowRunRetryButton,
+    FlowRunResumeButton,
+    FlowRunCancelButton,
+    FlowRunPauseButton,
+    FlowRunMenu,
+    FlowRunStartTime,
+    DurationIconText
+  } from '@/components'
+  import DeploymentIconText from '@/components/DeploymentIconText.vue'
+  import FlowRunTaskCount from '@/components/FlowRunTaskCount.vue'
+  import WorkPoolIconText from '@/components/WorkPoolIconText.vue'
+  import WorkQueueIconText from '@/components/WorkQueueIconText.vue'
+  import { useDeployment, useTaskRunsCount, useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import { isPendingStateType } from '@/models'
+  import { toPluralString } from '@/utilities'
 
   const props = defineProps<{
     flowRunId: string,
@@ -43,4 +94,50 @@
   const flowRunId = computed(() => props.flowRunId)
   const flowRunSubscription = useSubscription(api.flowRuns.getFlowRun, [flowRunId], { interval: 30000 })
   const flowRun = computed(() => flowRunSubscription.response)
+
+  const isPending = computed(() => flowRun.value?.stateType ? isPendingStateType(flowRun.value.stateType) : true)
+  const { taskRunsCount } = useTaskRunsCount(flowRunId)
+
+  const deploymentId = computed(() => flowRun.value?.deploymentId)
+  const { deployment } = useDeployment(deploymentId)
 </script>
+
+<style>
+.page-heading-flow-run { @apply
+  flex
+  flex-col
+  gap-2
+}
+
+.page-heading-flow-run__heading {
+  display: grid;
+  grid-template-columns: 1fr auto;
+}
+
+.page-heading-flow-run__meta { @apply
+  flex
+  flex-col
+  items-start
+  gap-2
+  whitespace-nowrap
+  mr-1
+  md:flex-row
+  md:flex-wrap
+  md:items-center
+}
+
+.page-heading-flow-run__relationships { @apply
+  flex
+  flex-col
+  items-start
+  text-xs
+  font-medium
+  gap-2
+  whitespace-nowrap
+  mr-1
+  md:items-center
+  md:flex-wrap
+  md:flex-row
+  md:gap-4
+}
+</style>

--- a/src/models/StateType.ts
+++ b/src/models/StateType.ts
@@ -16,6 +16,13 @@ export function isStateType(value: unknown): value is StateType {
   return typeof value === 'string' && stateType.includes(value as StateType)
 }
 
+export const pendingStateType = ['scheduled', 'pending']
+export type PendingStateType = typeof pendingStateType[number]
+
+export function isPendingStateType(value: unknown): value is PendingStateType {
+  return typeof value === 'string' && pendingStateType.includes(value as PendingStateType)
+}
+
 export const terminalStateType = [
   'completed',
   'cancelled',


### PR DESCRIPTION
Updates the FlowRunPageHeader to include top level meta details consistent with the FlowRunListItem. FlowRunDetails have also been updated to remove duplicate information.

Once this is deployed and updates are made in OSS and Nebula, the result will look like these examples:

A flow run has completed and has no worker/deployment/etc:
<img width="1495" alt="image" src="https://user-images.githubusercontent.com/6776415/232823779-69f7f509-d6be-4e25-9bf4-5f28f786c480.png">

A flow run has not ran yet:
<img width="1498" alt="image" src="https://user-images.githubusercontent.com/6776415/232823903-ba06b7e6-167c-41d0-8578-40034f73347f.png">
