### PR TITLE
Fix/work pool card items layout

### DIFF
--- a/src/components/DashboardWorkPoolCard.vue
+++ b/src/components/DashboardWorkPoolCard.vue
@@ -20,9 +20,11 @@
         <WorkPoolQueueStatusArray :work-pool="workPool" />
       </DashboardWorkPoolCardDetail>
 
-      <DashboardWorkPoolCardDetail label="Avg. Late time">
-        <WorkPoolAverageLateTime :work-pool="workPool" :filter="flowRunsFilter" />
-        <DashboardWorkPoolLateCount :work-pool="workPool" :filter="flowRunsFilter" />
+      <DashboardWorkPoolCardDetail label="Late runs">
+        <div class="dashboard-work-pool-card__late-runs">
+          <DashboardWorkPoolLateCount :work-pool="workPool" :filter="flowRunsFilter" />
+          <WorkPoolAverageLateTime :work-pool="workPool" :filter="flowRunsFilter" />
+        </div>
       </DashboardWorkPoolCardDetail>
 
       <DashboardWorkPoolCardDetail label="Completes">
@@ -97,10 +99,14 @@
 
 .dashboard-work-pool-card__details { @apply
   p-3
-  flex
-  flex-wrap
-  justify-between
+  grid
+  grid-cols-4
   gap-y-2
-  sm:flex-nowrap
+}
+
+.dashboard-work-pool-card__late-runs { @apply
+  inline-flex
+  items-center
+  gap-1
 }
 </style>

--- a/src/components/DashboardWorkPoolCard.vue
+++ b/src/components/DashboardWorkPoolCard.vue
@@ -20,12 +20,9 @@
         <WorkPoolQueueStatusArray :work-pool="workPool" />
       </DashboardWorkPoolCardDetail>
 
-      <DashboardWorkPoolCardDetail label="Late runs">
-        <WorkPoolLateCount :work-pool="workPool" :filter="flowRunsFilter" />
-      </DashboardWorkPoolCardDetail>
-
       <DashboardWorkPoolCardDetail label="Avg. Late time">
         <WorkPoolAverageLateTime :work-pool="workPool" :filter="flowRunsFilter" />
+        <DashboardWorkPoolLateCount :work-pool="workPool" :filter="flowRunsFilter" />
       </DashboardWorkPoolCardDetail>
 
       <DashboardWorkPoolCardDetail label="Completes">
@@ -41,10 +38,10 @@
   import DashboardWorkPoolCardDetail from '@/components/DashboardWorkPoolCardDetail.vue'
   import DashboardWorkPoolFlowRunCompletes from '@/components/DashboardWorkPoolFlowRunCompletes.vue'
   import DashboardWorkPoolFlowRunsTotal from '@/components/DashboardWorkPoolFlowRunsTotal.vue'
+  import DashboardWorkPoolLateCount from '@/components/DashboardWorkPoolLateCount.vue'
   import FlowRunsBarChart from '@/components/FlowRunsBarChart.vue'
   import WorkPoolAverageLateTime from '@/components/WorkPoolAverageLateTime.vue'
   import WorkPoolLastPolled from '@/components/WorkPoolLastPolled.vue'
-  import WorkPoolLateCount from '@/components/WorkPoolLateCount.vue'
   import WorkPoolQueueStatusArray from '@/components/WorkPoolQueueStatusArray.vue'
   import { useWorkspaceRoutes } from '@/compositions'
   import { FlowRunsFilter, WorkPool } from '@/models'

--- a/src/components/DashboardWorkPoolCard.vue
+++ b/src/components/DashboardWorkPoolCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="dashboard-work-pool-card">
     <div class="dashboard-work-pool-card__header">
-      <p-link :to="routes.workPool(workPool.name)">
+      <p-link class="dashboard-work-pool-card__name" :to="routes.workPool(workPool.name)">
         {{ workPool.name }}
       </p-link>
       <FlowRunsBarChart
@@ -9,6 +9,7 @@
         mini
         :filter="flowRunsFilter"
       />
+      <DashboardWorkPoolFlowRunsTotal :work-pool="workPool" :filter="filter" />
     </div>
     <dl class="dashboard-work-pool-card__details">
       <DashboardWorkPoolCardDetail label="Polled">
@@ -25,10 +26,6 @@
 
       <DashboardWorkPoolCardDetail label="Avg. Late time">
         <WorkPoolAverageLateTime :work-pool="workPool" :filter="flowRunsFilter" />
-      </DashboardWorkPoolCardDetail>
-
-      <DashboardWorkPoolCardDetail label="Total runs">
-        <DashboardWorkPoolFlowRunsTotal :work-pool="workPool" :filter="filter" />
       </DashboardWorkPoolCardDetail>
 
       <DashboardWorkPoolCardDetail label="Completes">
