### PR TITLE
Remove popout from flow run timeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@prefecthq/prefect-ui-library",
             "version": "1.5.4",
             "dependencies": {
-                "@prefecthq/graphs": "1.0.6",
+                "@prefecthq/graphs": "1.0.7",
                 "@prefecthq/radar": "0.0.19",
                 "@types/lodash.isequal": "4.5.6",
                 "axios": "0.27.2",
@@ -971,9 +971,9 @@
             }
         },
         "node_modules/@prefecthq/graphs": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-1.0.6.tgz",
-            "integrity": "sha512-hTm80K6hJsIpk9g8OCXNymOD+1Nmc3RqiuTPJXnBOi3DR+g4hphfGm2hrQeL+1xhU2cUY3FUFgd3QN61dP75GA==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-1.0.7.tgz",
+            "integrity": "sha512-iUzKOuK8SMQOwD+pEyXNS4EL1MT7MVvTU5PL98+b80iRhV7a75tcIRwC1/NPJiqfYTy+jCjp5yBDmDLF77bujQ==",
             "dependencies": {
                 "@pixi-essentials/cull": "^1.1.0",
                 "@prefecthq/vue-compositions": "1.0.0",
@@ -7105,9 +7105,9 @@
             }
         },
         "@prefecthq/graphs": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-1.0.6.tgz",
-            "integrity": "sha512-hTm80K6hJsIpk9g8OCXNymOD+1Nmc3RqiuTPJXnBOi3DR+g4hphfGm2hrQeL+1xhU2cUY3FUFgd3QN61dP75GA==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-1.0.7.tgz",
+            "integrity": "sha512-iUzKOuK8SMQOwD+pEyXNS4EL1MT7MVvTU5PL98+b80iRhV7a75tcIRwC1/NPJiqfYTy+jCjp5yBDmDLF77bujQ==",
             "requires": {
                 "@pixi-essentials/cull": "^1.1.0",
                 "@prefecthq/vue-compositions": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
             },
             "peerDependencies": {
                 "@prefecthq/prefect-design": "^1.7.0",
-                "@prefecthq/vue-charts": "^0.4.0",
+                "@prefecthq/vue-charts": "^0.4.1",
                 "@prefecthq/vue-compositions": "^1.4.1",
                 "vee-validate": "^4.7.0",
                 "vue": "^3.2.45",
@@ -1065,9 +1065,9 @@
             }
         },
         "node_modules/@prefecthq/vue-charts": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-0.4.0.tgz",
-            "integrity": "sha512-czECFAwJzcAKd/OIggTdRIlB1vmRhzTwij+rj8pcJ/zeoCplumKuvFIKLeI9iUNnTAVObBLqYkIGdTzfLk4Zzw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-0.4.1.tgz",
+            "integrity": "sha512-+4nl0GynbQH5gyDBmUuJDnOtt4E0dG2/cvKIvLxJiGbupKKAWbHLz8vf5iQLVPn/50bJq8A8GzAQV30sGMJ+OA==",
             "peer": true,
             "dependencies": {
                 "@prefecthq/vue-compositions": "1.4.2",
@@ -7166,9 +7166,9 @@
             }
         },
         "@prefecthq/vue-charts": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-0.4.0.tgz",
-            "integrity": "sha512-czECFAwJzcAKd/OIggTdRIlB1vmRhzTwij+rj8pcJ/zeoCplumKuvFIKLeI9iUNnTAVObBLqYkIGdTzfLk4Zzw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-0.4.1.tgz",
+            "integrity": "sha512-+4nl0GynbQH5gyDBmUuJDnOtt4E0dG2/cvKIvLxJiGbupKKAWbHLz8vf5iQLVPn/50bJq8A8GzAQV30sGMJ+OA==",
             "peer": true,
             "requires": {
                 "@prefecthq/vue-compositions": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     },
     "peerDependencies": {
         "@prefecthq/prefect-design": "^1.7.0",
-        "@prefecthq/vue-charts": "^0.4.0",
+        "@prefecthq/vue-charts": "^0.4.1",
         "@prefecthq/vue-compositions": "^1.4.1",
         "vee-validate": "^4.7.0",
         "vue": "^3.2.45",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "vue-router": "^4.0.12"
     },
     "dependencies": {
-        "@prefecthq/graphs": "1.0.6",
+        "@prefecthq/graphs": "1.0.7",
         "@prefecthq/radar": "0.0.19",
         "@types/lodash.isequal": "4.5.6",
         "axios": "0.27.2",


### PR DESCRIPTION
This PR removes the popout from the flow run timeline. The `selectedNode` state will be managed by the parent now.
Also bumps the vue-charts dependency in prep for what I'll need in Nebula.

NOTE: Nebula and OSS will need fallowup PR's once this is merged. I won't merge it until I have those ready.