### PR TITLE
Add empty state to dashboard Flow Runs card tabs

### DIFF
--- a/src/components/FlowRunStateTypeEmpty.vue
+++ b/src/components/FlowRunStateTypeEmpty.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="flow-run-state-type-empty">
+    <template v-if="component">
+      <component :is="component" class="flow-run-state-type-empty__img" />
+    </template>
+
+    <p class="flow-run-state-type-empty__message">
+      {{ description }}
+    </p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import FlowRunStateTypeEmptyAwaitingImage from '@/components/FlowRunStateTypeEmptyAwaitingImage.vue'
+  import FlowRunStateTypeEmptyBadTerminalImage from '@/components/FlowRunStateTypeEmptyBadTerminalImage.vue'
+  import FlowRunStateTypeEmptyGoodTerminalImage from '@/components/FlowRunStateTypeEmptyGoodTerminalImage.vue'
+  import FlowRunStateTypeEmptyLiveImage from '@/components/FlowRunStateTypeEmptyLiveImage.vue'
+  import { StateType } from '@/models'
+  import { MaybeArray } from '@/types'
+  import { asArray } from '@/utilities'
+
+  const props = defineProps<{
+    stateType: MaybeArray<StateType>,
+  }>()
+
+  const states = computed(() => asArray(props.stateType))
+
+  const formatter = new Intl.ListFormat('en', { style: 'long', type: 'disjunction' })
+  const description = computed(() => {
+    const statesString = formatter.format(states.value)
+
+    return `You currently have 0 ${statesString} runs.`
+  })
+
+  const component = computed(() => {
+    if (states.value.includes('failed')) {
+      return FlowRunStateTypeEmptyBadTerminalImage
+    }
+
+    if (states.value.includes('running')) {
+      return FlowRunStateTypeEmptyLiveImage
+    }
+
+    if (states.value.includes('completed')) {
+      return FlowRunStateTypeEmptyGoodTerminalImage
+    }
+
+    if (states.value.includes('scheduled')) {
+      return FlowRunStateTypeEmptyAwaitingImage
+    }
+
+    return null
+  })
+</script>
+
+<style>
+.flow-run-state-type-empty { @apply
+  flex
+  flex-col
+  items-center
+  gap-8
+  my-20
+}
+
+.flow-run-state-type-empty__img { @apply
+  h-32
+}
+
+.flow-run-state-type-empty__message { @apply
+  text-lg
+  text-center
+  max-w-xs
+}
+</style>

--- a/src/components/FlowRunStateTypeEmptyAwaitingImage.vue
+++ b/src/components/FlowRunStateTypeEmptyAwaitingImage.vue
@@ -1,0 +1,247 @@
+<template>
+  <svg viewBox="0 0 92 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="88.2922"
+      y="96.4243"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 88.2922 96.4243)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="69.6321"
+      y="22.974"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 69.6321 22.974)"
+      fill="#2C0C00"
+    />
+    <rect
+      x="88.2922"
+      y="78.1342"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 88.2922 78.1342)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="52.6266"
+      y="97.3386"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 52.6266 97.3386)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="52.6266"
+      y="42.4686"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 52.6266 42.4686)"
+      fill="#FFB838"
+    />
+    <rect
+      x="70.9166"
+      y="60.7586"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 70.9166 60.7586)"
+      fill="#FFAD1A"
+    />
+    <rect
+      x="53.5411"
+      y="79.9631"
+      width="14.632"
+      height="14.632"
+      rx="1.4632"
+      transform="rotate(180 53.5411 79.9631)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="70.9166"
+      y="97.3386"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 70.9166 97.3386)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="52.6266"
+      y="115.629"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 52.6266 115.629)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="53.5411"
+      y="61.6732"
+      width="14.632"
+      height="14.632"
+      rx="1.4632"
+      transform="rotate(180 53.5411 61.6732)"
+      fill="#FFAD1A"
+    />
+    <rect
+      x="70.0022"
+      y="41.5541"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 70.0022 41.5541)"
+      fill="#2C0C00"
+    />
+    <rect
+      x="70.0022"
+      y="114.714"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 70.0022 114.714)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="70.9166"
+      y="79.0486"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 70.9166 79.0486)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="33.4221"
+      y="114.714"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 33.4221 114.714)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="34.3365"
+      y="97.3386"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 34.3365 97.3386)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="34.3365"
+      y="79.0486"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 34.3365 79.0486)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="34.3365"
+      y="61.1785"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 34.3365 61.1785)"
+      fill="#FFAD1A"
+    />
+    <rect
+      x="33.4221"
+      y="41.5541"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 33.4221 41.5541)"
+      fill="#2C0C00"
+    />
+    <rect
+      x="33.4221"
+      y="22.974"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 33.4221 22.974)"
+      fill="#2C0C00"
+    />
+    <rect
+      x="87.3777"
+      y="113.8"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 87.3777 113.8)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="87.3777"
+      y="40.6396"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 87.3777 40.6396)"
+      fill="#FFB838"
+    />
+    <rect
+      x="14.2175"
+      y="113.8"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 14.2175 113.8)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="15.1321"
+      y="96.4243"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 15.1321 96.4243)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="15.1321"
+      y="78.1342"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 15.1321 78.1342)"
+      fill="#FFEAC4"
+    />
+    <rect
+      x="15.1321"
+      y="59.8441"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 15.1321 59.8441)"
+      fill="#FFAD1A"
+    />
+    <rect
+      x="14.2175"
+      y="40.6396"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 14.2175 40.6396)"
+      fill="#FFB838"
+    />
+    <rect
+      x="88.2922"
+      y="59.8441"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 88.2922 59.8441)"
+      fill="#FFAD1A"
+    />
+  </svg>
+</template>

