### PR TITLE
fix bg of flow run list items on cards

### DIFF
--- a/src/components/FlowRunsAccordionContent.vue
+++ b/src/components/FlowRunsAccordionContent.vue
@@ -48,4 +48,10 @@
   flex
   justify-center
 }
+
+.flow-flow-runs-list .state-list-item { @apply
+  bg-slate-50
+  dark:bg-slate-700
+  dark:bg-opacity-50
+}
 </style>


### PR DESCRIPTION
This fixes the background color for FlowRunListItem on a card bg. Because this appears to be (currently) the only place this component is placed on a card, I opted for a css override. We don't do a lot of props for the purposes of style changes, but we could instead have a `on-card` prop or something and let the component itself manage this style adjustment, open to thoughts on that.

Dark mode after:
<img width="620" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/3e2e6ca3-5610-46c6-9690-e43af061537d">
_Note: On dark mode, the fully opaque `slate-700` failed contrast check for readability, this semi-transparent version sorta barely passes for larger text, but it's the same acceptance level that passes on the straight `slate-800` bg as well, so I figured it's good enough for now. I did try a semi-transparent `slate-900` but it was weird in actual experience._

Light mode after:
<img width="622" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/7ab3e2b0-a721-49b5-a992-1d7cf1791459">


Before:

<img width="618" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/84e2358e-68a5-44b1-99c6-458e985196f9">


<img width="611" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/42648af4-e32d-4c5f-b241-e60834d8f24c">