@@ -84,12 +81,16 @@
 
 .dashboard-work-pool-card__header { @apply
   flex
-  justify-between
-  align-middle
+  items-center
+  gap-4
   p-3
   border-b
   border-slate-200
   dark:border-slate-700
+}
+
+.dashboard-work-pool-card__name { @apply
+  flex-grow
 }
 
 .dashboard-work-pool-card__mini-bars { @apply

--- a/src/components/DashboardWorkPoolCardDetail.vue
+++ b/src/components/DashboardWorkPoolCardDetail.vue
@@ -18,7 +18,6 @@
 <style>
 .dashboard-work-pool-card-detail { @apply
   text-center
-  w-[100px]
   max-w-full
 }
 

--- a/src/components/DashboardWorkPoolFlowRunCompletes.vue
+++ b/src/components/DashboardWorkPoolFlowRunCompletes.vue
@@ -157,6 +157,7 @@
 .work-pool-flow-run-complete-percentage__difference { @apply
   cursor-help
   text-xs
+  whitespace-nowrap
 }
 
 .work-pool-flow-run-complete-percentage__difference--negative { @apply

--- a/src/components/DashboardWorkPoolFlowRunsTotal.vue
+++ b/src/components/DashboardWorkPoolFlowRunsTotal.vue
@@ -1,10 +1,11 @@
 <template>
-  <span class="dashboard-work-pool-flow-runs-total">{{ allRunsCount }}</span>
+  <DashboardStatistic class="dashboard-work-pool-flow-runs-total" label="total" :value="allRunsCount" />
 </template>
 
 <script lang="ts" setup>
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
+  import DashboardStatistic from '@/components/DashboardStatistic.vue'
   import { useInterval, useWorkspaceApi } from '@/compositions'
   import { WorkPool, FlowRunsFilter } from '@/models'
   import { mapper } from '@/services'
@@ -36,5 +37,5 @@
   }))
   const options = useInterval()
   const allRunsCountSubscription = useSubscription(api.flowRuns.getFlowRunsCount, [allRunsCountFilter], options)
-  const allRunsCount = computed(() => allRunsCountSubscription.response)
+  const allRunsCount = computed(() => allRunsCountSubscription.response ?? 0)
 </script>

--- a/src/components/DashboardWorkPoolLateCount.vue
+++ b/src/components/DashboardWorkPoolLateCount.vue
@@ -1,6 +1,6 @@
 <template>
   <span class="work-pool-late-count" :class="classes">
-    {{ lateFlowRunsCount }}
+    ({{ lateFlowRunsCount }} runs)
   </span>
 </template>
 

--- a/src/components/DashboardWorkPoolLateCount.vue
+++ b/src/components/DashboardWorkPoolLateCount.vue
@@ -1,6 +1,6 @@
 <template>
   <span class="work-pool-late-count" :class="classes">
-    ({{ lateFlowRunsCount }} runs)
+    {{ lateFlowRunsCount }}
   </span>
 </template>
 

--- a/src/components/WorkPoolAverageLateTime.vue
+++ b/src/components/WorkPoolAverageLateTime.vue
@@ -1,11 +1,6 @@
 <template>
-  <span class="work-pool-average-late-time" :class="classes">
-    <template v-if="averageLateness">
-      {{ secondsToApproximateString(averageLateness) }}
-    </template>
-    <template v-else>
-      N/A
-    </template>
+  <span v-if="averageLateness" class="work-pool-average-late-time">
+    ({{ secondsToApproximateString(averageLateness) }} avg.)
   </span>
 </template>
 
@@ -39,14 +34,11 @@
 
   const averageLatenessSubscription = useSubscription(api.flowRuns.getFlowRunsAverageLateness, [lateFlowRunsFilter], options)
   const averageLateness = computed(() => averageLatenessSubscription.response)
-
-  const classes = computed(() => ({
-    'work-pool-average-late-time--zero': !averageLateness.value,
-  }))
 </script>
 
 <style>
-.work-pool-average-late-time--zero { @apply
-  text-slate-500
+.work-pool-average-late-time { @apply
+  text-xs
+  whitespace-nowrap
 }
 </style>

--- a/src/components/WorkPoolQueueStatusArray.vue
+++ b/src/components/WorkPoolQueueStatusArray.vue
@@ -46,6 +46,7 @@
   items-center
   justify-center
   gap-1
+  min-h-[1.5rem]
   max-w-full
 }
 


### PR DESCRIPTION
Rearranges some content on the work pool list items for the work pools card so that things have room to breath:

After:
<img width="607" alt="Screenshot 2023-07-14 at 10 03 15 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/8f040107-a504-4f9e-82a1-39a94aa6d2bf">

After with late runs:
<img width="610" alt="Screenshot 2023-07-14 at 10 02 20 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/951eb9a4-1dc3-4542-9eee-b37136ceec6b">


Before:
<img width="606" alt="Screenshot 2023-07-14 at 8 24 29 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/8a623969-b417-4aca-b9f1-7a52bf700d9f">
