### PR TITLE
Updates retrieval of default values for schemas

### DIFF
--- a/src/components/WorkPoolBaseJobTemplateFormSection.vue
+++ b/src/components/WorkPoolBaseJobTemplateFormSection.vue
@@ -44,9 +44,9 @@
   import { computed, ref, watch } from 'vue'
   import { SchemaFormFieldsWithValues, BetaBadge, JsonInput } from '@/components'
   import { localization } from '@/localization'
-  import { mapper } from '@/services'
+  import { getSchemaDefaultValues, mapper } from '@/services'
   import { Schema, SchemaProperties, SchemaValues, WorkerBaseJobTemplate } from '@/types'
-  import { getSchemaDefaults, getSchemaWithoutDefaults, mapValues, stringify } from '@/utilities'
+  import { getSchemaWithoutDefaults, mapValues, stringify } from '@/utilities'
 
 
   const props = defineProps<{
@@ -85,7 +85,7 @@
   const variablesSchemaHasProperties = computed<boolean>(() => Object.keys(variablesSchemaProperties.value).length > 0)
   const currentDefaults = computed<SchemaValues>({
     get() {
-      return getSchemaDefaults(variablesSchema.value)
+      return getSchemaDefaultValues(variablesSchema.value)
     },
     set(values) {
       const newTemplate = {

--- a/src/services/schemas/properties/SchemaPropertyArray.ts
+++ b/src/services/schemas/properties/SchemaPropertyArray.ts
@@ -34,7 +34,7 @@ export class SchemaPropertyArray extends SchemaPropertyService {
       return ''
     }
 
-    return []
+    return this.property.default ?? []
   }
 
   protected request(value: SchemaValue): unknown {

--- a/src/services/schemas/properties/SchemaPropertyObject.ts
+++ b/src/services/schemas/properties/SchemaPropertyObject.ts
@@ -19,7 +19,7 @@ export class SchemaPropertyObject extends SchemaPropertyService {
 
   protected get default(): unknown {
     if (this.componentIs(JsonInput)) {
-      return stringifyUnknownJson(this.property.default) ?? ''
+      return stringifyUnknownJson(this.property.default) ?? null
     }
 
     return this.property.default ?? {}

--- a/src/services/schemas/properties/SchemaPropertyObject.ts
+++ b/src/services/schemas/properties/SchemaPropertyObject.ts
@@ -1,9 +1,10 @@
 import { JsonInput } from '@/components'
+import { InvalidSchemaValueError } from '@/models'
 import { schemaPropertyServiceFactory } from '@/services/schemas/properties'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue, isSchemaValues, SchemaValues } from '@/types/schemas'
-import { isEmptyObject, mapValues } from '@/utilities'
+import { isEmptyObject, isNullish, mapValues } from '@/utilities'
 import { parseUnknownJson, stringifyUnknownJson } from '@/utilities/json'
 
 export class SchemaPropertyObject extends SchemaPropertyService {
@@ -19,9 +20,11 @@ export class SchemaPropertyObject extends SchemaPropertyService {
   protected get default(): unknown {
     // some object properties don't have specific properties and a JsonInput is used
     if (!this.has('properties')) {
-      return ''
+      if (this.has('default')) {
+        return this.property.default
+      }
+      return null
     }
-
     return {}
   }
 
@@ -51,6 +54,9 @@ export class SchemaPropertyObject extends SchemaPropertyService {
   protected response(value: SchemaValue): unknown {
     // if there are no nested properties a JsonInput is used
     if (!this.has('properties')) {
+      if (isNullish(value)) {
+        throw new InvalidSchemaValueError()
+      }
       return stringifyUnknownJson(value)
     }
 

--- a/src/services/schemas/properties/SchemaPropertyService.ts
+++ b/src/services/schemas/properties/SchemaPropertyService.ts
@@ -75,7 +75,6 @@ export abstract class SchemaPropertyService {
 
   public mapRequestValue(value: SchemaValue): SchemaValue | undefined {
     const mappedValue = this.request(value)
-
     if (this.isDefaultValue(mappedValue)) {
       return undefined
     }

--- a/src/services/schemas/properties/SchemaPropertyService.ts
+++ b/src/services/schemas/properties/SchemaPropertyService.ts
@@ -75,6 +75,7 @@ export abstract class SchemaPropertyService {
 
   public mapRequestValue(value: SchemaValue): SchemaValue | undefined {
     const mappedValue = this.request(value)
+
     if (this.isDefaultValue(mappedValue)) {
       return undefined
     }

--- a/src/services/schemas/properties/SchemaPropertyString.ts
+++ b/src/services/schemas/properties/SchemaPropertyString.ts
@@ -62,7 +62,7 @@ export class SchemaPropertyString extends SchemaPropertyService {
       case 'time-delta':
         return null
       default:
-        return ''
+        return this.property.default ?? ''
     }
   }
 

--- a/src/services/schemas/properties/SchemaPropertyString.ts
+++ b/src/services/schemas/properties/SchemaPropertyString.ts
@@ -1,6 +1,7 @@
 import { PNumberInput, PSelect, PTextInput } from '@prefecthq/prefect-design'
 import DateInput from '@/components/DateInput.vue'
 import JsonInput from '@/components/JsonInput.vue'
+import { isString, mapper, stringifyUnknownJson } from '@/index'
 import { InvalidSchemaValueError } from '@/models'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
@@ -10,6 +11,48 @@ import { dateFunctions } from '@/utilities/timezone'
 import { isEmail, isJson, ValidationMethodFactory } from '@/utilities/validation'
 
 export class SchemaPropertyString extends SchemaPropertyService {
+
+  protected override get component(): SchemaPropertyComponentWithProps {
+    if (this.has('enum')) {
+      return this.withProps(PSelect, {
+        options: this.getSelectOptions(),
+      })
+    }
+
+    switch (this.property.format) {
+      case 'date':
+        return this.withProps(DateInput)
+      case 'date-time':
+        return this.withProps(DateInput, { showTime: true })
+      case 'json-string':
+        return this.withProps(JsonInput)
+      case 'time-delta':
+        return this.withProps(PNumberInput)
+      default:
+        return this.withProps(PTextInput)
+    }
+  }
+
+  protected override get default(): SchemaValue {
+    if (this.componentIs(PSelect)) {
+      return this.property.default ?? null
+    }
+
+    if (this.componentIs(DateInput)) {
+      return isString(this.property.default) ? new Date(this.property.default) : null
+    }
+
+    if (this.componentIs(JsonInput)) {
+      return stringifyUnknownJson(this.property.default) ?? ''
+    }
+
+    if (this.componentIs(PNumberInput)) {
+      return this.property.default ?? null
+    }
+
+    return this.property.default ?? ''
+  }
+
   protected get validators(): ValidationMethodFactory[] {
     const { format } = this.property
 
@@ -47,43 +90,6 @@ export class SchemaPropertyString extends SchemaPropertyService {
         return this.responseDateTimeValue(value)
       default:
         return value
-    }
-  }
-
-  protected override get default(): SchemaValue {
-    // default value for a PSelect
-    if (this.property.enum) {
-      return this.property.default ?? null
-    }
-
-    switch (this.property.format) {
-      case 'date':
-      case 'date-time':
-      case 'time-delta':
-        return null
-      default:
-        return this.property.default ?? ''
-    }
-  }
-
-  protected override get component(): SchemaPropertyComponentWithProps {
-    if (this.has('enum')) {
-      return this.withProps(PSelect, {
-        options: this.getSelectOptions(),
-      })
-    }
-
-    switch (this.property.format) {
-      case 'date':
-        return this.withProps(DateInput)
-      case 'date-time':
-        return this.withProps(DateInput, { showTime: true })
-      case 'json-string':
-        return this.withProps(JsonInput)
-      case 'time-delta':
-        return this.withProps(PNumberInput)
-      default:
-        return this.withProps(PTextInput)
     }
   }
 


### PR DESCRIPTION
Default values were not showing the `WorkPoolDetails` component despite being present in the base job template. This PR updates the Schema Property services to pull default values from their respective properties.