### PR TITLE
fix dashboard and flow stats polling

### DIFF
--- a/src/components/FlowRunsBarChart.vue
+++ b/src/components/FlowRunsBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="chart" class="flow-runs-bar-chart" :class="classes.root" :style="styles.root" @mouseleave="close">
+  <div ref="chart" class="flow-runs-bar-chart" :class="classes.root" @mouseleave="close">
     <template v-for="(flowRun, index) in barFlowRuns" :key="getKey(flowRun, index)">
       <p-pop-over class="flow-runs-bar-chart__bar-container" :to="chart" :placement="placement" :group="group" auto-close>
         <template #target="{ open }">
@@ -41,9 +41,6 @@
   const { width, height } = useElementRect(chart)
   const bars = computed(() => Math.floor(width.value / desiredBarWidth.value))
   const barsDebounced = useDebouncedRef(bars, 1000)
-  const styles = computed(() => ({
-    root: `grid-template-columns: repeat(${bars.value}, 1fr)`,
-  }))
 
   const classes = computed(() => ({
     root: {
@@ -117,15 +114,15 @@
   }
 
   function organizeFlowRunsWithGaps(flowRuns: FlowRun[]): (FlowRun | null)[] {
-    const { expectedStartTimeAfter, expectedStartTimeBefore } = props.filter.flowRuns ?? {}
+    const { expectedStartTimeAfter, expectedStartTimeBefore = new Date() } = props.filter.flowRuns ?? {}
 
-    if (!expectedStartTimeBefore || !expectedStartTimeAfter) {
+    if (!expectedStartTimeAfter) {
       return []
     }
 
     const totalTime = expectedStartTimeBefore.getTime() - expectedStartTimeAfter.getTime()
-    const bucketSize = totalTime / bars.value
-    const buckets: (FlowRun | null)[] = new Array(bars.value).fill(null)
+    const bucketSize = totalTime / barsDebounced.value
+    const buckets: (FlowRun | null)[] = new Array(barsDebounced.value).fill(null)
 
     function getEmptyBucket(index: number): number | null {
       if (index < 0) {
@@ -163,9 +160,10 @@
 <style>
 .flow-runs-bar-chart { @apply
   relative
-  grid
-  items-end
-  grid-rows-1;
+  w-full
+  h-full
+  flex
+  items-end;
   --bar-padding: 3px;
   --bar-min-height: 6px;
 }

--- a/src/maps/dashboard.ts
+++ b/src/maps/dashboard.ts
@@ -14,7 +14,7 @@ export const mapWorkspaceDashboardFilterToTaskRunsFilter: MapFunction<WorkspaceD
     },
     taskRuns: {
       startTimeAfter: subSeconds(now, source.timeSpanInSeconds),
-      startTimeBefore: now,
+      startTimeNull: false,
     },
   }
 }
@@ -24,7 +24,6 @@ export const mapWorkspaceDashboardFilterToTaskRunsHistoryFilter: MapFunction<Wor
 
   return {
     historyStart: subSeconds(now, source.timeSpanInSeconds),
-    historyEnd: now,
     historyIntervalSeconds: source.timeSpanInSeconds / 20,
     flowRuns: {
       tags: {
@@ -39,7 +38,7 @@ export const mapWorkspaceDashboardFilterToFlowRunsFilter: MapFunction<WorkspaceD
   const filter: FlowRunsFilter = {
     flowRuns: {
       expectedStartTimeAfter: subSeconds(now, source.timeSpanInSeconds),
-      expectedStartTimeBefore: now,
+      startTimeNull: false,
       tags: {
         name: source.tags,
       },
@@ -55,7 +54,6 @@ export const mapWorkspaceDashboardFilterToWorkPoolWorkersFilter: MapFunction<Wor
   return {
     workers: {
       lastHeartbeatTimeAfter: subSeconds(now, source.timeSpanInSeconds),
-      lastHeartbeatTimeBefore: now,
     },
   }
 }

--- a/src/maps/filters.ts
+++ b/src/maps/filters.ts
@@ -517,9 +517,11 @@ export const mapWorkPoolQueuesFilter: MapFunction<WorkPoolQueuesFilter, WorkPool
 }
 
 export const mapTaskRunsHistoryFilter: MapFunction<TaskRunsHistoryFilter, TaskRunsHistoryFilterRequest> = function(source) {
+  const now = new Date()
+
   return {
     history_start: this.map('Date', source.historyStart, 'string'),
-    history_end: this.map('Date', source.historyEnd, 'string'),
+    history_end: this.map('Date', source.historyEnd ?? now, 'string'),
     history_interval_seconds: source.historyIntervalSeconds,
     flows: this.map('FlowFilter', source.flows, 'FlowFilterRequest'),
     deployments: this.map('DeploymentFilter', source.deployments, 'DeploymentFilterRequest'),

--- a/src/maps/flowStatsFilter.ts
+++ b/src/maps/flowStatsFilter.ts
@@ -12,7 +12,7 @@ export const mapFlowStatsFilterToFlowRunsFilter: MapFunction<FlowStatsFilter, Fl
     },
     flowRuns: {
       expectedStartTimeAfter: subSeconds(now, source.timeSpanInSeconds),
-      expectedStartTimeBefore: now,
+      startTimeNull: false,
     },
   }
 
@@ -28,7 +28,7 @@ export const mapFlowStatsFilterToTaskRunsFilter: MapFunction<FlowStatsFilter, Ta
     },
     taskRuns: {
       startTimeAfter: subSeconds(now, source.timeSpanInSeconds),
-      startTimeBefore: now,
+      startTimeNull: false,
     },
   }
 }

--- a/src/maps/taskRunHistory.ts
+++ b/src/maps/taskRunHistory.ts
@@ -28,11 +28,11 @@ export const mapTaskRunsFilterToTaskRunsHistoryFilter: MapFunction<TaskRunsFilte
 
   const { flows, flowRuns, deployments, taskRuns } = source
   const {
-    startTimeBefore = now,
+    startTimeBefore,
     startTimeAfter = subHours(now, defaultTimeSpanHours),
   } = taskRuns ?? {}
 
-  const timeSpanInSeconds = (startTimeBefore.getTime() - startTimeAfter.getTime()) / 1000
+  const timeSpanInSeconds = ((startTimeBefore ?? now).getTime() - startTimeAfter.getTime()) / 1000
 
   return {
     flows,

--- a/src/models/Filters.ts
+++ b/src/models/Filters.ts
@@ -260,6 +260,6 @@ export type WorkPoolWorkersFilter = {
 
 export type TaskRunsHistoryFilter = Pick<TaskRunsFilter, 'deployments' | 'flows' | 'flowRuns' | 'taskRuns'> & {
   historyStart: Date,
-  historyEnd: Date,
+  historyEnd?: Date,
   historyIntervalSeconds: number,
 }


### PR DESCRIPTION
Removes the end date requirements for the dashboard and Flow Stats related mappers. That way when polling happens, they'll always fetch data up to the latest moment.