### PR TITLE
Bugfix: Boolean schema property incorrect mapping when defaults match value

### DIFF
--- a/src/services/schemas/properties/SchemaPropertyBoolean.ts
+++ b/src/services/schemas/properties/SchemaPropertyBoolean.ts
@@ -2,11 +2,22 @@ import { PToggle } from '@prefecthq/prefect-design'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue } from '@/types/schemas'
+import { isNullish } from '@/utilities'
 
 export class SchemaPropertyBoolean extends SchemaPropertyService {
 
   protected get default(): unknown {
     return this.property.default ?? null
+  }
+
+  public mapRequestValue(value: SchemaValue): SchemaValue | undefined {
+    const mappedValue = this.request(value)
+
+    if (isNullish(mappedValue)) {
+      return undefined
+    }
+
+    return mappedValue
   }
 
   protected override get component(): SchemaPropertyComponentWithProps {


### PR DESCRIPTION
This PR overrides the request value mapper from the base schema property service class for boolean values; this will ensure that form toggles are respected even when they match the default in the schema (previously these were falling back to runtime values)