### PR TITLE
hide failed line in Task Runs card if none

### DIFF
--- a/src/components/WorkspaceDashboardTaskRunsCard.vue
+++ b/src/components/WorkspaceDashboardTaskRunsCard.vue
@@ -11,7 +11,7 @@
     </div>
 
     <div class="workspace-dashboard-task-runs-card__chart-container">
-      <LineChart v-if="taskRunsChartData.hasFailed" :data="taskRunsChartData.failed" :options="{ maxValue: maxFailedValue }" class="workspace-dashboard-task-runs-card__chart workspace-dashboard-task-runs-card__chart--failed" />
+      <LineChart v-if="isDefined(failed) && failed > 0" :data="taskRunsChartData.failed" :options="{ maxValue: maxFailedValue }" class="workspace-dashboard-task-runs-card__chart workspace-dashboard-task-runs-card__chart--failed" />
       <LineChart :data="taskRunsChartData.completed" :options="{ maxValue: maxCompletedValue }" class="workspace-dashboard-task-runs-card__chart workspace-dashboard-task-runs-card__chart--completed" />
     </div>
   </p-card>
@@ -113,7 +113,6 @@
   const taskRunsChartData = computed(() => {
     const completed: LineChartData = []
     const failed: LineChartData = []
-    let hasFailed = false
     const running: LineChartData = []
 
     history.value.forEach(item => {
@@ -125,7 +124,6 @@
           completedCount += state.countRuns
         } else if (['FAILED', 'CRASHED'].includes(state.stateType)) {
           failedCount += state.countRuns
-          hasFailed = true
         }
       })
 
@@ -139,7 +137,6 @@
     return {
       completed,
       failed,
-      hasFailed,
       running,
     }
   })

--- a/src/components/WorkspaceDashboardTaskRunsCard.vue
+++ b/src/components/WorkspaceDashboardTaskRunsCard.vue
@@ -11,7 +11,7 @@
     </div>
 
     <div class="workspace-dashboard-task-runs-card__chart-container">
-      <LineChart :data="taskRunsChartData.failed" :options="{ maxValue: maxFailedValue }" class="workspace-dashboard-task-runs-card__chart workspace-dashboard-task-runs-card__chart--failed" />
+      <LineChart v-if="taskRunsChartData.hasFailed" :data="taskRunsChartData.failed" :options="{ maxValue: maxFailedValue }" class="workspace-dashboard-task-runs-card__chart workspace-dashboard-task-runs-card__chart--failed" />
       <LineChart :data="taskRunsChartData.completed" :options="{ maxValue: maxCompletedValue }" class="workspace-dashboard-task-runs-card__chart workspace-dashboard-task-runs-card__chart--completed" />
     </div>
   </p-card>
@@ -113,6 +113,7 @@
   const taskRunsChartData = computed(() => {
     const completed: LineChartData = []
     const failed: LineChartData = []
+    let hasFailed = false
     const running: LineChartData = []
 
     history.value.forEach(item => {
@@ -124,6 +125,7 @@
           completedCount += state.countRuns
         } else if (['FAILED', 'CRASHED'].includes(state.stateType)) {
           failedCount += state.countRuns
+          hasFailed = true
         }
       })
 
@@ -137,6 +139,7 @@
     return {
       completed,
       failed,
+      hasFailed,
       running,
     }
   })


### PR DESCRIPTION
Felt weird to have a flat red line when task runs have ran 100% as Completed

<img width="306" alt="Screenshot 2023-07-14 at 9 12 32 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/c8eb91c8-d1d9-4fe7-bd96-5bb9c45db0e3">
<img width="310" alt="Screenshot 2023-07-14 at 9 13 42 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/51c507d1-d030-4945-b8dc-dbd55727575d">
