### PR TITLE
Enhancement: Use p-textarea instead of p-text-input for strings in schemas 

### DIFF
--- a/src/services/schemas/properties/SchemaPropertyString.ts
+++ b/src/services/schemas/properties/SchemaPropertyString.ts
@@ -1,4 +1,4 @@
-import { PNumberInput, PSelect, PTextInput } from '@prefecthq/prefect-design'
+import { PNumberInput, PSelect, PTextarea } from '@prefecthq/prefect-design'
 import DateInput from '@/components/DateInput.vue'
 import JsonInput from '@/components/JsonInput.vue'
 import { isString, mapper, stringifyUnknownJson } from '@/index'
@@ -29,7 +29,7 @@ export class SchemaPropertyString extends SchemaPropertyService {
       case 'time-delta':
         return this.withProps(PNumberInput)
       default:
-        return this.withProps(PTextInput)
+        return this.withProps(PTextarea)
     }
   }
 

--- a/src/services/schemas/properties/SchemaPropertyString.ts
+++ b/src/services/schemas/properties/SchemaPropertyString.ts
@@ -31,7 +31,6 @@ export class SchemaPropertyString extends SchemaPropertyService {
       case 'password':
         return this.withProps(PTextInput)
       default:
-        console.log('format', this.property.format)
         return this.withProps(PTextarea)
     }
   }

--- a/src/services/schemas/properties/SchemaPropertyString.ts
+++ b/src/services/schemas/properties/SchemaPropertyString.ts
@@ -1,4 +1,4 @@
-import { PNumberInput, PSelect, PTextarea } from '@prefecthq/prefect-design'
+import { PNumberInput, PSelect, PTextarea, PTextInput } from '@prefecthq/prefect-design'
 import DateInput from '@/components/DateInput.vue'
 import JsonInput from '@/components/JsonInput.vue'
 import { isString, mapper, stringifyUnknownJson } from '@/index'
@@ -28,7 +28,10 @@ export class SchemaPropertyString extends SchemaPropertyService {
         return this.withProps(JsonInput)
       case 'time-delta':
         return this.withProps(PNumberInput)
+      case 'password':
+        return this.withProps(PTextInput)
       default:
+        console.log('format', this.property.format)
         return this.withProps(PTextarea)
     }
   }


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/8447

Gives a bigger input box to better handle larger strings

After:

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/40272060/233756841-f8e90cc1-c3b4-4190-9697-0b1cf9955b49.png">

Before:

<img width="554" alt="image" src="https://user-images.githubusercontent.com/40272060/233756853-34194700-d988-424e-ad14-2edd01b42dde.png">
