### PR TITLE
anchor task runs chart to bottom

### DIFF
--- a/src/components/WorkspaceDashboardTaskRunsCard.vue
+++ b/src/components/WorkspaceDashboardTaskRunsCard.vue
@@ -222,6 +222,8 @@
 .workspace-dashboard-task-runs-card__summary { @apply
   grid
   gap-1
+  relative
+  z-10
 }
 
 .workspace-dashboard-task-runs-card__statistic--completed .dashboard-statistic__value { @apply

--- a/src/components/WorkspaceDashboardTaskRunsCard.vue
+++ b/src/components/WorkspaceDashboardTaskRunsCard.vue
@@ -216,7 +216,7 @@
   gap-4
   auto-rows-max
   overflow-hidden
-  pb-20
+  pb-8
 }
 
 .workspace-dashboard-task-runs-card__summary { @apply

--- a/src/components/WorkspaceDashboardTaskRunsCard.vue
+++ b/src/components/WorkspaceDashboardTaskRunsCard.vue
@@ -216,6 +216,7 @@
   gap-4
   auto-rows-max
   overflow-hidden
+  pb-20
 }
 
 .workspace-dashboard-task-runs-card__summary { @apply
@@ -237,17 +238,20 @@
 }
 
 .workspace-dashboard-task-runs-card__chart-container { @apply
-  relative
+  absolute
   min-h-0
   h-16
+  left-0
+  right-0
+  bottom-4
 }
 
 .workspace-dashboard-task-runs-card__chart { @apply
   absolute
   min-h-0
-  -left-8
+  left-0
   top-0
-  -right-8
+  right-0
   bottom-0
 }
 


### PR DESCRIPTION
This positions the chart absolute to the bottom so that it will align with the Events chart nicer (I'll update the events chart with the same styles for consistency):

Before, the events card is taller so the baselines aren't lined up:
<img width="615" alt="Screenshot 2023-07-12 at 5 30 00 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/6082d8b0-78ac-4b0f-9384-25eb151d1112">

I also noticed the left/right positioning of the chart pushed it out of bounds of the card, seemingly cutting off information (@pleek91 unless this was intentional?)
<img width="339" alt="Screenshot 2023-07-12 at 5 30 11 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/e602fe7f-858d-47f8-b217-11086b991b00">

After, chart is aligned absolute to the bottom:
<img width="315" alt="Screenshot 2023-07-12 at 5 30 26 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/60751136-763c-48a7-bbf5-662c31a585e1">

It's also contained within the card:
<img width="337" alt="Screenshot 2023-07-12 at 5 30 48 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/b17ab73a-1102-44a9-9418-c8ce97a21fd8">


UPDATE:
Also reduced the bottom padding affordance, as the graph is cumulative, it's designed to go up and to the right, which actually lends pretty reliable space for the graph to encroach on the text's space. This was actually a part of the original design.
<img width="312" alt="Screenshot 2023-07-12 at 5 43 37 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/b3afa248-8b65-4a36-b4e0-b4391953ae12">
