### PR TITLE
Enhancement: Schema / deployment form

### DIFF
--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -11,7 +11,15 @@
         </p-label>
 
         <p-label label="Description (Optional)" :state="descriptionState">
-          <p-code-input v-model="description" lang="markdown" show-line-numbers :state="descriptionState" />
+          <p-code-input
+            v-model="description"
+            class="deployment-form__description-input"
+            :min-lines="3"
+            lang="markdown"
+            show-line-numbers
+            :state="descriptionState"
+            :placeholder="localization.info.descriptionPlaceholder"
+          />
         </p-label>
 
         <p-label label="Work Pool (Optional)">
@@ -68,7 +76,13 @@
         {{ localization.info.infraOverrides }}
       </h3>
       <p-label label="Infrastructure Overrides (Optional)" :message="overrideErrorMessage" :state="overrideState">
-        <JsonInput v-model="infrastructureOverrides" show-format-button />
+        <JsonInput
+          v-model="infrastructureOverrides"
+          show-line-numbers
+          :min-lines="3"
+          class="deployment-form__infrastructure-overrides-input"
+          show-format-button
+        />
       </p-label>
     </p-content>
 
@@ -184,6 +198,13 @@
   flex
   gap-2
   items-center
+}
+
+.deployment-form__description-input,
+.deployment-form__infrastructure-overrides-input { @apply
+  min-h-[2.5rem]
+  resize-y
+  min-w-full
 }
 
 .deployment-form__schedule {

--- a/src/components/JsonInput.vue
+++ b/src/components/JsonInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-code-input v-model="internalValue" lang="json" class="json-input">
+  <p-code-input v-model="internalValue" lang="json" class="json-input" v-bind="{ showLineNumbers, minLines }">
     <template v-if="showFormatButton" #append>
       <p-button class="json-input__prettify-button" size="xs" @click="format">
         Format
@@ -17,8 +17,10 @@
   import { stringify } from '@/utilities/json'
 
   const props = defineProps<{
+    minLines?: number,
     modelValue: string | undefined,
     showFormatButton?: boolean,
+    showLineNumbers?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/SchemaFormInput.vue
+++ b/src/components/SchemaFormInput.vue
@@ -13,7 +13,7 @@
     </template>
 
     <template v-if="meta">
-      <component :is="meta.component" v-model="propValue" v-bind="{ ...meta.props, ...meta.attrs }" />
+      <component :is="meta.component" v-model="propValue" class="schema-form-input__component" v-bind="{ ...meta.props, ...meta.attrs }" />
     </template>
   </p-label>
 </template>
@@ -50,6 +50,13 @@
   grid
   gap-1
 }
+
+.schema-form-input__component { @apply
+  max-w-full
+  min-h-[2.5rem]
+  resize-y
+}
+
 .schema-form-input__description {
   overflow-wrap: anywhere;
 }

--- a/src/components/SchemaFormInput.vue
+++ b/src/components/SchemaFormInput.vue
@@ -51,7 +51,7 @@
   gap-1
 }
 
-.schema-form-input__component { @apply
+.schema-form-input__component .p-code-input { @apply
   max-w-full
   min-h-[2.5rem]
   resize-y

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -103,6 +103,7 @@ export const en = {
     artifact: 'Artifact',
     artifacts: 'Artifacts',
     addTagPlaceholder: 'Add tag (press enter to submit)',
+    descriptionPlaceholder: 'Add a description (supports Markdown)',
     parentFlowRun: 'Parent Flow Run',
     flow: 'Flow',
     searchByFlowName: 'Search by flow name',

--- a/src/services/schemas/properties/SchemaPropertyArray.ts
+++ b/src/services/schemas/properties/SchemaPropertyArray.ts
@@ -14,7 +14,7 @@ export class SchemaPropertyArray extends SchemaPropertyService {
       return this.withProps(PSelect, { options })
     }
 
-    return this.withProps(JsonInput)
+    return this.withProps(JsonInput, { showLineNumbers: true, minLines: 3 })
   }
 
   protected get default(): unknown {

--- a/src/services/schemas/properties/SchemaPropertyArray.ts
+++ b/src/services/schemas/properties/SchemaPropertyArray.ts
@@ -14,7 +14,7 @@ export class SchemaPropertyArray extends SchemaPropertyService {
       return this.withProps(PSelect, { options })
     }
 
-    return this.withProps(JsonInput, { showLineNumbers: true, minLines: 3 })
+    return this.withProps(JsonInput)
   }
 
   protected get default(): unknown {

--- a/src/services/schemas/properties/SchemaPropertyArray.ts
+++ b/src/services/schemas/properties/SchemaPropertyArray.ts
@@ -1,4 +1,4 @@
-import { PCombobox, PSelect } from '@prefecthq/prefect-design'
+import { PSelect } from '@prefecthq/prefect-design'
 import { JsonInput } from '@/components'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
@@ -11,19 +11,7 @@ export class SchemaPropertyArray extends SchemaPropertyService {
     const options = this.getSelectOptions()
 
     if (options.length) {
-      return this.withProps(PSelect, {
-        options: this.getSelectOptions(),
-      })
-    }
-
-    const itemType = this.property.items?.type
-
-    if (itemType === 'number' || itemType === 'string') {
-      return this.withProps(PCombobox, {
-        options: [],
-        allowUnknownValue: true,
-        placeholder: 'Enter value',
-      })
+      return this.withProps(PSelect, { options })
     }
 
     return this.withProps(JsonInput)
@@ -31,7 +19,7 @@ export class SchemaPropertyArray extends SchemaPropertyService {
 
   protected get default(): unknown {
     if (this.componentIs(JsonInput)) {
-      return ''
+      return stringifyUnknownJson(this.property.default ?? [])
     }
 
     return this.property.default ?? []

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -120,6 +120,8 @@ export function getSchemaPropertyComponentWithDefaultProps({ component, props }:
     case JsonInput:
       return schemaPropertyComponentWithProps(JsonInput, {
         showFormatButton: true,
+        showLineNumbers: true,
+        minLines: 3,
         ...props,
       })
     default:


### PR DESCRIPTION
This PR makes some minor improvements to deployment forms and fixes a few long standing issues with schemas. One bigish change is the removal of `PSelect` in list properties; this is to work around some incompatibilities between the component and the intent of list properties (in particular duplicate values and ordering)