### PR TITLE
BugFix: Flow run logs missing until after refresh

### DIFF
--- a/src/components/FlowRunLogs.vue
+++ b/src/components/FlowRunLogs.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { ref, computed, toRefs } from 'vue'
+  import { ref, computed, toRefs, watch } from 'vue'
   import LogLevelSelect from '@/components/LogLevelSelect.vue'
   import LogsContainer from '@/components/LogsContainer.vue'
   import LogsSort from '@/components/LogsSort.vue'
@@ -74,6 +74,12 @@
   function clear(): void {
     logLevel.value = 0
   }
+
+  watch(() => flowRun.value.stateType, type => {
+    if (isTerminalStateType(type)) {
+      logsSubscription.refresh()
+    }
+  })
 </script>
 
 <style>


### PR DESCRIPTION
# Description
Because we stop polling for logs once the flow run reaches a terminal state some logs can be missed that occur between the last logs poll interval and the flow run entering a terminal state. 

Added a refresh that happens when the flow enters a terminal state to make sure any last logs are shown in the ui. 