### PR TITLE
BugFix: Fix `useStorage` composition destroying the storage context

### DIFF
--- a/src/services/storage/useStorage.ts
+++ b/src/services/storage/useStorage.ts
@@ -42,10 +42,10 @@ export function useStorage<T extends StorageItem>(storage: Storage<T>): () => Us
     }
 
     return {
-      add: storage.add,
-      addAll: storage.addAll,
-      remove: storage.remove,
-      removeAll: storage.removeAll,
+      add: (value: T) => storage.add(value),
+      addAll: (values: T[]) => storage.addAll(values),
+      remove: (id: string) => storage.remove(id),
+      removeAll: (ids: string[]) => storage.removeAll(ids),
       get,
       getAll,
     }


### PR DESCRIPTION
# Description
I noticed some errors around storage on the flow run page. They were caused by returning the storage methods directly from the composition rather than wrapping them in arrow function to preserve context. 