### PR TITLE
Bugfix: `anyOf` and `array` schema mapping

### DIFF
--- a/src/components/SchemaFormInput.vue
+++ b/src/components/SchemaFormInput.vue
@@ -42,7 +42,8 @@
   const isNullType = computed(() => props.property.type === 'null')
 
   const propKey = computed(() => props.property.type === 'block' ? `${props.propKey}.blockDocumentId` : props.propKey)
-  const { value: propValue, errorMessage, meta: state } = useField(propKey, meta.value?.validators)
+  const validators = computed(() => meta.value?.validators ?? [])
+  const { value: propValue, errorMessage, meta: state } = useField(propKey, validators)
 </script>
 
 <style>

--- a/src/services/schemas/properties/SchemaPropertyArray.ts
+++ b/src/services/schemas/properties/SchemaPropertyArray.ts
@@ -35,6 +35,10 @@ export class SchemaPropertyArray extends SchemaPropertyService {
 
   protected response(value: SchemaValue): unknown {
     if (this.componentIs(JsonInput)) {
+      if (typeof value === 'string') {
+        return value
+      }
+
       return stringifyUnknownJson(value)
     }
 

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -232,14 +232,10 @@ export function getSchemaValueDefinitionIndex(definitions: Schema[], value: Sche
     return definitions.findIndex(definition => definition.type === 'block')
   }
 
-  try {
-    const parsedValue = parseUnknownJson(value)
+  const parsedValue = parseUnknownJson(value)
 
-    if (isRecord(parsedValue) || Array.isArray(parsedValue)) {
-      return findObjectDefinitionIndex(definitions, parsedValue)
-    }
-  } catch {
-    // do nothing, use the raw value
+  if (isRecord(parsedValue) || Array.isArray(parsedValue)) {
+    return findObjectDefinitionIndex(definitions, parsedValue)
   }
 
   switch (typeof value) {

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -1,5 +1,6 @@
 import { de } from 'date-fns/locale'
 import { JsonInput } from '@/components'
+import { isRecord } from '@/index'
 import { isBlockDocumentReferenceValue, isBlockDocumentValue } from '@/models'
 import { schemaPropertyServiceFactory } from '@/services/schemas/properties'
 import { SchemaProperty, SchemaPropertyInputAttrs, Schema, SchemaValues, SchemaValue, schemaHas, SchemaPropertyAnyOf, SchemaPropertyAllOf } from '@/types/schemas'
@@ -231,15 +232,17 @@ export function getSchemaValueDefinitionIndex(definitions: Schema[], value: Sche
     return definitions.findIndex(definition => definition.type === 'block')
   }
 
-  let parsedValue = value
-
   try {
-    parsedValue = parseUnknownJson(value)
+    const parsedValue = parseUnknownJson(value)
+
+    if (isRecord(parsedValue) || Array.isArray(parsedValue)) {
+      return findObjectDefinitionIndex(definitions, parsedValue)
+    }
   } catch {
     // do nothing, use the raw value
   }
 
-  switch (typeof parsedValue) {
+  switch (typeof value) {
     case 'number':
       return definitions.findIndex(definition => definition.type == 'number' || definition.type === 'integer')
     case 'string':
@@ -247,7 +250,7 @@ export function getSchemaValueDefinitionIndex(definitions: Schema[], value: Sche
     case 'boolean':
       return definitions.findIndex(definition => definition.type == 'boolean')
     case 'object':
-      return findObjectDefinitionIndex(definitions, parsedValue ?? {})
+      return findObjectDefinitionIndex(definitions, value)
     default:
       return null
   }


### PR DESCRIPTION
This PR makes two important changes to the way array values are mapped in schemas:

1. The property array response mapper first checks if a value is already a JSON string before attempting to stringify it for use in code input components
2. Schemas attempt to parse a value when deciding which union property to display

There's still a bug here where validators for fieldsets in the union will apply to the incorrect member, but I'm working on that