### PR TITLE
Enhancement: Use bottom placement for flow run scatter plot popover

### DIFF
--- a/src/components/FlowRunPopOver.vue
+++ b/src/components/FlowRunPopOver.vue
@@ -18,7 +18,7 @@
     flowRunId: string,
   }>()
 
-  const placement = [positions.bottom, positions.top, positions.right, positions.left]
+  const placement = [positions.top, positions.bottom, positions.right, positions.left]
 </script>
 
 <style>

--- a/src/components/FlowRunPopOver.vue
+++ b/src/components/FlowRunPopOver.vue
@@ -1,5 +1,5 @@
 <template>
-  <PPopOver class="flow-run-pop-over" group="flow-run-pop-over" auto-close>
+  <PPopOver class="flow-run-pop-over" group="flow-run-pop-over" auto-close :placement="placement">
     <template #target="{ open }">
       <div class="flow-run-pop-over__trigger" @mouseover="open" />
     </template>
@@ -11,12 +11,14 @@
 </template>
 
 <script lang="ts" setup>
-  import { PPopOver } from '@prefecthq/prefect-design'
+  import { PPopOver, positions } from '@prefecthq/prefect-design'
   import FlowRunPopoverContent from '@/components/FlowRunPopOverContent.vue'
 
   defineProps<{
     flowRunId: string,
   }>()
+
+  const placement = [positions.bottom, positions.top, positions.right, positions.left]
 </script>
 
 <style>

--- a/src/components/FlowRunPopOver.vue
+++ b/src/components/FlowRunPopOver.vue
@@ -1,10 +1,10 @@
 <template>
-  <PPopOver ref="popover" class="flow-run-pop-over">
-    <template #target>
-      <div ref="trigger" class="flow-run-pop-over__trigger" @mouseover="open" />
+  <PPopOver class="flow-run-pop-over" group="flow-run-pop-over" auto-close>
+    <template #target="{ open }">
+      <div class="flow-run-pop-over__trigger" @mouseover="open" />
     </template>
 
-    <div ref="content" class="flow-run-pop-over__content">
+    <div class="flow-run-pop-over__content">
       <FlowRunPopoverContent :flow-run-id="flowRunId" />
     </div>
   </PPopOver>
@@ -12,60 +12,11 @@
 
 <script lang="ts" setup>
   import { PPopOver } from '@prefecthq/prefect-design'
-  import { onMounted, onUnmounted, ref } from 'vue'
   import FlowRunPopoverContent from '@/components/FlowRunPopOverContent.vue'
 
   defineProps<{
     flowRunId: string,
   }>()
-
-  const popover = ref<InstanceType<typeof PPopOver>>()
-  const trigger = ref<HTMLDivElement>()
-  const content = ref<HTMLDivElement>()
-
-  onMounted(() => {
-    document.addEventListener('mouseover', mouseover)
-    document.addEventListener('click', click)
-  })
-
-  onUnmounted(() => {
-    document.removeEventListener('mouseover', mouseover)
-    document.removeEventListener('click', click)
-  })
-
-  function open(): void {
-    if (popover.value) {
-      popover.value.open()
-    }
-  }
-
-  function click(event: MouseEvent): void {
-    const target = event.target as HTMLElement
-
-    if (!popover.value || !content.value) {
-      return
-    }
-
-    if (content.value.contains(target)) {
-      return
-    }
-
-    popover.value.close()
-  }
-
-  function mouseover(event: MouseEvent): void {
-    const target = event.target as HTMLElement
-
-    if (!popover.value || !trigger.value) {
-      return
-    }
-
-    if (trigger.value.contains(target) || !target.classList.contains('flow-run-pop-over__trigger')) {
-      return
-    }
-
-    popover.value.close()
-  }
 </script>
 
 <style>
@@ -83,5 +34,10 @@
 .flow-run-pop-over__trigger { @apply
   w-full
   h-full
+}
+
+.flow-run-pop-over__content { @apply
+  p-2
+  pointer-events-none
 }
 </style>


### PR DESCRIPTION
# Description
Fixes an issue where horizontally scrubbing through flow runs was difficult due to the popover appearing directly to the right of the flow run point on the chart. 

Closes https://github.com/PrefectHQ/prefect-ui-library/issues/1460

Also removed the custom logic for closing the popover in favor of the built in functionality which didn't exist when this component was first created. 

Also added a big a padding between the popover and the flow run point so even if the popover opens in the direction of the next point if they are right next to each other the next point should be visible. 