### PR TITLE
audit StateListItem selection disabling

### DIFF
--- a/demo/sections/flowRuns/FlowRunList.vue
+++ b/demo/sections/flowRuns/FlowRunList.vue
@@ -1,6 +1,6 @@
 <template>
   <ComponentPage title="FlowRunList">
-    <FlowRunList :flow-runs="flowRuns" :selected="[]" class="color-mode-default" />
+    <FlowRunList :flow-runs="flowRuns" disable-deletion class="color-mode-default" />
   </ComponentPage>
 </template>
 

--- a/demo/sections/flowRuns/FlowRunListItem.vue
+++ b/demo/sections/flowRuns/FlowRunListItem.vue
@@ -1,13 +1,13 @@
 <template>
   <ComponentPage title="FlowRunListItem" :demos="demos">
-    <FlowRunListItem :flow-run="flowRun" :selected="[]" class="color-mode-default" />
+    <FlowRunListItem :flow-run="flowRun" selectable class="color-mode-default" />
 
     <template #disabled>
-      <FlowRunListItem :flow-run="flowRun" :selected="[]" class="color-mode-default" disabled />
+      <FlowRunListItem :flow-run="flowRun" selectable disabled class="color-mode-default" />
     </template>
 
     <template #no-relations>
-      <FlowRunListItem :flow-run="flowRunWithNoRelations" :selected="[]" class="color-mode-default" disabled />
+      <FlowRunListItem :flow-run="flowRunWithNoRelations" class="color-mode-default" />
     </template>
   </ComponentPage>
 </template>

--- a/src/components/ConcurrencyLimitActiveRuns.vue
+++ b/src/components/ConcurrencyLimitActiveRuns.vue
@@ -1,5 +1,5 @@
 <template>
-  <TaskRunList v-if="hasActiveSlots" :selected="null" :task-runs="activeRuns" disabled />
+  <TaskRunList v-if="hasActiveSlots" :task-runs="activeRuns" />
   <p-empty-results v-else>
     <template #message>
       No active task runs

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -69,6 +69,7 @@
               :flow="item"
               :filter="routeFilter"
               :disabled="disabled"
+              selectable
               class="flow-list__flow"
               @update="handleUpdate"
               @delete="handleDelete"

--- a/src/components/FlowListItem.vue
+++ b/src/components/FlowListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="classes" :styles="styles" class="flow-list-item-container">
-    <StateListItem v-bind="attrs" :disabled="disabled" class="flow-list-item" :state-type="flowState">
+    <StateListItem v-bind="attrs" :disabled="disabled" :selectable="selectable" class="flow-list-item" :state-type="flowState">
       <template #name>
         <p-link :to="routes.flow(flow.id)">
           <p-heading :heading="5">