--- a/src/components/FlowRunStateTypeEmptyBadTerminalImage.vue
+++ b/src/components/FlowRunStateTypeEmptyBadTerminalImage.vue
@@ -1,0 +1,292 @@
+<template>
+  <svg viewBox="0 0 157 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="16.2571"
+      y="88.6859"
+      width="12.8"
+      height="12.8"
+      rx="2.19428"
+      transform="rotate(180 16.2571 88.6859)"
+      fill="#A4E392"
+    />
+    <rect
+      x="81.3142"
+      y="89.6"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 81.3142 89.6)"
+      fill="#306739"
+    />
+    <rect
+      x="117.886"
+      y="89.6"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 117.886 89.6)"
+      fill="#78D382"
+    />
+    <rect
+      x="15.3428"
+      y="69.4857"
+      width="10.9714"
+      height="10.9714"
+      rx="2.92571"
+      transform="rotate(180 15.3428 69.4857)"
+      fill="#D4F8B5"
+    />
+    <rect
+      x="81.3142"
+      y="71.3143"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 81.3142 71.3143)"
+      fill="#51A456"
+    />
+    <rect
+      x="117.886"
+      y="71.3143"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 117.886 71.3143)"
+      fill="#78D382"
+    />
+    <rect
+      x="81.3142"
+      y="53.0286"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 81.3142 53.0286)"
+      fill="#78D382"
+    />
+    <rect
+      x="98.6858"
+      y="33.8286"
+      width="12.8"
+      height="12.8"
+      rx="2.19428"
+      transform="rotate(180 98.6858 33.8286)"
+      fill="#A4E392"
+    />
+    <rect
+      x="35.4573"
+      y="89.6002"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 35.4573 89.6002)"
+      fill="#78D382"
+    />
+    <rect
+      x="99.6001"
+      y="89.6"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 99.6001 89.6)"
+      fill="#51A456"
+    />
+    <rect
+      x="135.257"
+      y="88.6857"
+      width="12.8"
+      height="12.8"
+      rx="2.19428"
+      transform="rotate(180 135.257 88.6857)"
+      fill="#78D382"
+    />
+    <rect
+      x="63.0286"
+      y="89.6"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 63.0286 89.6)"
+      fill="#306739"
+    />
+    <rect
+      x="34.543"
+      y="70.4"
+      width="12.8"
+      height="12.8"
+      rx="2.19428"
+      transform="rotate(180 34.543 70.4)"
+      fill="#A4E392"
+    />
+    <rect
+      x="99.6001"
+      y="71.3143"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 99.6001 71.3143)"
+      fill="#51A456"
+    />
+    <rect
+      x="135.257"
+      y="70.4"
+      width="12.8"
+      height="12.8"
+      rx="2.19428"
+      transform="rotate(180 135.257 70.4)"
+      fill="#78D382"
+    />
+    <rect
+      x="97.6287"
+      y="14.6285"
+      width="10.9714"
+      height="10.9714"
+      rx="2.92571"
+      transform="rotate(180 97.6287 14.6285)"
+      fill="#A4E392"
+    />
+    <rect
+      x="61.6287"
+      y="51.6285"
+      width="10.9714"
+      height="10.9714"
+      rx="2.92571"
+      transform="rotate(180 61.6287 51.6285)"
+      fill="#A4E392"
+    />
+    <rect
+      x="80.2571"
+      y="33.8286"
+      width="12.8"
+      height="12.8"
+      rx="2.19428"
+      transform="rotate(180 80.2571 33.8286)"
+      fill="#78D382"
+    />
+    <rect
+      x="63.0286"
+      y="71.3143"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 63.0286 71.3143)"
+      fill="#51A456"
+    />
+    <rect
+      x="35.4573"
+      y="107.886"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 35.4573 107.886)"
+      fill="#78D382"
+    />
+    <rect
+      x="99.6001"
+      y="107.886"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 99.6001 107.886)"
+      fill="#51A456"
+    />
+    <rect
+      x="135.257"
+      y="106.971"
+      width="12.8"
+      height="12.8"
+      rx="2.19428"
+      transform="rotate(180 135.257 106.971)"
+      fill="#78D382"
+    />
+    <rect
+      x="63.0286"
+      y="107.886"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 63.0286 107.886)"
+      fill="#51A456"
+    />
+    <rect
+      x="34.543"
+      y="125.257"
+      width="12.8"
+      height="12.8"
+      rx="2.19428"
+      transform="rotate(180 34.543 125.257)"
+      fill="#A4E392"
+    />
+    <rect
+      x="99.6001"
+      y="126.171"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 99.6001 126.171)"
+      fill="#78D382"
+    />
+    <rect
+      x="63.0286"
+      y="126.171"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 63.0286 126.171)"
+      fill="#78D382"
+    />
+    <rect
+      x="16.2571"
+      y="106.971"
+      width="12.8"
+      height="12.8"
+      rx="2.19428"
+      transform="rotate(180 16.2571 106.971)"
+      fill="#A4E392"
+    />
+    <rect
+      x="81.3142"
+      y="107.886"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 81.3142 107.886)"
+      fill="#51A456"
+    />
+    <rect
+      x="117.886"
+      y="107.886"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 117.886 107.886)"
+      fill="#78D382"
+    />
+    <rect
+      x="15.3428"
+      y="124.343"
+      width="10.9714"
+      height="10.9714"
+      rx="2.92571"
+      transform="rotate(180 15.3428 124.343)"
+      fill="#D4F8B5"
+    />
+    <rect
+      x="81.3142"
+      y="126.171"
+      width="14.6286"
+      height="14.6286"
+      rx="1.46286"
+      transform="rotate(180 81.3142 126.171)"
+      fill="#78D382"
+    />
+    <rect
+      x="116.971"
+      y="125.257"
+      width="12.8"
+      height="12.8"
+      rx="2.19428"
+      transform="rotate(180 116.971 125.257)"
+      fill="#78D382"
+    />
+  </svg>
+</template>

