### PR TITLE
Enhancement: Show disabled cancel button for runs not created by a deployment

### DIFF
--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -175,5 +175,6 @@ export const en = {
     taskInput: 'Task inputs show parameter keys and can also show task run relationships.',
     workPoolInfrastructureConfigurationInstructions: 'Below you can configure workers\' behavior when executing flow runs from this work pool. You can use the editor in the **Advanced** section to modify the existing configuration options if you need additional configuration options.\nIf you don\'t need to change the default behavior, hit **Create** to create your work pool!',
     workPoolInfrastructureConfigurationAgent: 'Prefect Agents handle infrastructure configuration via infrastructure blocks attached to deployments. You can hit **Create** to create this work pool and then head over to the **Blocks** tab to create an infrastructure block for your deployments.\nTo learn more about how to configure infrastructure for Prefect Agents, check out the [docs](https://docs.prefect.io/latest/concepts/infrastructure/).',
+    disableFlowRunCancel: 'Prefect only offers cancellation of runs directly created by a deployment.',
   },
 }


### PR DESCRIPTION
Updates the cancel button to:

1. No longer use the parent flow run check to hide the button - simply checks for the presence of a deployment
2. Disables the button when no deployment is connected and gives a tooltip message about why the run cannot be cancelled
3. Permission and state checks stay in place

Should resolve https://github.com/PrefectHQ/prefect/issues/9320

<img width="1102" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/ceb404d5-2fce-4a35-8b7e-fccbb4089c3b">