@@ -78,6 +78,7 @@
   import { Flow, FlowsFilter } from '@/models'
 
   const props = defineProps<{
+    selectable?: boolean,
     flow: Flow,
     filter?: FlowsFilter,
     disabled?: boolean,

--- a/src/components/FlowRunFilteredList.vue
+++ b/src/components/FlowRunFilteredList.vue
@@ -11,7 +11,7 @@
       <StateNameSelect :selected="states" empty-message="All run states" class="flow-run-filtered-list__state-select" @update:selected="updateState" />
       <FlowRunsSort v-model="sort" class="flow-run-filtered-list__flow-runs-sort" />
     </div>
-    <FlowRunList v-model:selected="selectedFlowRuns" :flow-runs="flowRuns" :disabled="disabled || !can.delete.flow_run" @bottom="flowRunsSubscription.loadMore" />
+    <FlowRunList v-model:selected="selectedFlowRuns" :flow-runs="flowRuns" :disable-deletion="disableDeletion || !can.delete.flow_run" @bottom="flowRunsSubscription.loadMore" />
     <PEmptyResults v-if="empty">
       <template #message>
         <slot name="empty-message">
@@ -40,7 +40,7 @@
   const props = defineProps<{
     flowRunFilter: FlowRunsFilter,
     states?: PrefectStateNames[],
-    disabled?: boolean,
+    disableDeletion?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/FlowRunList.vue
+++ b/src/components/FlowRunList.vue
@@ -1,7 +1,7 @@
 <template>
   <p-virtual-scroller :items="flowRuns" class="flow-run-list">
     <template #default="{ item: flowRun }">
-      <FlowRunListItem v-model:selected="model" v-bind="{ flowRun, disabled }" />
+      <FlowRunListItem v-model:selected="model" :flow-run="flowRun" :selectable="!disableDeletion" />
     </template>
   </p-virtual-scroller>
 </template>
@@ -12,9 +12,9 @@
   import { FlowRun } from '@/models/FlowRun'
 
   const props = defineProps<{
-    selected: string[] | null,
+    selected?: string[] | null,
     flowRuns: FlowRun[],
-    disabled?: boolean,
+    disableDeletion?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/FlowRunListItem.vue
+++ b/src/components/FlowRunListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="el" class="flow-run-list-item">
-    <StateListItem v-model:selected="model" v-bind="{ value, disabled, tags, stateType }">
+    <StateListItem v-model:selected="model" :selectable="selectable" v-bind="{ value, disabled, tags, stateType }">
       <template #name>
         <FlowRunBreadCrumbs :flow-run="flowRun" />
       </template>
@@ -43,7 +43,8 @@
   import { FlowRun } from '@/models/FlowRun'
 
   const props = defineProps<{
-    selected: CheckboxModel | null,
+    selectable?: boolean,
+    selected?: CheckboxModel | null,
     flowRun: FlowRun,
     disabled?: boolean,
   }>()

--- a/src/components/FlowRunSubFlows.vue
+++ b/src/components/FlowRunSubFlows.vue
@@ -7,7 +7,7 @@
     </div>
 
     <template v-if="!empty">
-      <FlowRunList :selected="[]" :flow-runs="flowRuns" disabled @bottom="loadMoreSubFlowRuns" />
+      <FlowRunList :flow-runs="flowRuns" disable-deletion @bottom="loadMoreSubFlowRuns" />
     </template>
 
     <PEmptyResults v-if="empty">

--- a/src/components/FlowRunTaskRuns.vue
+++ b/src/components/FlowRunTaskRuns.vue
@@ -6,7 +6,7 @@
       <TaskRunsSort v-model="filter.sort" />
     </div>
 
-    <TaskRunList :selected="[]" :task-runs="taskRuns" disabled @bottom="taskRunsSubscription.loadMore" />
+    <TaskRunList :task-runs="taskRuns" @bottom="taskRunsSubscription.loadMore" />
 
     <PEmptyResults v-if="empty">
       <template #message>

--- a/src/components/StateListItem.vue
+++ b/src/components/StateListItem.vue
@@ -47,6 +47,7 @@
   import { StateType } from '@/models/StateType'
 
   const props = defineProps<{
+    selectable?: boolean,
     selected?: CheckboxModel | null,
     value?: unknown,
     stateType?: StateType | null | undefined,
@@ -55,22 +56,12 @@
   }>()
 
   const component = computed(() => {
-    if (!props.disabled && isLegacySelectable()) {
+    if (props.selectable && !props.disabled) {
       return PListItemInput
     }
 
     return PListItem
   })
-
-  const isLegacySelectable = (): boolean => {
-    // this check preserves legacy functionality where passing in `selected` as an
-    // empty array would hide the checkbox.
-    if (Array.isArray(props.selected) && props.selected.length !== 0) {
-      return false
-    }
-
-    return true
-  }
 
   const emit = defineEmits<{
     (event: 'update:selected', value: CheckboxModel): void,

--- a/src/components/TaskRunList.vue
+++ b/src/components/TaskRunList.vue
@@ -1,7 +1,7 @@
 <template>
   <p-virtual-scroller :items="taskRuns" class="task-run-list">
     <template #default="{ item: taskRun }">
-      <TaskRunListItem v-model:selected="model" v-bind="{ taskRun, disabled }" />
+      <TaskRunListItem v-model:selected="model" :selectable="selectable" v-bind="{ taskRun, disabled }" />
     </template>
   </p-virtual-scroller>
 </template>
@@ -12,7 +12,8 @@
   import { TaskRun } from '@/models/TaskRun'
 
   const props = defineProps<{
-    selected: string[] | null,
+    selectable?: boolean,
+    selected?: string[] | null,
     taskRuns: TaskRun[],
     disabled?: boolean,
   }>()

--- a/src/components/TaskRunListItem.vue
+++ b/src/components/TaskRunListItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <StateListItem v-model:selected="model" v-bind="{ value, disabled, tags, stateType }" class="task-run-list-item">
+  <StateListItem v-model:selected="model" :selectable="selectable" v-bind="{ value, disabled, tags, stateType }" class="task-run-list-item">
     <template #name>
       <p-link :to="routes.taskRun(taskRun.id)">
         <span>{{ taskRun.name }}</span>
@@ -33,7 +33,8 @@
   import { secondsToApproximateString } from '@/utilities/seconds'
 
   const props = defineProps<{
-    selected: CheckboxModel | null,
+    selectable?: boolean,
+    selected?: CheckboxModel | null,
     taskRun: TaskRun,
     disabled?: boolean,
   }>()

--- a/src/components/WorkPoolQueueUpcomingFlowRunsList.vue
+++ b/src/components/WorkPoolQueueUpcomingFlowRunsList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="work-pool-queue-upcoming-flow-runs-list">
-    <FlowRunList :selected="[]" :flow-runs="scheduledFlowRuns" disabled />
+    <FlowRunList disable-deletion :flow-runs="scheduledFlowRuns" />
 
     <p-empty-results v-if="empty">
       <template v-if="isPaused" #message>

--- a/src/components/WorkQueueFlowRunsList.vue
+++ b/src/components/WorkQueueFlowRunsList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="work-queue-flow-runs-list">
-    <FlowRunList :selected="[]" :flow-runs="flowRuns" disabled />
+    <FlowRunList disable-deletion :flow-runs="flowRuns" />
 
     <p-empty-results v-if="empty">
       <template v-if="isPaused" #message>


### PR DESCRIPTION
Previously, StateListItem had confusing methods for disabling selection. This PR makes selection an opt-in feature, `disable` will still hide the checkbox as well. Fallowing the paths here took a number of passes to make sure the logic made sense, some consuming components enable selection by default and have opt-out patterns.

This change will require only 1 change in the Nebula repo, none in OSS.