### PR TITLE
Bugfix:`SchemaInput` values mapping

### DIFF
--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -112,7 +112,7 @@
   const { handleSubmit, isSubmitting } = useForm<DeploymentEdit>({
     initialValues: {
       description: props.deployment.description,
-      parameters: props.deployment.rawParameters,
+      parameters: props.deployment.parameters,
       schedule: props.deployment.schedule,
       isScheduleActive: props.deployment.isScheduleActive,
       workPoolName: props.deployment.workPoolName,
@@ -137,7 +137,7 @@
   const { value: tags } = useField<string[] | null>('tags')
   const { value: infrastructureOverrides, meta: overrideState, errorMessage: overrideErrorMessage } = useField<string>('infrastructureOverrides', rules.infrastructureOverrides)
 
-  const { schema } = useOptionalPropertiesSchema(props.deployment.rawSchema ?? {})
+  const { schema } = useOptionalPropertiesSchema(props.deployment.rawSchema)
 
   const emit = defineEmits<{
     (event: 'submit', value: DeploymentUpdate): void,

--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -95,7 +95,7 @@
   import { useForm } from '@/compositions/useForm'
   import { localization } from '@/localization'
   import { Deployment, DeploymentFlowRunCreate } from '@/models'
-  import { mocker } from '@/services'
+  import { mapper, mocker } from '@/services'
   import { SchemaInputType } from '@/types/schemaInput'
   import { SchemaValues } from '@/types/schemas'
   import { isJson, fieldRules, isRequiredIf } from '@/utilities/validation'
@@ -125,7 +125,7 @@
   }
 
   const combinedParameters = computed(() => {
-    return { ...props.deployment.parameters, ...props.parameters }
+    return mapper.map('SchemaValuesResponse', { values: { ...props.deployment.rawParameters, ...props.parameters }, schema: props.deployment.parameterOpenApiSchema }, 'SchemaValues')
   })
 
   const { handleSubmit } = useForm<DeploymentFlowRunCreate>({

--- a/src/components/QuickRunParametersModal.vue
+++ b/src/components/QuickRunParametersModal.vue
@@ -42,7 +42,7 @@
 
   const { handleSubmit } = useForm<DeploymentFlowRunCreate>({
     initialValues: {
-      parameters: props.deployment.rawParameters,
+      parameters: props.deployment.parameters,
       schema: props.deployment.parameterOpenApiSchema,
     },
   })

--- a/src/components/SchemaInput.vue
+++ b/src/components/SchemaInput.vue
@@ -41,7 +41,7 @@
   import { localization } from '@/localization'
   import { getSchemaDefaultValues, mapper } from '@/services'
   import { SchemaInputType } from '@/types/schemaInput'
-  import { Schema, SchemaValues } from '@/types/schemas'
+  import { SchemaValues, Schema } from '@/types/schemas'
   import { isJson, fieldRules, isDefined } from '@/utilities'
 
   const props = defineProps<{
@@ -77,8 +77,10 @@
     },
   })
 
-  const defaultValues = merge(getSchemaDefaultValues(props.schema), mapper.map('SchemaValuesResponse', { values: props.modelValue ?? {}, schema: props.schema }, 'SchemaValues'))
-  const { json, record } = useJsonRecord(defaultValues)
+  const schemaDefaultValues = getSchemaDefaultValues(props.schema)
+  const defaultValues = merge({}, schemaDefaultValues, props.modelValue ?? {})
+  const unmappedDefaultValues = mapper.map('SchemaValues', { values: defaultValues, schema: props.schema }, 'SchemaValuesRequest')
+  const { json, record } = useJsonRecord(unmappedDefaultValues)
 
   const rules = {
     jsonValues: fieldRules(localization.info.values, isJson),

--- a/src/compositions/useOptionalPropertiesSchema.ts
+++ b/src/compositions/useOptionalPropertiesSchema.ts
@@ -1,6 +1,7 @@
 import { merge } from 'lodash'
 import { ComputedRef, MaybeRef, computed, ref } from 'vue'
 import { SchemaResponse } from '@/models'
+import { mapper } from '@/services'
 import { Schema } from '@/types'
 
 export type UseOptionalPropertiesSchema = {
@@ -13,7 +14,7 @@ export function useOptionalPropertiesSchema(rawSchema: MaybeRef<SchemaResponse |
   const computedSchema = computed(() => {
     const newSchema = merge({}, rawSchemaRef.value)
     newSchema.required = []
-    return newSchema
+    return mapper.map('SchemaResponse', newSchema, 'Schema')
   })
 
   return {

--- a/src/maps/deployment.ts
+++ b/src/maps/deployment.ts
@@ -5,7 +5,8 @@ import { Deployment } from '@/models/Deployment'
 import { MapFunction } from '@/services/Mapper'
 
 export const mapDeploymentResponseToDeployment: MapFunction<DeploymentResponse, Deployment> = function(source) {
-  const schema = this.map('SchemaResponse', source.parameter_openapi_schema ?? {}, 'Schema')
+  const rawSchema = source.parameter_openapi_schema ?? {}
+  const schema = this.map('SchemaResponse', rawSchema, 'Schema')
   const values = this.map('SchemaValuesResponse', { values: source.parameters, schema }, 'SchemaValues')
 
   return new Deployment({
@@ -22,7 +23,7 @@ export const mapDeploymentResponseToDeployment: MapFunction<DeploymentResponse, 
     isScheduleActive: source.is_schedule_active,
     parameters: values,
     rawParameters: source.parameters,
-    rawSchema: source.parameter_openapi_schema,
+    rawSchema,
     tags: source.tags ? sortStringArray(source.tags) : null,
     manifestPath: source.manifest_path,
     path: source.path,

--- a/src/mocks/deployment.ts
+++ b/src/mocks/deployment.ts
@@ -1,9 +1,12 @@
 import { Deployment } from '@/models/Deployment'
+import { mapper } from '@/services'
 import { MockFunction } from '@/services/Mocker'
 import { random } from '@/utilities/math'
 
 export const randomDeployment: MockFunction<Deployment, [Partial<Deployment>?]> = function(overrides = {}) {
   const schema = this.create('schema', [overrides.parameterOpenApiSchema])
+  const rawParameters = this.create('parameters', [{}, schema])
+  const parameters = mapper.map('SchemaValuesResponse', { values: rawParameters, schema }, 'SchemaValues')
   const schedule = random() > 0.25 ? this.create('schedule') : null
 
   return {
@@ -18,9 +21,9 @@ export const randomDeployment: MockFunction<Deployment, [Partial<Deployment>?]> 
     flowId: this.create('id'),
     schedule,
     isScheduleActive: schedule ? this.create('boolean') : false,
-    parameters: this.create('parameters', [{}, schema]),
+    parameters,
     parameterOpenApiSchema: schema,
-    rawParameters: this.create('parameters', [{}, schema]),
+    rawParameters,
     rawSchema: schema,
     tags: this.createMany('noun', this.create('number', [0, 5])),
     manifestPath: this.create('id'),

--- a/src/models/Deployment.ts
+++ b/src/models/Deployment.ts
@@ -22,7 +22,7 @@ export interface IDeployment {
   manifestPath: string | null,
   path: string | null,
   rawParameters: SchemaValues,
-  rawSchema: SchemaResponse | null,
+  rawSchema: SchemaResponse,
   entrypoint: string | null,
   storageDocumentId: string | null,
   infrastructureDocumentId: string | null,
@@ -46,7 +46,7 @@ export class Deployment implements IDeployment {
   public parameters: SchemaValues
   public parameterOpenApiSchema: Schema
   public readonly rawParameters: SchemaValues
-  public readonly rawSchema: SchemaResponse | null
+  public readonly rawSchema: SchemaResponse
   public tags: string[] | null
   public manifestPath: string | null
   public path: string | null


### PR DESCRIPTION
This PR contains a few changes

- `rawSchema` is no longer a nullable field on the deployment model (saves us from nullish coalescing an empty object everywhere we reference it)
- updates all the forms that are using `SchemaInput` under the hood that were passing references to `rawParameters` - this was a bad dev ex and created confusion around who's responsible for mapping. Instead, the `SchemaInput` component unmaps the passed model value downstream use (code editors that don't want mapped values)
- updates the `UseOptionalPropertiesSchema` composition to map raw schemas after removing required parameters. This is only used in one place right now but with the updated types should provided a clearer dev ex in future uses