### PR TITLE
Add awaiting retry to state names list

### DIFF
--- a/src/types/states.ts
+++ b/src/types/states.ts
@@ -16,6 +16,7 @@ export const prefectStateNames = [
   'Crashed',
   'Failed',
   'TimedOut',
+  'AwaitingRetry',
 ] as const
 export type PrefectStateNames = typeof prefectStateNames[number]
 
@@ -33,6 +34,7 @@ export const prefectStateNameTypes = {
   'Crashed': 'crashed',
   'Failed': 'failed',
   'TimedOut': 'failed',
+  'AwaitingRetry': 'scheduled',
 } as const satisfies Record<PrefectStateNames, StateType>
 
 export const prefectStateNamesWithoutScheduled = [

--- a/src/types/states.ts
+++ b/src/types/states.ts
@@ -6,6 +6,7 @@ export const prefectStateNames = [
   'Scheduled',
   'Late',
   'Resuming',
+  'AwaitingRetry',
   'Pending',
   'Paused',
   'Running',
@@ -16,7 +17,6 @@ export const prefectStateNames = [
   'Crashed',
   'Failed',
   'TimedOut',
-  'AwaitingRetry',
 ] as const
 export type PrefectStateNames = typeof prefectStateNames[number]
 
@@ -24,6 +24,7 @@ export const prefectStateNameTypes = {
   'Scheduled': 'scheduled',
   'Late': 'scheduled',
   'Resuming': 'scheduled',
+  'AwaitingRetry': 'scheduled',
   'Pending': 'pending',
   'Paused': 'paused',
   'Running': 'running',
@@ -34,7 +35,6 @@ export const prefectStateNameTypes = {
   'Crashed': 'crashed',
   'Failed': 'failed',
   'TimedOut': 'failed',
-  'AwaitingRetry': 'scheduled',
 } as const satisfies Record<PrefectStateNames, StateType>
 
 export const prefectStateNamesWithoutScheduled = [


### PR DESCRIPTION
Adds AwaitingRetry as a state name to the UI

<img width="1188" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/f893c27e-848c-4ff6-845c-dce0f727fea9">

Since it's [listed in the docs](https://docs.prefect.io/latest/concepts/states/?h=awaiting#state-types) it feels worth of inclusion in the UI. 