### PR TITLE
Chore: Use utility for `isRunning` in FlowRunTimeline

### DIFF
--- a/src/components/FlowRunTimeline.vue
+++ b/src/components/FlowRunTimeline.vue
@@ -210,11 +210,8 @@
     }, 0)
   }
 
-  const isRunning = computed(() => {
-    return props.flowRun.state?.name.toLowerCase() === 'running'
-  })
-
   const api = useWorkspaceApi()
+  const isRunning = computed(() => isRunningStateType(props.flowRun.stateType))
   const interval = isRunningStateType(props.flowRun.stateType) ? { interval: 5000 } : undefined
 
   const graphSubscription = useSubscription(


### PR DESCRIPTION
# Description
Just some logic I noticed that we could use a utility for. 