### PR TITLE
update flow runs card tabs on dashboard

### DIFF
--- a/src/components/FlowRunStateTypeTabs.vue
+++ b/src/components/FlowRunStateTypeTabs.vue
@@ -16,9 +16,11 @@
 
 <script lang="ts" setup>
   import { useRouteQueryParam } from '@prefecthq/vue-compositions'
+  import { computed } from 'vue'
   import FlowRunsAccordion from '@/components/FlowRunsAccordion.vue'
   import FlowRunStateTypeCount from '@/components/FlowRunStateTypeCount.vue'
   import FlowRunStateTypeTabDescription from '@/components/FlowRunStateTypeTabDescription.vue'
+  import { useFlowRunsCount } from '@/compositions'
   import { FlowRunsFilter } from '@/models/Filters'
   import { StateType } from '@/models/StateType'
 
@@ -28,11 +30,23 @@
 
   const tabStates: Record<string, StateType[]> = {
     failed: ['failed', 'crashed'],
-    running: ['running', 'pending', 'paused'],
+    running: ['running', 'pending', 'cancelling'],
     completed: ['completed'],
-    scheduled: ['scheduled', 'cancelled'],
+    scheduled: ['scheduled', 'paused'],
+    cancelled: ['cancelled'],
   }
-  const tabs = Object.keys(tabStates)
+
+  const { count: cancelledCount } = useFlowRunsCount(getStateTypeFilter('cancelled'))
+
+  const tabs = computed(() => {
+    const tabNames = Object.keys(tabStates)
+
+    if (!cancelledCount.value || cancelledCount.value < 1) {
+      tabNames.splice(tabNames.indexOf('cancelled'), 1)
+    }
+
+    return tabNames
+  })
 
   const selected = useRouteQueryParam('flow-run-state', 'failed')
 
@@ -58,12 +72,8 @@
 </script>
 
 <style>
-.flow-run-state-type-tabs .p-tab-navigation { @apply
-  grid
-  grid-cols-4
-}
-
 .flow-run-state-type-tabs .p-tab { @apply
+  flex-grow
   flex
   items-center
   justify-center

--- a/src/components/FlowRunStateTypeTabs.vue
+++ b/src/components/FlowRunStateTypeTabs.vue
@@ -42,7 +42,7 @@
     const tabNames = Object.keys(tabStates)
 
     if (!cancelledCount.value || cancelledCount.value < 1) {
-      tabNames.splice(tabNames.indexOf('cancelled'), 1)
+      tabNames.filter(value => value !== 'cancelled')
     }
 
     return tabNames


### PR DESCRIPTION
This updates the categories for what shows in each tab on the Flow Runs card of the Dashboard.

If there are cancelled runs, a rare 5th tab is shown.

Without:
<img width="617" alt="Screenshot 2023-06-29 at 3 32 27 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/d2d0385d-35d4-4a1e-9765-9fd64bf51417">

With:
<img width="614" alt="Screenshot 2023-06-29 at 3 32 46 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/035f168d-409c-4749-9371-32bfee146307">
