### PR TITLE
update work pool health indicator

### DIFF
--- a/src/components/WorkPoolQueueStatusIcon.vue
+++ b/src/components/WorkPoolQueueStatusIcon.vue
@@ -43,7 +43,7 @@
     icon: Icon,
   }>(() => {
     if (workPoolQueue.value?.isPaused) {
-      return { state: 'paused', name: 'Paused', icon: 'PauseIcon' }
+      return { state: 'paused', name: 'Paused', icon: 'PauseCircleIcon' }
     }
     if (healthy.value) {
       return { state: 'healthy', name: 'Healthy', icon: 'CheckCircleIcon' }
@@ -58,6 +58,7 @@
 .work-queue-status-icon { @apply
   flex
   items-center
+  cursor-help
 }
 
 .work-queue-status-icon--healthy { @apply
@@ -66,14 +67,13 @@
   align-middle
   bg-green-500
   rounded-full
-  text-state-completed-600
 }
 
 .work-queue-status-icon--unhealthy { @apply
-  text-state-failed-700
+  text-state-failed-500
 }
 
 .work-queue-status-icon--paused { @apply
-  text-state-pending-700
+  text-state-paused-500
 }
 </style>

--- a/src/components/WorkPoolQueueStatusIcon.vue
+++ b/src/components/WorkPoolQueueStatusIcon.vue
@@ -24,7 +24,6 @@
   const props = defineProps<{
     workQueueName: string,
     workPoolName: string,
-    tooltipPreText?: string,
   }>()
 
   const api = useWorkspaceApi()
@@ -51,7 +50,7 @@
     return { state: 'unhealthy', name: 'Unhealthy', icon: 'ExclamationCircleIcon' }
   })
 
-  const tooltipText = computed(() => `${props.tooltipPreText ?? 'Work queue is'} ${status.value.state}`)
+  const tooltipText = computed(() => `${workPoolQueue.value?.name} work queue is ${status.value.state}`)
   const classes = computed(() => `work-queue-status-icon--${status.value.state}`)
 </script>
 

--- a/src/components/WorkPoolQueueStatusIcon.vue
+++ b/src/components/WorkPoolQueueStatusIcon.vue
@@ -1,7 +1,18 @@
 <template>
-  <template v-if="workPoolQueue && workQueueStatus">
-    <p-icon :icon="status.icon" size="small" class="work-queue-status-icon" :class="classes" />
-  </template>
+  <p-tooltip
+    v-if="workPoolQueue && workQueueStatus"
+    class="work-queue-status-icon"
+    :text="`Work queue is ${status.state}`"
+  >
+    <div v-if="status.state === 'healthy'" class="work-queue-status-icon--healthy" />
+    <p-icon
+      v-if="status.state !== 'healthy'"
+      :icon="status.icon"
+      size="small"
+      class="work-queue-status-icon"
+      :class="classes"
+    />
+  </p-tooltip>
 </template>
 
 <script lang="ts" setup>
@@ -26,29 +37,43 @@
   const { workQueueStatus } = useWorkQueueStatus(workQueueId)
   const healthy = computed(() => workQueueStatus.value?.healthy)
 
-  const status = computed<{ name: string, icon: Icon }>(() => {
+  const status = computed<{
+    state: 'paused' | 'healthy' | 'unhealthy',
+    name: string,
+    icon: Icon,
+  }>(() => {
     if (workPoolQueue.value?.isPaused) {
-      return { name: 'Paused', icon: 'PauseIcon' }
+      return { state: 'paused', name: 'Paused', icon: 'PauseIcon' }
     }
     if (healthy.value) {
-      return { name: 'Healthy', icon: 'CheckCircleIcon' }
+      return { state: 'healthy', name: 'Healthy', icon: 'CheckCircleIcon' }
     }
-    return { name: 'Unhealthy', icon: 'XCircleIcon' }
+    return { state: 'unhealthy', name: 'Unhealthy', icon: 'ExclamationCircleIcon' }
   })
 
-  const classes = computed(() => `work-queue-status-icon--${status.value.name.toLowerCase()}`)
+  const classes = computed(() => `work-queue-status-icon--${status.value.state}`)
 </script>
 
 <style>
-.work-queue-status-icon--healthy{ @apply
+.work-queue-status-icon { @apply
+  flex
+  items-center
+}
+
+.work-queue-status-icon--healthy { @apply
+  w-2
+  h-2
+  align-middle
+  bg-green-500
+  rounded-full
   text-state-completed-600
 }
 
-.work-queue-status-icon--unhealthy{ @apply
+.work-queue-status-icon--unhealthy { @apply
   text-state-failed-700
 }
 
-.work-queue-status-icon--paused{ @apply
+.work-queue-status-icon--paused { @apply
   text-state-pending-700
 }
 </style>

--- a/src/components/WorkPoolQueueStatusIcon.vue
+++ b/src/components/WorkPoolQueueStatusIcon.vue
@@ -2,7 +2,7 @@
   <p-tooltip
     v-if="workPoolQueue && workQueueStatus"
     class="work-queue-status-icon"
-    :text="`Work queue is ${status.state}`"
+    :text="tooltipText"
   >
     <div v-if="status.state === 'healthy'" class="work-queue-status-icon--healthy" />
     <p-icon
@@ -24,6 +24,7 @@
   const props = defineProps<{
     workQueueName: string,
     workPoolName: string,
+    tooltipPreText?: string,
   }>()
 
   const api = useWorkspaceApi()
@@ -31,7 +32,6 @@
 
   const workPoolQueuesSubscription = useSubscriptionWithDependencies(api.workPoolQueues.getWorkPoolQueueByName, workPoolQueueArgs)
   const workPoolQueue = computed(() => workPoolQueuesSubscription.response)
-
 
   const workQueueId = computed(() => workPoolQueue.value?.id)
   const { workQueueStatus } = useWorkQueueStatus(workQueueId)
@@ -51,6 +51,7 @@
     return { state: 'unhealthy', name: 'Unhealthy', icon: 'ExclamationCircleIcon' }
   })
 
+  const tooltipText = computed(() => `${props.tooltipPreText ?? 'Work queue is'} ${status.value.state}`)
   const classes = computed(() => `work-queue-status-icon--${status.value.state}`)
 </script>
 


### PR DESCRIPTION
Updating these indicators in preparation for the new Dashboard view. The previous icons used for healthy and unhealthy appeared interactive/clickable (similar to a dismiss button or radio). This makes them more generic. The green dot is intended to be more passive than an illustrative icon. Distinction is maintained between each for accessibility (e.g. a red dot may not be visibly distinguishable from a green dot to certain users).


New healthy dark:
<img width="274" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/c42f5d96-14a6-4e61-807a-15e16afac526">

New healthy light:
<img width="275" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/46bd3192-dfe1-40ab-8a7d-652920f4cd4e">

New unhealthy dark:
<img width="286" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/d7146f3b-103f-4224-8682-016856d2b0a7">

New unhealthy light:
<img width="287" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/4537e9ca-b5e0-4a6d-bf8d-56654bca7beb">

New paused dark:
<img width="281" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/8da767b7-132c-4332-9463-04f640a493d8">

New paused light:
<img width="281" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/af0659e0-c38e-464f-8485-3891d4f46fba">