--- a/src/components/FlowRunStateTypeEmptyGoodTerminalImage.vue
+++ b/src/components/FlowRunStateTypeEmptyGoodTerminalImage.vue
@@ -1,0 +1,292 @@
+<template>
+  <svg viewBox="0 0 111 110" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="54.4553"
+      y="90.4055"
+      width="16.461"
+      height="16.461"
+      rx="0.7316"
+      transform="rotate(180 54.4553 90.4055)"
+      fill="#9B0806"
+    />
+    <rect
+      x="51.7119"
+      y="14.502"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 51.7119 14.502)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="89.2063"
+      y="88.5764"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 89.2063 88.5764)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="88.2917"
+      y="14.502"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 88.2917 14.502)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="53.5408"
+      y="71.201"
+      width="14.632"
+      height="14.632"
+      rx="1.4632"
+      transform="rotate(180 53.5408 71.201)"
+      fill="#EB8583"
+    />
+    <rect
+      x="89.2063"
+      y="70.2865"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 89.2063 70.2865)"
+      fill="#EB8583"
+    />
+    <rect
+      x="15.1318"
+      y="87.6619"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 15.1318 87.6619)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="70.9165"
+      y="88.5764"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 70.9165 88.5764)"
+      fill="#EB8583"
+    />
+    <rect
+      x="70.002"
+      y="14.502"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 70.002 14.502)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="106.582"
+      y="87.6619"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 106.582 87.6619)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="34.3364"
+      y="88.5764"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 34.3364 88.5764)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="33.4219"
+      y="14.502"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 33.4219 14.502)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="15.1318"
+      y="69.372"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 15.1318 69.372)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="71.8308"
+      y="71.201"
+      width="14.632"
+      height="14.632"
+      rx="1.4632"
+      transform="rotate(180 71.8308 71.201)"
+      fill="#9B0806"
+    />
+    <rect
+      x="106.582"
+      y="69.372"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 106.582 69.372)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="35.2507"
+      y="71.201"
+      width="14.632"
+      height="14.632"
+      rx="1.4632"
+      transform="rotate(180 35.2507 71.201)"
+      fill="#9B0806"
+    />
+    <rect
+      x="15.1318"
+      y="32.7919"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 15.1318 32.7919)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="70.002"
+      y="105.952"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 70.002 105.952)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="70.9165"
+      y="33.7064"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 70.9165 33.7064)"
+      fill="#EB8583"
+    />
+    <rect
+      x="106.582"
+      y="32.7919"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 106.582 32.7919)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="33.4219"
+      y="105.952"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 33.4219 105.952)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="34.3364"
+      y="33.7064"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 34.3364 33.7064)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="15.1318"
+      y="51.082"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 15.1318 51.082)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="71.8308"
+      y="52.911"
+      width="14.632"
+      height="14.632"
+      rx="1.4632"
+      transform="rotate(180 71.8308 52.911)"
+      fill="#EB8583"
+    />
+    <rect
+      x="34.3364"
+      y="51.9965"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 34.3364 51.9965)"
+      fill="#EB8583"
+    />
+    <rect
+      x="51.7119"
+      y="105.952"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 51.7119 105.952)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="52.6265"
+      y="33.7064"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 52.6265 33.7064)"
+      fill="#EB8583"
+    />
+    <rect
+      x="88.2917"
+      y="105.952"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 88.2917 105.952)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="89.2063"
+      y="33.7064"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 89.2063 33.7064)"
+      fill="#FFD3D3"
+    />
+    <rect
+      x="53.5408"
+      y="52.911"
+      width="14.632"
+      height="14.632"
+      rx="1.4632"
+      transform="rotate(180 53.5408 52.911)"
+      fill="#EB8583"
+    />
+    <rect
+      x="89.2063"
+      y="51.9965"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 89.2063 51.9965)"
+      fill="#9B0806"
+    />
+    <rect
+      x="106.582"
+      y="51.082"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 106.582 51.082)"
+      fill="#FFD3D3"
+    />
+  </svg>
+</template>

