### PR TITLE
hide checkbox on disabled

### DIFF
--- a/src/components/StateListItem.vue
+++ b/src/components/StateListItem.vue
@@ -55,7 +55,7 @@
   }>()
 
   const component = computed(() => {
-    if (!props.disabled && props.value !== undefined) {
+    if (!props.disabled || props.value !== undefined) {
       return PListItemInput
     }
 

--- a/src/components/StateListItem.vue
+++ b/src/components/StateListItem.vue
@@ -5,7 +5,7 @@
     :value="value"
     class="state-list-item"
     :class="classes"
-    disabled
+    :disabled="disabled"
   >
     <div class="state-list-item__content-container">
       <div class="state-list-item__content">
@@ -51,10 +51,11 @@
     value?: unknown,
     stateType?: StateType | null | undefined,
     tags?: string[] | null,
+    disabled?: boolean,
   }>()
 
   const component = computed(() => {
-    if (props.value !== undefined) {
+    if (!props.disabled && props.value !== undefined) {
       return PListItemInput
     }
 

--- a/src/components/StateListItem.vue
+++ b/src/components/StateListItem.vue
@@ -55,12 +55,22 @@
   }>()
 
   const component = computed(() => {
-    if (!props.disabled || props.value !== undefined) {
+    if (!props.disabled && isLegacySelectable()) {
       return PListItemInput
     }
 
     return PListItem
   })
+
+  const isLegacySelectable = (): boolean => {
+    // this check preserves legacy functionality where passing in `selected` as an
+    // empty array would hide the checkbox.
+    if (Array.isArray(props.selected) && props.selected.length !== 0) {
+      return false
+    }
+
+    return true
+  }
 
   const emit = defineEmits<{
     (event: 'update:selected', value: CheckboxModel): void,


### PR DESCRIPTION
`disabled` was used to prevent the checkbox from animating in and being clickable. This change keeps respects that expectation, but actually removes a checkbox from view when it's disabled.