### PR TITLE
Bugfix: Route filter should be passed to flow list items

### DIFF
--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -66,7 +66,7 @@
               v-model:selected="selected"
               :value="item.id"
               :flow="item"
-              :filter="props.filter"
+              :filter="routeFilter"
               :disabled="disabled"
               class="flow-list__flow"
               @update="handleUpdate"


### PR DESCRIPTION
The `FlowList` component was incorrectly passing just its base filter to its list items. This PR instead passes the route filter which includes the base filter and any additional user-supplied filters.