### PR TITLE
BugFix: Deployment parameter overrides not showing up when creating a custom run

### DIFF
--- a/src/components/DeploymentCustomRunOverflowMenuItem.vue
+++ b/src/components/DeploymentCustomRunOverflowMenuItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <router-link :to="routes.deploymentFlowRunCreate(deploymentId)">
+  <router-link v-if="deployment" :to="routes.deploymentFlowRunCreate(deploymentId, deployment.rawParameters)">
     <p-overflow-menu-item>
       <slot>
         Custom run
@@ -9,11 +9,14 @@
 </template>
 
 <script lang="ts" setup>
-  import { useWorkspaceRoutes } from '@/compositions'
+  import { toRefs } from 'vue'
+  import { useDeployment, useWorkspaceRoutes } from '@/compositions'
 
-  defineProps<{
+  const props = defineProps<{
     deploymentId: string,
   }>()
 
+  const { deploymentId } = toRefs(props)
   const routes = useWorkspaceRoutes()
+  const { deployment } = useDeployment(deploymentId)
 </script>

--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -137,7 +137,7 @@
   const { handleSubmit, isSubmitting } = useForm<DeploymentEdit>({
     initialValues: {
       description: props.deployment.description,
-      parameters: props.deployment.parameters,
+      parameters: props.deployment.rawParameters,
       schedule: props.deployment.schedule,
       isScheduleActive: props.deployment.isScheduleActive,
       workPoolName: props.deployment.workPoolName,

--- a/src/components/DeploymentParameters.vue
+++ b/src/components/DeploymentParameters.vue
@@ -1,5 +1,5 @@
 <template>
-  <SchemaFormFieldsWithValues v-model:values="parameters" :schema="deployment.parameterOpenApiSchema" />
+  <SchemaFormFieldsWithValues v-model:values="parameters" :schema="parameterOpenApiSchema" />
 </template>
 
 <script setup lang="ts">
@@ -31,8 +31,7 @@
 
   const parameters = computed({
     get() {
-      const source = { values: props.modelValue, schema: parameterOpenApiSchema.value }
-      return mapper.map('SchemaValuesResponse', source, 'SchemaValues')
+      return props.modelValue
     },
     set(value) {
       emits('update:modelValue', value)

--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -106,7 +106,7 @@
 
   const props = defineProps<{
     deployment: Deployment,
-    // these are the unmapped SchemaValues
+    // these must be the unmapped SchemaValues
     parameters?: SchemaValues,
   }>()
 

--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -99,14 +99,15 @@
   import { TimezoneSelect, DateInput, DeploymentParameters } from '@/components'
   import { useForm } from '@/compositions/useForm'
   import { Deployment, DeploymentFlowRunCreate } from '@/models'
-  import { getSchemaDefaultValues, mapper, mocker } from '@/services'
+  import { getSchemaDefaultValues, mocker } from '@/services'
   import { SchemaValues } from '@/types/schemas'
   import { isRecord, parseUnknownJson, stringifyUnknownJson } from '@/utilities'
   import { fieldRules, isRequiredIf } from '@/utilities/validation'
 
   const props = defineProps<{
     deployment: Deployment,
-    parameters?: Deployment['parameters'],
+    // these are the unmapped SchemaValues
+    parameters?: SchemaValues,
   }>()
 
   const generateRandomName = (): string => {
@@ -133,9 +134,8 @@
 
   const rawParameters = computed(() => {
     const schemaDefaults = getSchemaDefaultValues(props.deployment.parameterOpenApiSchema)
-    const unmapped = mapper.map('SchemaValues', { schema: props.deployment.parameterOpenApiSchema, values: parameters.value }, 'SchemaValuesRequest')
 
-    return merge(schemaDefaults, unmapped)
+    return merge(schemaDefaults, props.parameters)
   })
 
   const { handleSubmit } = useForm<DeploymentFlowRunCreate>({

--- a/src/components/QuickRunParametersModal.vue
+++ b/src/components/QuickRunParametersModal.vue
@@ -43,7 +43,7 @@
 
   const { handleSubmit } = useForm<DeploymentFlowRunCreate>({
     initialValues: {
-      parameters: props.deployment.parameters,
+      parameters: props.deployment.rawParameters,
       schema: props.deployment.parameterOpenApiSchema,
     },
   })


### PR DESCRIPTION
# Description
Part of the fix for https://github.com/PrefectHQ/prefect/issues/9534

Adds deployment parameters to the url when creating a custom run from the deployment menu. Fixes the `DeploymentParameters` component implementation where certain values (like dates) would revert to default values because of being mapped multiple times. 