--- a/src/components/FlowRunStateTypeEmptyLiveImage.vue
+++ b/src/components/FlowRunStateTypeEmptyLiveImage.vue
@@ -1,0 +1,337 @@
+<template>
+  <svg viewBox="0 0 129 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="52.4965"
+      y="88.7064"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 52.4965 88.7064)"
+      fill="#080072"
+    />
+    <rect
+      x="50.6675"
+      y="13.7175"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 50.6675 13.7175)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="89.0764"
+      y="88.7064"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 89.0764 88.7064)"
+      fill="#080072"
+    />
+    <rect
+      x="88.6321"
+      y="105.632"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 88.6321 105.632)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="106.422"
+      y="105.922"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 106.422 105.922)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="52.4965"
+      y="70.4165"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 52.4965 70.4165)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="89.0764"
+      y="70.4165"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 89.0764 70.4165)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="70.7865"
+      y="88.7064"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 70.7865 88.7064)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="68.9575"
+      y="13.7175"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 68.9575 13.7175)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="87.2175"
+      y="13.7175"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 87.2175 13.7175)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="33.292"
+      y="87.7919"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 33.292 87.7919)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="33.292"
+      y="105.922"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 33.292 105.922)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="14.0875"
+      y="68.5875"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 14.0875 68.5875)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="14.0875"
+      y="86.7175"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 14.0875 86.7175)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="71.701"
+      y="71.3311"
+      width="14.632"
+      height="14.632"
+      rx="1.4632"
+      transform="rotate(180 71.701 71.3311)"
+      fill="#080072"
+    />
+    <rect
+      x="107.366"
+      y="70.4165"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 107.366 70.4165)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="123.798"
+      y="68.5875"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 123.798 68.5875)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="106.452"
+      y="87.632"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 106.452 87.632)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="123.798"
+      y="86.7175"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 123.798 86.7175)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="34.2064"
+      y="70.4165"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 34.2064 70.4165)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="70.7865"
+      y="106.996"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 70.7865 106.996)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="68.9575"
+      y="123.297"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 68.9575 123.297)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="87.2175"
+      y="123.297"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 87.2175 123.297)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="70.7865"
+      y="33.8364"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 70.7865 33.8364)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="33.292"
+      y="32.9219"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 33.292 32.9219)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="14.0875"
+      y="50.2975"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 14.0875 50.2975)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="70.7865"
+      y="52.1265"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 70.7865 52.1265)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="33.292"
+      y="51.212"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 33.292 51.212)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="51.582"
+      y="106.082"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 51.582 106.082)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="50.6675"
+      y="123.297"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 50.6675 123.297)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="51.582"
+      y="32.9219"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 51.582 32.9219)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="88.162"
+      y="32.9219"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 88.162 32.9219)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="106.422"
+      y="32.9219"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 106.422 32.9219)"
+      fill="#8FDDFF"
+    />
+    <rect
+      x="52.4965"
+      y="52.1265"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 52.4965 52.1265)"
+      fill="#080072"
+    />
+    <rect
+      x="89.0764"
+      y="52.1265"
+      width="12.803"
+      height="12.803"
+      rx="2.1948"
+      transform="rotate(180 89.0764 52.1265)"
+      fill="#080072"
+    />
+    <rect
+      x="106.452"
+      y="51.212"
+      width="10.974"
+      height="10.974"
+      rx="2.9264"
+      transform="rotate(180 106.452 51.212)"
+      fill="#13A7FF"
+    />
+    <rect
+      x="123.798"
+      y="50.2975"
+      width="9.145"
+      height="9.145"
+      rx="3.658"
+      transform="rotate(180 123.798 50.2975)"
+      fill="#8FDDFF"
+    />
+  </svg>
+</template>

--- a/src/components/FlowRunStateTypeTabDescription.vue
+++ b/src/components/FlowRunStateTypeTabDescription.vue
@@ -1,13 +1,17 @@
 <template>
   <template v-if="hasCount">
-    <span class="flow-run-state-type-tab-description">
+    <span v-if="description" class="flow-run-state-type-tab-description">
       {{ description }}
     </span>
+    <div v-else>
+      <FlowRunStateTypeEmpty :state-type="stateType" />
+    </div>
   </template>
 </template>
 
 <script lang="ts" setup>
   import { computed } from 'vue'
+  import FlowRunStateTypeEmpty from '@/components/FlowRunStateTypeEmpty.vue'
   import { useFlowRunsCount } from '@/compositions/useFlowRunsCount'
   import { FlowRunsFilter } from '@/models/Filters'
   import { StateType } from '@/models/StateType'
@@ -42,7 +46,7 @@
       return `Flows with ${statesString} runs`
     }
 
-    return `No flows with ${statesString} runs`
+    return null
   })
 </script>
 


### PR DESCRIPTION
Adds empty states to each tab of the Flow Runs card on the dashboard. Currently confirming dark mode styles.

https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/54f9871d-67a9-4c18-ad65-f26c3657728b

