### PR TITLE
BugFix: Flow run filters not working on the flow runs page

### DIFF
--- a/src/compositions/useFlowRuns.ts
+++ b/src/compositions/useFlowRuns.ts
@@ -1,4 +1,5 @@
 import { SubscriptionOptions, UseSubscription, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
+import merge from 'lodash/merge'
 import { computed, ComputedRef, MaybeRef, Ref, ref, watch } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useFilterPagination } from '@/compositions/useFilterPagination'
@@ -30,11 +31,10 @@ export function useFlowRuns(filter: FlowRunsFilter | Ref<FlowRunsFilter | null |
       return null
     }
 
-    const filter: FlowRunsFilter = {
-      ...filterRef.value,
+    const filter: FlowRunsFilter = merge({}, filterRef.value, {
       limit: limit.value,
       offset: offset.value,
-    }
+    })
 
     return [filter]
   })


### PR DESCRIPTION
# Description
Since `filter` is a sometimes a reactive, destructuring in a computed doesn't track changes correctly. using `merge` makes sure that all dependencies are tracked. 