### PR TITLE
BugFix: `datetime` deployment parameter value lost when switching from json to custom

### DIFF
--- a/src/utilities/jsonSafe.spec.ts
+++ b/src/utilities/jsonSafe.spec.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from 'vitest'
 import { jsonSafeParse } from '@/utilities/jsonSafeParse'
 import { jsonSafeStringify } from '@/utilities/jsonSafeStringify'
 
-const date = new Date()
-
 // these values should be reversible.
 // parsing the first value should return the second
 // stringifying the second value should return the first
@@ -17,7 +15,6 @@ const valid = [
   ['[1,2,3]', [1, 2, 3]],
   ['["foo","bar"]', ['foo', 'bar']],
   ['"\\""', '"'],
-  [`"${date.toISOString()}"`, date],
 ] as const
 
 const invalid = [

--- a/src/utilities/jsonSafeParse.ts
+++ b/src/utilities/jsonSafeParse.ts
@@ -1,23 +1,8 @@
-import { parseISO } from 'date-fns'
 import { isString } from '@/utilities/strings'
 
 export type JsonSafeParse = {
   success: boolean,
   value: unknown,
-}
-
-type JsonParse = Parameters<typeof JSON.parse>
-type JsonReviver = JsonParse[1]
-
-const ISO_DATE_REGEX = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
-
-const reviver: JsonReviver = (key, value) => {
-  // string check makes this significantly faster
-  if (isString(value) && ISO_DATE_REGEX.test(value)) {
-    return parseISO(value)
-  }
-
-  return value
 }
 
 export function jsonSafeParse(value: unknown): JsonSafeParse {
@@ -26,7 +11,7 @@ export function jsonSafeParse(value: unknown): JsonSafeParse {
       throw new Error()
     }
 
-    const parsed = JSON.parse(value, reviver)
+    const parsed = JSON.parse(value)
 
     return {
       success: true,


### PR DESCRIPTION
# Description
Removes the custom json reviver that converted iso dates back to date objects. The rest of the schema logic expects them to remain as strings. 