### PR TITLE
Chore: Fix export in BatchProcessor that caused circular references

### DIFF
--- a/src/services/BatchProcessor/BatchProcessor.ts
+++ b/src/services/BatchProcessor/BatchProcessor.ts
@@ -1,4 +1,4 @@
-import { BatchLookupError } from '@/index'
+import { BatchLookupError } from '@/models/BatchLookupError'
 import { MaybePromise } from '@/types'
 
 export type BatchCallbackLookup<V, R> = (value: V) => MaybePromise<R>


### PR DESCRIPTION
# Description
Fixes the `cannot access "mocks" before initialization` error we were seeing in the demo app