### PR TITLE
Bugfix: Unmapped default values and mapped JSON values

### DIFF
--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -144,7 +144,6 @@
     (event: 'cancel'): void,
   }>()
 
-
   const { validate } = useValidationObserver()
 
   const submit = handleSubmit(async (values): Promise<void> => {

--- a/src/components/SchemaInput.vue
+++ b/src/components/SchemaInput.vue
@@ -99,7 +99,7 @@
 
   watchEffect(() => {
     if (inputType.value === 'json') {
-      emit('update:modelValue', record.value)
+      emit('update:modelValue', mapper.map('SchemaValuesResponse', { values: record.value, schema: props.schema }, 'SchemaValues'))
     } else {
       emit('update:modelValue', values)
     }

--- a/src/components/SchemaInput.vue
+++ b/src/components/SchemaInput.vue
@@ -89,7 +89,7 @@
   const { error, state } = useValidation(json, localization.info.values, rules.jsonValues)
 
   const { validate: validateReactiveForm, errors: reactiveFormErrors, values } = useForm({
-    initialValues: record,
+    initialValues: defaultValues,
   })
 
   useValidation(record, localization.info.values, async () => {


### PR DESCRIPTION
As the title states, this PR fixes a subtle bug where the default values passed to the `useForm` composition were the _unmapped_ values created in #1516; likewise the values coming from the json input were passed back to the calling component unmapped, when they should have been mapped. 