### PR TITLE
Bugfix: Fix use of model value in deployment parameters component

### DIFF
--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -155,7 +155,7 @@
 
   const { value: description, meta: descriptionState } = useField<string>('description')
   const { value: schedule } = useField<Schedule | null>('schedule')
-  const { value: parameters } = useField<SchemaValues | null>('parameters')
+  const { value: parameters } = useField<SchemaValues>('parameters')
   const { value: isScheduleActive } = useField<boolean>('isScheduleActive')
   const { value: workPoolName } = useField<string | null>('workPoolName')
   const { value: workQueueName } = useField<string | null>('workQueueName')

--- a/src/components/DeploymentParameters.vue
+++ b/src/components/DeploymentParameters.vue
@@ -12,6 +12,7 @@
 
   const props = defineProps<{
     deployment: Deployment,
+    modelValue: SchemaValues,
   }>()
 
   const emits = defineEmits<{
@@ -30,7 +31,7 @@
 
   const parameters = computed({
     get() {
-      const source = { values: props.deployment.parameters, schema: parameterOpenApiSchema.value }
+      const source = { values: props.modelValue, schema: parameterOpenApiSchema.value }
       return mapper.map('SchemaValuesResponse', source, 'SchemaValues')
     },
     set(value) {
@@ -38,3 +39,5 @@
     },
   })
 </script>
+
+

--- a/src/components/QuickRunParametersModal.vue
+++ b/src/components/QuickRunParametersModal.vue
@@ -69,7 +69,7 @@
     internalShowModal.value = false
   })
 
-  const { value: parameters } = useField<SchemaValues | null>('parameters')
+  const { value: parameters } = useField<SchemaValues>('parameters')
 
   async function createDeploymentFlowRun(deploymentId: string, value: DeploymentFlowRunCreate): Promise<void> {
     try {


### PR DESCRIPTION
Uses the prop parameters instead of deployment.parameters to set the values in the deployment form and flow run create form.  Fixes a bug introduced by #1407 which ignored values passed by the "copy to new run" button. 