### PR TITLE
Bugfix: Recursive work pool variables

### DIFF
--- a/src/components/WorkPoolBaseJobTemplateFormSection.vue
+++ b/src/components/WorkPoolBaseJobTemplateFormSection.vue
@@ -84,7 +84,9 @@
   const variablesSchemaHasProperties = computed<boolean>(() => Object.keys(variablesSchemaProperties.value).length > 0)
   const currentDefaults = computed<SchemaValues>({
     get() {
-      return getSchemaDefaultValues(variablesSchema.value)
+      const schema = mapper.map('SchemaResponse', variablesSchema.value, 'Schema')
+      const defaults = getSchemaDefaultValues(schema)
+      return defaults
     },
     set(values) {
       const newTemplate = {

--- a/src/services/schemas/properties/SchemaPropertyAny.ts
+++ b/src/services/schemas/properties/SchemaPropertyAny.ts
@@ -34,13 +34,7 @@ export class SchemaPropertyAny extends SchemaPropertyService {
 
   protected request(value: SchemaValue): unknown {
     if (this.has('anyOf') || this.has('allOf')) {
-      const reference = this.referenceRequest(value)
-
-      if (reference === undefined) {
-        return undefined
-      }
-
-      return reference
+      return this.referenceRequest(value)
     }
 
     return parseUnknownJson(value)
@@ -48,13 +42,7 @@ export class SchemaPropertyAny extends SchemaPropertyService {
 
   protected response(value: SchemaValue): unknown {
     if (this.has('anyOf') || this.has('allOf')) {
-      const reference = this.referenceResponse(value)
-
-      if (reference === undefined) {
-        return undefined
-      }
-
-      return reference
+      return this.referenceResponse(value)
     }
 
     return stringifyUnknownJson(value)
@@ -66,6 +54,7 @@ export class SchemaPropertyAny extends SchemaPropertyService {
     }
 
     const definition = getSchemaValueDefinition(this.property, value)
+
     if (definition === null) {
       return this.invalid()
     }

--- a/src/services/schemas/properties/SchemaPropertyAny.ts
+++ b/src/services/schemas/properties/SchemaPropertyAny.ts
@@ -8,7 +8,7 @@ import { parseUnknownJson, stringifyUnknownJson } from '@/utilities/json'
 
 export class SchemaPropertyAny extends SchemaPropertyService {
   protected get default(): unknown {
-    let defaultValue: unknown
+    let defaultValue: unknown = null
 
     if (this.has('default')) {
       defaultValue = this.property.default

--- a/src/services/schemas/properties/SchemaPropertyAny.ts
+++ b/src/services/schemas/properties/SchemaPropertyAny.ts
@@ -1,33 +1,26 @@
-import { getSchemaPropertyResponseValue, getSchemaValueDefinition, schemaPropertyServiceFactory } from '..'
 import { JsonInput } from '@/components'
-import { isBlockDocumentReferenceValue, isBlockDocumentValue } from '@/models'
+import { getSchemaValueDefinition, schemaPropertyServiceFactory } from '@/services/schemas'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { getSchemaPropertyDefaultValue, SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue } from '@/types/schemas'
-import { isEmptyObject, isNotNullish, sameValue } from '@/utilities'
+import { isEmptyObject, sameValue } from '@/utilities'
 import { parseUnknownJson, stringifyUnknownJson } from '@/utilities/json'
 
 export class SchemaPropertyAny extends SchemaPropertyService {
   protected get default(): unknown {
-    const isJson = this.componentIs(JsonInput)
-
     let defaultValue: unknown
 
-    if (this.has('anyOf') || this.has('allOf')) {
+    if (this.has('default')) {
+      defaultValue = this.property.default
+    } else if (this.has('anyOf') || this.has('allOf')) {
       defaultValue = this.getDefaultValueForFirstDefinition()
-    } else if (this.has('default') && isNotNullish(this.property.default)) {
-      if (isBlockDocumentReferenceValue(this.property.default) || isBlockDocumentValue(this.property.default)) {
-        defaultValue = this.property.default
-      } else {
-        defaultValue = getSchemaPropertyDefaultValue(this.property, this.level + 1)
-      }
     }
 
-    if (isJson) {
-      defaultValue = stringifyUnknownJson(defaultValue)
+    if (this.componentIs(JsonInput)) {
+      return stringifyUnknownJson(defaultValue) ?? ''
     }
 
-    return defaultValue
+    return defaultValue ?? {}
   }
 
   protected get component(): SchemaPropertyComponentWithProps {

--- a/src/services/schemas/properties/SchemaPropertyAny.ts
+++ b/src/services/schemas/properties/SchemaPropertyAny.ts
@@ -20,7 +20,7 @@ export class SchemaPropertyAny extends SchemaPropertyService {
       return stringifyUnknownJson(defaultValue) ?? ''
     }
 
-    return defaultValue ?? {}
+    return defaultValue
   }
 
   protected get component(): SchemaPropertyComponentWithProps {

--- a/src/services/schemas/properties/SchemaPropertyAny.ts
+++ b/src/services/schemas/properties/SchemaPropertyAny.ts
@@ -1,26 +1,35 @@
 import { getSchemaPropertyResponseValue, getSchemaValueDefinition, schemaPropertyServiceFactory } from '..'
 import { JsonInput } from '@/components'
+import { isBlockDocumentReferenceValue } from '@/models'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { getSchemaPropertyDefaultValue, SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue } from '@/types/schemas'
-import { isEmptyObject, sameValue } from '@/utilities'
+import { isEmptyObject, isNotNullish, sameValue } from '@/utilities'
 import { parseUnknownJson, stringifyUnknownJson } from '@/utilities/json'
 
 export class SchemaPropertyAny extends SchemaPropertyService {
   protected get default(): unknown {
-    if (this.has('default')) {
+    if (this.has('default') && isNotNullish(this.property.default)) {
+      if (isBlockDocumentReferenceValue(this.property.default)) {
+        return this.property.default
+      }
+
       return getSchemaPropertyResponseValue(this.property, this.property.default, this.level + 1)
     }
 
-    if (this.componentIs(JsonInput)) {
-      return ''
-    }
+    const isJson = this.componentIs(JsonInput)
 
     if (this.has('anyOf') || this.has('allOf')) {
-      return this.getDefaultValueForFirstDefinition()
+      const defaultValueForFirstDefinition = this.getDefaultValueForFirstDefinition()
+
+      if (isJson) {
+        return stringifyUnknownJson(defaultValueForFirstDefinition)
+      }
+
+      return defaultValueForFirstDefinition
     }
 
-    return null
+    return this.property.default
   }
 
   protected get component(): SchemaPropertyComponentWithProps {

--- a/src/services/schemas/properties/SchemaPropertyObject.ts
+++ b/src/services/schemas/properties/SchemaPropertyObject.ts
@@ -1,6 +1,5 @@
 import { JsonInput } from '@/components'
 import { InvalidSchemaValueError } from '@/models'
-import { schemaPropertyServiceFactory } from '@/services/schemas/properties'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps, getSchemaPropertyRequestValue, getSchemaPropertyResponseValue } from '@/services/schemas/utilities'
 import { SchemaValue, isSchemaValues, SchemaValues } from '@/types/schemas'
@@ -25,6 +24,11 @@ export class SchemaPropertyObject extends SchemaPropertyService {
     const parsed = (this.property.default ?? {}) as SchemaValues
     const mapped = mapValues(this.property.properties ?? {}, (key, property) => {
       const propertyValue = parsed[key]
+
+      if (isNullish(propertyValue)) {
+        return null
+      }
+
       return getSchemaPropertyResponseValue(property!, propertyValue, this.level + 1)
     })
 

--- a/src/services/schemas/properties/SchemaPropertyObject.ts
+++ b/src/services/schemas/properties/SchemaPropertyObject.ts
@@ -21,18 +21,7 @@ export class SchemaPropertyObject extends SchemaPropertyService {
       return stringifyUnknownJson(this.property.default) ?? null
     }
 
-    const parsed = (this.property.default ?? {}) as SchemaValues
-    const mapped = mapValues(this.property.properties ?? {}, (key, property) => {
-      const propertyValue = parsed[key]
-
-      if (isNullish(propertyValue)) {
-        return null
-      }
-
-      return getSchemaPropertyResponseValue(property!, propertyValue, this.level + 1)
-    })
-
-    return mapped
+    return this.property.default ?? {}
   }
 
   protected request(value: SchemaValue): unknown {

--- a/src/services/schemas/properties/SchemaPropertyService.ts
+++ b/src/services/schemas/properties/SchemaPropertyService.ts
@@ -70,6 +70,14 @@ export abstract class SchemaPropertyService {
       }
     }
 
+    try {
+      return this.response(this.default)
+    } catch (error) {
+      if (!(error instanceof InvalidSchemaValueError)) {
+        console.error(error)
+      }
+    }
+
     return this.default
   }
 

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -195,7 +195,7 @@ export function getSchemaValueAnyOfDefinition(property: SchemaPropertyAnyOf, val
   const index = getSchemaValueAnyOfDefinitionIndex(property, value)
 
   if (index === null || index === -1) {
-    console.warn('Schema property with anyOf had a value but could not be associated with a definition', property, value)
+    console.trace('Schema property with anyOf had a value but could not be associated with a definition', property, value)
 
     return null
   }
@@ -214,7 +214,7 @@ export function getSchemaValueAllOfDefinition(property: SchemaPropertyAllOf, val
   const index = getSchemaValueAllOfDefinitionIndex(property, value)
 
   if (index === null || index === -1) {
-    console.warn('Schema property with allOf had a value but could not be associated with a definition', property, value)
+    console.trace('Schema property with allOf had a value but could not be associated with a definition', property, value)
 
     return null
   }

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -195,7 +195,7 @@ export function getSchemaValueAnyOfDefinition(property: SchemaPropertyAnyOf, val
   const index = getSchemaValueAnyOfDefinitionIndex(property, value)
 
   if (index === null || index === -1) {
-    console.trace('Schema property with anyOf had a value but could not be associated with a definition', property, value)
+    console.log('Schema property with anyOf had a value but could not be associated with a definition', property, value)
 
     return null
   }
@@ -214,7 +214,7 @@ export function getSchemaValueAllOfDefinition(property: SchemaPropertyAllOf, val
   const index = getSchemaValueAllOfDefinitionIndex(property, value)
 
   if (index === null || index === -1) {
-    console.trace('Schema property with allOf had a value but could not be associated with a definition', property, value)
+    console.log('Schema property with allOf had a value but could not be associated with a definition', property, value)
 
     return null
   }

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -195,7 +195,7 @@ export function getSchemaValueAnyOfDefinition(property: SchemaPropertyAnyOf, val
   const index = getSchemaValueAnyOfDefinitionIndex(property, value)
 
   if (index === null || index === -1) {
-    console.warn('Schema property with anyOf had a value but could not be associated with a definition')
+    console.warn('Schema property with anyOf had a value but could not be associated with a definition', property, value)
 
     return null
   }
@@ -214,7 +214,7 @@ export function getSchemaValueAllOfDefinition(property: SchemaPropertyAllOf, val
   const index = getSchemaValueAllOfDefinitionIndex(property, value)
 
   if (index === null || index === -1) {
-    console.warn('Schema property with allOf had a value but could not be associated with a definition')
+    console.warn('Schema property with allOf had a value but could not be associated with a definition', property, value)
 
     return null
   }


### PR DESCRIPTION
This PR reverts some of the changes to default logic for the any and object schema services, placing this logic instead in the root property service response value fallback. 

Previously we were attempting to map the default value whenever it was being accessed, which was incorrect because the response service logic was _also_ hitting the default as a fallback, which resulted in infinite recursion in situations where the default value was null or undefined. 

This also fixes an issue where defaults, used as values for worker variables, weren't using the mapped schema when retrieving default values. This meant that form values that relied on referenced definitions (blocks in particular) were never properly populated. 

Resolves: #2984