### PR TITLE
Bugfix: `Any` and `Object` default mapping

### DIFF
--- a/src/services/schemas/properties/SchemaPropertyAny.ts
+++ b/src/services/schemas/properties/SchemaPropertyAny.ts
@@ -1,4 +1,4 @@
-import { getSchemaValueDefinition, schemaPropertyServiceFactory } from '..'
+import { getSchemaPropertyResponseValue, getSchemaValueDefinition, schemaPropertyServiceFactory } from '..'
 import { JsonInput } from '@/components'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { getSchemaPropertyDefaultValue, SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
@@ -9,9 +9,7 @@ import { parseUnknownJson, stringifyUnknownJson } from '@/utilities/json'
 export class SchemaPropertyAny extends SchemaPropertyService {
   protected get default(): unknown {
     if (this.has('default')) {
-      const level = this.level + 1
-      const service = schemaPropertyServiceFactory(this.property, level)
-      return service.mapResponseValue(this.property.default)
+      return getSchemaPropertyResponseValue(this.property, this.property.default, this.level + 1)
     }
 
     if (this.componentIs(JsonInput)) {

--- a/src/services/schemas/properties/SchemaPropertyAny.ts
+++ b/src/services/schemas/properties/SchemaPropertyAny.ts
@@ -9,7 +9,9 @@ import { parseUnknownJson, stringifyUnknownJson } from '@/utilities/json'
 export class SchemaPropertyAny extends SchemaPropertyService {
   protected get default(): unknown {
     if (this.has('default')) {
-      return this.property.default
+      const level = this.level + 1
+      const service = schemaPropertyServiceFactory(this.property, level)
+      return service.mapResponseValue(this.property.default)
     }
 
     if (this.componentIs(JsonInput)) {

--- a/src/services/schemas/properties/SchemaPropertyObject.ts
+++ b/src/services/schemas/properties/SchemaPropertyObject.ts
@@ -22,7 +22,15 @@ export class SchemaPropertyObject extends SchemaPropertyService {
       return stringifyUnknownJson(this.property.default) ?? null
     }
 
-    return this.property.default ?? {}
+    const parsed = (this.property.default ?? {}) as SchemaValues
+    const mapped = mapValues(this.property.properties ?? {}, (key, property) => {
+      const propertyValue = parsed[key]
+      const service = schemaPropertyServiceFactory(property!, this.level + 1)
+
+      return service.mapResponseValue(propertyValue)
+    })
+
+    return mapped
   }
 
   protected request(value: SchemaValue): unknown {

--- a/src/services/schemas/properties/SchemaPropertyObject.ts
+++ b/src/services/schemas/properties/SchemaPropertyObject.ts
@@ -2,7 +2,7 @@ import { JsonInput } from '@/components'
 import { InvalidSchemaValueError } from '@/models'
 import { schemaPropertyServiceFactory } from '@/services/schemas/properties'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
-import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
+import { SchemaPropertyComponentWithProps, getSchemaPropertyRequestValue, getSchemaPropertyResponseValue } from '@/services/schemas/utilities'
 import { SchemaValue, isSchemaValues, SchemaValues } from '@/types/schemas'
 import { isEmptyObject, isNullish, mapValues } from '@/utilities'
 import { parseUnknownJson, stringifyUnknownJson } from '@/utilities/json'
@@ -25,9 +25,7 @@ export class SchemaPropertyObject extends SchemaPropertyService {
     const parsed = (this.property.default ?? {}) as SchemaValues
     const mapped = mapValues(this.property.properties ?? {}, (key, property) => {
       const propertyValue = parsed[key]
-      const service = schemaPropertyServiceFactory(property!, this.level + 1)
-
-      return service.mapResponseValue(propertyValue)
+      return getSchemaPropertyResponseValue(property!, propertyValue, this.level + 1)
     })
 
     return mapped
@@ -44,9 +42,7 @@ export class SchemaPropertyObject extends SchemaPropertyService {
 
     const mapped = mapValues(this.property.properties ?? {}, (key, property) => {
       const propertyValue = value[key]
-      const service = schemaPropertyServiceFactory(property!, this.level + 1)
-
-      return service.mapRequestValue(propertyValue)
+      return getSchemaPropertyRequestValue(property!, propertyValue, this.level + 1)
     })
 
     if (isEmptyObject(mapped)) {
@@ -71,9 +67,7 @@ export class SchemaPropertyObject extends SchemaPropertyService {
 
     return mapValues(this.property.properties ?? {}, (key, property) => {
       const propertyValue = parsed[key]
-      const service = schemaPropertyServiceFactory(property!, this.level + 1)
-
-      return service.mapResponseValue(propertyValue)
+      return getSchemaPropertyResponseValue(property!, propertyValue, this.level + 1)
     })
   }
 }

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -52,8 +52,8 @@ export function getSchemaRequestValue(schema: Schema, values: SchemaValues): Sch
 /*
  * Gets a UI friendly version of a property's api friendly value. Used for mapping.
  */
-export function getSchemaPropertyResponseValue(property: SchemaProperty, value: SchemaValue, level?: number): SchemaValue {
-  const service = schemaPropertyServiceFactory(property, level ?? 0)
+export function getSchemaPropertyResponseValue(property: SchemaProperty, value: SchemaValue, level: number = 0): SchemaValue {
+  const service = schemaPropertyServiceFactory(property, level)
 
   return service.mapResponseValue(value)
 }
@@ -61,8 +61,8 @@ export function getSchemaPropertyResponseValue(property: SchemaProperty, value: 
 /*
  * Gets a api friendly version of a property's UI friendly value. Used for mapping.
  */
-export function getSchemaPropertyRequestValue(property: SchemaProperty, value: SchemaValue, level?: number): SchemaValue {
-  const service = schemaPropertyServiceFactory(property, level ?? 0)
+export function getSchemaPropertyRequestValue(property: SchemaProperty, value: SchemaValue, level: number = 0): SchemaValue {
+  const service = schemaPropertyServiceFactory(property, level)
 
   return service.mapRequestValue(value)
 }

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -52,8 +52,8 @@ export function getSchemaRequestValue(schema: Schema, values: SchemaValues): Sch
 /*
  * Gets a UI friendly version of a property's api friendly value. Used for mapping.
  */
-export function getSchemaPropertyResponseValue(property: SchemaProperty, value: SchemaValue): SchemaValue {
-  const service = schemaPropertyServiceFactory(property, 0)
+export function getSchemaPropertyResponseValue(property: SchemaProperty, value: SchemaValue, level?: number): SchemaValue {
+  const service = schemaPropertyServiceFactory(property, level ?? 0)
 
   return service.mapResponseValue(value)
 }
@@ -61,8 +61,8 @@ export function getSchemaPropertyResponseValue(property: SchemaProperty, value: 
 /*
  * Gets a api friendly version of a property's UI friendly value. Used for mapping.
  */
-export function getSchemaPropertyRequestValue(property: SchemaProperty, value: SchemaValue): SchemaValue {
-  const service = schemaPropertyServiceFactory(property, 0)
+export function getSchemaPropertyRequestValue(property: SchemaProperty, value: SchemaValue, level?: number): SchemaValue {
+  const service = schemaPropertyServiceFactory(property, level ?? 0)
 
   return service.mapRequestValue(value)
 }


### PR DESCRIPTION
This PR changes the way defaults are handled for `any` and `object` properties; previously unmapped defaults were returned when a nullish value was passed to the service. Now, defaults are mapped the same as other response values