### PR TITLE
Bugfix: Json validation

### DIFF
--- a/src/services/schemas/properties/SchemaPropertyService.ts
+++ b/src/services/schemas/properties/SchemaPropertyService.ts
@@ -1,5 +1,4 @@
 import { SelectOption } from '@prefecthq/prefect-design'
-import { JsonInput } from '@/index'
 import { InvalidSchemaValueError } from '@/models/InvalidSchemaValueError'
 import { getSchemaPropertyAttrs, getSchemaPropertyComponentWithDefaultProps, getSchemaPropertyDefaultValidators, schemaPropertyComponentWithProps, SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { schemaHas, SchemaProperty, SchemaPropertyInputAttrs, SchemaPropertyMeta, SchemaValue } from '@/types/schemas'
@@ -7,7 +6,7 @@ import { Require } from '@/types/utilities'
 import { sameValue } from '@/utilities'
 import { isNumberArray, isStringArray } from '@/utilities/arrays'
 import { ComponentDefinition } from '@/utilities/components'
-import { fieldRules, isJson, ValidationMethod, ValidationMethodFactory } from '@/utilities/validation'
+import { fieldRules, ValidationMethod, ValidationMethodFactory } from '@/utilities/validation'
 
 export type SchemaPropertyServiceSource = {
   property: SchemaProperty,

--- a/src/services/schemas/properties/SchemaPropertyService.ts
+++ b/src/services/schemas/properties/SchemaPropertyService.ts
@@ -106,10 +106,6 @@ export abstract class SchemaPropertyService {
     const defaults = getSchemaPropertyDefaultValidators(this.property, required)
     const validators = fieldRules(title, ...this.validators)
 
-    if (this.componentIs(JsonInput)) {
-      validators.push(isJson(title))
-    }
-
     return [...validators, ...defaults]
   }
 

--- a/src/utilities/json.ts
+++ b/src/utilities/json.ts
@@ -33,7 +33,7 @@ export function stringifyUnknownJson(value: unknown): string | null | undefined 
   const parsed = parseUnknownJson(value)
 
   if (isString(parsed)) {
-    return value as string
+    return parsed
   }
 
   return JSON.stringify(parsed)

--- a/src/utilities/json.ts
+++ b/src/utilities/json.ts
@@ -14,7 +14,7 @@ export function parseUnknownJson(value: unknown): unknown {
     try {
       const parsed = JSON.parse(value)
 
-      // If the parsed value is a record, we return it.
+      // If the parsed value isn't a string, we return it.
       if (!isString(parsed)) {
         return parsed
       }

--- a/src/utilities/json.ts
+++ b/src/utilities/json.ts
@@ -9,9 +9,18 @@ export function stringify(value: JsonValue, replacer?: JsonReplacer): string {
 }
 
 export function parseUnknownJson(value: unknown): unknown {
-  if (typeof value === 'string') {
+  // If the incoming value is a string, we attempt to parse it as JSON.
+  if (isString(value)) {
     try {
-      return JSON.parse(value)
+      const parsed = JSON.parse(value)
+
+      // If the parsed value is a record, we return it.
+      if (!isString(parsed)) {
+        return parsed
+      }
+
+      // Otherwise, we return the original value, since strings are valid JSON.
+      return value
     } catch {
       // silence is golden
     }
@@ -24,7 +33,7 @@ export function stringifyUnknownJson(value: unknown): string | null | undefined 
   const parsed = parseUnknownJson(value)
 
   if (isString(parsed)) {
-    return parsed
+    return value as string
   }
 
   return JSON.stringify(parsed)


### PR DESCRIPTION
Removes JSON validation from schema JSON inputs in favor of value mapping instead - all values are now parsed but will fall back to strings instead, which are always valid JSON. Also fixes an issue where parsing was leading to quotes getting swallowed incorrectly. 