### PR TITLE
BugFix: Schema parameters not respecting strings for certain values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
         "pydantic",
         "rrule",
         "semibold",
+        "stringifying",
         "subflow",
         "Symlog",
         "tailwindcss",

--- a/src/components/SchemaInput.vue
+++ b/src/components/SchemaInput.vue
@@ -99,19 +99,6 @@
     return mapper.map('SchemaValuesResponse', { values, schema: props.schema }, 'SchemaValues')
   }
 
-  function shouldSync(values: SchemaValues, json: string): boolean {
-    try {
-      const valuesString = JSON.stringify(values)
-      const jsonRequest = JSON.parse(json)
-      const mappedJson = toSchemaValues(jsonRequest)
-      const jsonString = JSON.stringify(mappedJson)
-
-      return valuesString !== jsonString
-    } catch {
-      return false
-    }
-  }
-
   const { validate: validateReactiveForm, errors: reactiveFormErrors } = useReactiveForm(values, {
     initialValues: values.value,
   })
@@ -122,19 +109,18 @@
     return isEmptyObject(reactiveFormErrors.value)
   })
 
-  watch(values, values => {
-    if (shouldSync(values, json.value)) {
-      const mappedValues = toSchemaValuesRequest(values)
-
-      json.value = stringify(mappedValues)
-    }
-  })
-
-  watch(json, json => {
-    if (shouldSync(values.value, json)) {
-      const parsed = JSON.parse(json)
+  watch(inputType, type => {
+    if (type === 'form') {
+      const parsed = JSON.parse(json.value)
 
       values.value = toSchemaValues(parsed)
+      return
+    }
+
+    if (type === 'json') {
+      const mappedValues = toSchemaValuesRequest(values.value)
+
+      json.value = stringify(mappedValues)
     }
   })
 </script>

--- a/src/components/SchemaInput.vue
+++ b/src/components/SchemaInput.vue
@@ -126,7 +126,7 @@
 
   watch(inputType, (newType, oldType) => {
     if (newType === 'form') {
-      return syncJsonToForm
+      return syncJsonToForm()
     }
 
     if (newType === 'json') {

--- a/src/services/schemas/properties/SchemaPropertyAny.ts
+++ b/src/services/schemas/properties/SchemaPropertyAny.ts
@@ -3,7 +3,9 @@ import { getSchemaValueDefinition, schemaPropertyServiceFactory } from '@/servic
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { getSchemaPropertyDefaultValue, SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue } from '@/types/schemas'
-import { isEmptyObject, parseUnknownJson, sameValue, stringifyUnknownJson } from '@/utilities'
+import { isEmptyObject, sameValue } from '@/utilities'
+import { jsonSafeParse } from '@/utilities/jsonSafeParse'
+import { jsonSafeStringify } from '@/utilities/jsonSafeStringify'
 
 export class SchemaPropertyAny extends SchemaPropertyService {
   protected get default(): unknown {
@@ -16,7 +18,7 @@ export class SchemaPropertyAny extends SchemaPropertyService {
     }
 
     if (this.componentIs(JsonInput)) {
-      return stringifyUnknownJson(defaultValue) ?? ''
+      return jsonSafeStringify(defaultValue).value ?? ''
     }
 
     return defaultValue
@@ -36,7 +38,9 @@ export class SchemaPropertyAny extends SchemaPropertyService {
       return this.referenceRequest(value)
     }
 
-    return parseUnknownJson(value)
+    const { value: request } = jsonSafeParse(value)
+
+    return request
   }
 
   protected response(value: SchemaValue): unknown {
@@ -44,7 +48,9 @@ export class SchemaPropertyAny extends SchemaPropertyService {
       return this.referenceResponse(value)
     }
 
-    return stringifyUnknownJson(value)
+    const { value: response } = jsonSafeStringify(value)
+
+    return response
   }
 
   private referenceResponse(value: SchemaValue): SchemaValue {

--- a/src/services/schemas/properties/SchemaPropertyService.ts
+++ b/src/services/schemas/properties/SchemaPropertyService.ts
@@ -1,4 +1,5 @@
 import { SelectOption } from '@prefecthq/prefect-design'
+import { JsonInput } from '@/components'
 import { InvalidSchemaValueError } from '@/models/InvalidSchemaValueError'
 import { getSchemaPropertyAttrs, getSchemaPropertyComponentWithDefaultProps, getSchemaPropertyDefaultValidators, schemaPropertyComponentWithProps, SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { schemaHas, SchemaProperty, SchemaPropertyInputAttrs, SchemaPropertyMeta, SchemaValue } from '@/types/schemas'
@@ -6,7 +7,7 @@ import { Require } from '@/types/utilities'
 import { sameValue } from '@/utilities'
 import { isNumberArray, isStringArray } from '@/utilities/arrays'
 import { ComponentDefinition } from '@/utilities/components'
-import { fieldRules, ValidationMethod, ValidationMethodFactory } from '@/utilities/validation'
+import { fieldRules, isJson, ValidationMethod, ValidationMethodFactory } from '@/utilities/validation'
 
 export type SchemaPropertyServiceSource = {
   property: SchemaProperty,
@@ -104,6 +105,10 @@ export abstract class SchemaPropertyService {
     const { title = 'Property' } = this.property
     const defaults = getSchemaPropertyDefaultValidators(this.property, required)
     const validators = fieldRules(title, ...this.validators)
+
+    if (this.componentIs(JsonInput)) {
+      validators.push(isJson(title))
+    }
 
     return [...validators, ...defaults]
   }

--- a/src/utilities/jsonSafe.spec.ts
+++ b/src/utilities/jsonSafe.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { jsonSafeParse } from '@/utilities/jsonSafeParse'
+import { jsonSafeStringify } from '@/utilities/jsonSafeStringify'
+
+const date = new Date()
+
+// these values should be reversible.
+// parsing the first value should return the second
+// stringifying the second value should return the first
+const valid = [
+  ['true', true],
+  ['1', 1],
+  ['"foo"', 'foo'],
+  ['{}', {}],
+  ['{"foo":"bar"}', { foo: 'bar' }],
+  ['null', null],
+  ['[1,2,3]', [1, 2, 3]],
+  ['["foo","bar"]', ['foo', 'bar']],
+  [`"${date.toISOString()}"`, date],
+] as const
+
+const invalid = [
+  '"foo',
+  '{ "foo": ',
+]
+
+describe('jsonSafeParse', () => {
+
+  it.each(valid)('"%s" returns %s', (input, output) => {
+    const parsed = jsonSafeParse(input)
+
+    expect(parsed.value).toEqual(output)
+    expect(parsed.success).toBe(true)
+  })
+
+  it.each(invalid)('"%s" is invalid', (input) => {
+    const parsed = jsonSafeParse(input)
+
+    expect(parsed.value).toEqual(input)
+    expect(parsed.success).toBe(false)
+  })
+
+})
+
+describe('jsonSafeStringify', () => {
+
+  it.each(valid)('"%s" returns %s', (output, input) => {
+    const stringified = jsonSafeStringify(input)
+
+    expect(stringified.value).toEqual(output)
+    expect(stringified.success).toBe(true)
+  })
+
+  it.fails.each(invalid)('"%s" is invalid', (input) => {
+    const stringified = jsonSafeStringify(input)
+
+    expect(stringified.value).toEqual(input)
+    expect(stringified.success).toBe(false)
+  })
+
+})

--- a/src/utilities/jsonSafe.spec.ts
+++ b/src/utilities/jsonSafe.spec.ts
@@ -16,6 +16,7 @@ const valid = [
   ['null', null],
   ['[1,2,3]', [1, 2, 3]],
   ['["foo","bar"]', ['foo', 'bar']],
+  ['"\\""', '"'],
   [`"${date.toISOString()}"`, date],
 ] as const
 

--- a/src/utilities/jsonSafeParse.ts
+++ b/src/utilities/jsonSafeParse.ts
@@ -12,7 +12,8 @@ type JsonReviver = JsonParse[1]
 const ISO_DATE_REGEX = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
 
 const reviver: JsonReviver = (key, value) => {
-  if (ISO_DATE_REGEX.test(value)) {
+  // string check makes this significantly faster
+  if (isString(value) && ISO_DATE_REGEX.test(value)) {
     return parseISO(value)
   }
 

--- a/src/utilities/jsonSafeParse.ts
+++ b/src/utilities/jsonSafeParse.ts
@@ -1,0 +1,42 @@
+import { parseISO } from 'date-fns'
+import { isString } from '@/utilities/strings'
+
+export type JsonSafeParse = {
+  success: boolean,
+  value: unknown,
+}
+
+type JsonParse = Parameters<typeof JSON.parse>
+type JsonReviver = JsonParse[1]
+
+const ISO_DATE_REGEX = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
+
+const reviver: JsonReviver = (key, value) => {
+  if (ISO_DATE_REGEX.test(value)) {
+    return parseISO(value)
+  }
+
+  return value
+}
+
+export function jsonSafeParse(value: unknown): JsonSafeParse {
+  try {
+    if (!isString(value)) {
+      throw new Error()
+    }
+
+    const parsed = JSON.parse(value, reviver)
+
+    return {
+      success: true,
+      value: parsed,
+    }
+  } catch {
+    // silence is golden
+  }
+
+  return {
+    success: false,
+    value,
+  }
+}

--- a/src/utilities/jsonSafeStringify.ts
+++ b/src/utilities/jsonSafeStringify.ts
@@ -1,0 +1,22 @@
+export type JsonSafeStringify = {
+  success: boolean,
+  value: unknown,
+}
+
+export function jsonSafeStringify(value: unknown): JsonSafeStringify {
+  try {
+    const stringified = JSON.stringify(value)
+
+    return {
+      success: true,
+      value: stringified,
+    }
+  } catch {
+    // silence is golden
+  }
+
+  return {
+    success: false,
+    value,
+  }
+}


### PR DESCRIPTION
# Description
Fixes an issue specifically for schema properties of type `Any` where we were incorrectly converting values like `"123"` (a string) into `123` (an int). 

Closes https://github.com/PrefectHQ/prefect-ui-library/issues/1561

This introduces two new json utility methods: `jsonSafeParse` and `jsonSafeStringify` with unit tests to prove their functionality. These new utilities are used in the `SchemaPropertyAny` service replacing the flawed `parseUnknownJson` and `stringifyUnknown` json utilities. 

This also changes the syncing behavior of the `SchemaInput` component so we're no longer syncing the `form` and `json` tab values as the user types. Instead this happens when switching between tabs which is not only more performant but also is much safer.