### PR TITLE
Chore: Remove vee-validate from schema forms [WIP]

### DIFF
--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -76,7 +76,7 @@
       <p-button inset @click="cancel">
         Cancel
       </p-button>
-      <p-button type="submit">
+      <p-button :loading="pending" type="submit">
         Save
       </p-button>
     </template>
@@ -150,7 +150,7 @@
       formValues = {
         ...formValues,
         parameters: parameters.value,
-        schema: parameterOpenApiSchema.value,
+        schema: props.deployment.parameterOpenApiSchema,
       }
     }
 
@@ -158,6 +158,8 @@
   })
 
   const submit = async (): Promise<void> => {
+    console.log('submitting', values.value)
+    await new Promise(resolve => setTimeout(resolve, 5000))
     const valid = await validate()
 
     if (!valid) {

--- a/src/components/JsonInput.vue
+++ b/src/components/JsonInput.vue
@@ -17,7 +17,7 @@
   import { stringify } from '@/utilities/json'
 
   const props = defineProps<{
-    modelValue: string | undefined,
+    modelValue: string | Record<string, unknown> | undefined,
     showFormatButton?: boolean,
   }>()
 
@@ -27,6 +27,10 @@
 
   const internalValue = computed({
     get() {
+      if (typeof props.modelValue === 'object') {
+        return stringify(props.modelValue)
+      }
+
       return props.modelValue ?? ''
     },
     set(val: string) {

--- a/src/components/SchemaForm.vue
+++ b/src/components/SchemaForm.vue
@@ -1,19 +1,21 @@
 <template>
   <p-form @submit="submit">
-    <SchemaFormFields :schema="schema" />
+    <SchemaFormFields v-model="internalValue" :schema="schema" />
 
     <template #footer>
-      <p-button type="submit">
-        Save
-      </p-button>
+      <slot name="footer">
+        <p-button type="submit">
+          Save
+        </p-button>
+      </slot>
     </template>
   </p-form>
 </template>
 
 <script lang="ts" setup>
+  import { useValidationObserver } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
   import SchemaFormFields from '@/components/SchemaFormFields.vue'
-  import { useReactiveForm } from '@/compositions'
   import { Schema, SchemaValues } from '@/types/schemas'
 
   const props = defineProps<{
@@ -34,6 +36,12 @@
     },
   })
 
-  const { handleSubmit } = useReactiveForm(internalValue, { initialValues: { ...props.modelValue } })
-  const submit = handleSubmit(values => emit('submit', values))
+  const { validate } = useValidationObserver()
+
+  const submit = async (): Promise<void> => {
+    const valid = await validate()
+    if (valid) {
+      emit('submit', internalValue.value)
+    }
+  }
 </script>

--- a/src/components/SchemaFormFields.vue
+++ b/src/components/SchemaFormFields.vue
@@ -1,7 +1,7 @@
 <template>
   <p-content class="schema-form-fields">
     <template v-for="[propertyKey, prop] in sortedSchemaProperties" :key="getPropertyKey(propertyKey)">
-      <SchemaFormProperty :prop-key="getPropertyKey(propertyKey)" :property="prop!" />
+      <SchemaFormProperty v-model="internalValue[propertyKey]" :prop-key="getPropertyKey(propertyKey)" :property="prop!" />
     </template>
   </p-content>
 </template>
@@ -9,12 +9,26 @@
 <script lang="ts" setup>
   import { computed } from 'vue'
   import SchemaFormProperty from '@/components/SchemaFormProperty.vue'
-  import { Schema } from '@/types/schemas'
+  import { Schema, SchemaValues } from '@/types/schemas'
 
   const props = defineProps<{
+    modelValue?: SchemaValues,
     schema: Schema,
     property?: string,
   }>()
+
+  const emit = defineEmits<{
+    (event: 'update:modelValue', value: SchemaValues): void,
+  }>()
+
+  const internalValue = computed({
+    get() {
+      return props.modelValue ?? {}
+    },
+    set(val) {
+      emit('update:modelValue', val)
+    },
+  })
 
   function getPropertyKey(propertyKey: string): string {
     if (props.property) {

--- a/src/components/SchemaFormProperties.vue
+++ b/src/components/SchemaFormProperties.vue
@@ -2,7 +2,7 @@
   <p-label :label="label" :description="property.description" class="schema-form-properties">
     <p-content class="schema-form-properties__fields">
       <template v-for="(prop, key) in property.properties" :key="key">
-        <SchemaFormProperty :property="prop!" :prop-key="`${propKey}.${key}`" />
+        <SchemaFormProperty v-model="internalValue[key]" :property="prop!" :prop-key="`${propKey}.${key}`" />
       </template>
     </p-content>
   </p-label>
@@ -11,12 +11,26 @@
 <script lang="ts" setup>
   import { computed } from 'vue'
   import SchemaFormProperty from '@/components/SchemaFormProperty.vue'
-  import { SchemaProperty } from '@/types/schemas'
+  import { SchemaProperty, SchemaValues } from '@/types/schemas'
 
   const props = defineProps<{
+    modelValue?: SchemaValues,
     propKey: string,
     property: SchemaProperty,
   }>()
+
+  const emit = defineEmits<{
+    (event: 'update:modelValue', value: SchemaValues): void,
+  }>()
+
+  const internalValue = computed({
+    get() {
+      return props.modelValue ?? {}
+    },
+    set(val) {
+      emit('update:modelValue', val)
+    },
+  })
 
   const label = computed(() => props.property.meta?.required ? props.property.title : `${props.property.title} (Optional)`)
 </script>

--- a/src/components/SchemaFormProperty.vue
+++ b/src/components/SchemaFormProperty.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="schema-form-property">
-    <component :is="is" v-bind="{ property, propKey }" />
+    <component :is="is" v-model="internalValue" v-bind="{ property, propKey }" />
   </div>
 </template>
 
@@ -10,12 +10,26 @@
   import SchemaFormProperties from '@/components/SchemaFormProperties.vue'
   import SchemaFormPropertyAllOf from '@/components/SchemaFormPropertyAllOf.vue'
   import SchemaFormPropertyAnyOf from '@/components/SchemaFormPropertyAnyOf.vue'
-  import { SchemaProperty, schemaHas } from '@/types/schemas'
+  import { SchemaProperty, SchemaValue, schemaHas } from '@/types/schemas'
 
   const props = defineProps<{
+    modelValue?: SchemaValue,
     propKey: string,
     property: SchemaProperty,
   }>()
+
+  const emit = defineEmits<{
+    (event: 'update:modelValue', value: SchemaValue): void,
+  }>()
+
+  const internalValue = computed({
+    get() {
+      return props.modelValue ?? {}
+    },
+    set(val) {
+      emit('update:modelValue', val)
+    },
+  })
 
   const is = computed(() => {
     if (props.property.type === 'block') {

--- a/src/components/SchemaFormPropertyAllOf.vue
+++ b/src/components/SchemaFormPropertyAllOf.vue
@@ -1,17 +1,32 @@
 <template>
   <p-label :label="property.title" :description="property.description" class="schema-form-property-all-of">
     <template v-for="(prop, key) in property.allOf" :key="key">
-      <SchemaFormProperty :prop-key="propKey" :property="prop" />
+      <SchemaFormProperty v-model="internalValue" :prop-key="propKey" :property="prop" />
     </template>
   </p-label>
 </template>
 
 <script lang="ts" setup>
+  import { computed } from 'vue'
   import SchemaFormProperty from '@/components/SchemaFormProperty.vue'
-  import { SchemaPropertyAllOf } from '@/types/schemas'
+  import { SchemaPropertyAllOf, SchemaValues } from '@/types/schemas'
 
-  defineProps<{
+  const props = defineProps<{
+    modelValue?: SchemaValues,
     propKey: string,
     property: SchemaPropertyAllOf,
   }>()
+
+  const emit = defineEmits<{
+    (event: 'update:modelValue', value: SchemaValues): void,
+  }>()
+
+  const internalValue = computed({
+    get() {
+      return props.modelValue ?? {}
+    },
+    set(val) {
+      emit('update:modelValue', val)
+    },
+  })
 </script>

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -155,5 +155,6 @@ export const en = {
     deprecatedWorkQueue: 'This work queue uses a deprecated tag-based approach to matching flow runs; it will continue to work but you can\'t modify it',
     deploymentMissingWorkQueue: 'This deployment doesn\'t have an associated work queue; runs will be scheduled but won\'t be picked up by your agents',
     taskInput: 'Task inputs show parameter keys and can also show task run relationships.',
+    description: 'Description',
   },
 }


### PR DESCRIPTION
This PR seeks to remove vee-validate from schema logic by moving to a `modelValue` model instead. 

This is a work in progress and is a potentially breaking change for several of our schema-generated forms.