### PR TITLE
sort flows on the flow runs card

### DIFF
--- a/src/components/FlowRunsAccordion.vue
+++ b/src/components/FlowRunsAccordion.vue
@@ -29,7 +29,10 @@
     // eslint-disable-next-line no-unused-vars
     const { sort, limit, offset, ...filter } = props.filter
 
-    return filter
+    return {
+      ...filter,
+      sort: 'UPDATED_DESC',
+    }
   })
 
   const options = useInterval()


### PR DESCRIPTION
Sorts the flows newest to oldest on the Flow Runs card:

Before:
<img width="586" alt="Screenshot 2023-07-14 at 7 35 04 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/2388592e-a204-4ac6-bfb8-cfed4ac3ac18">

After:
<img width="586" alt="Screenshot 2023-07-14 at 7 34 07 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/4ed54934-8b6a-4623-9477-da8308ff7393">
