### PR TITLE
BugFix: Update useWorkPoolLastPolled to not accept a filter

### DIFF
--- a/src/components/DashboardWorkPoolCard.vue
+++ b/src/components/DashboardWorkPoolCard.vue
@@ -13,7 +13,7 @@
     </div>
     <dl class="dashboard-work-pool-card__details">
       <DashboardWorkPoolCardDetail label="Polled">
-        <WorkPoolLastPolled :work-pool="workPool" :filter="filter" />
+        <WorkPoolLastPolled :work-pool="workPool" />
       </DashboardWorkPoolCardDetail>
 
       <DashboardWorkPoolCardDetail label="Work Queues">

--- a/src/components/WorkPoolCard.vue
+++ b/src/components/WorkPoolCard.vue
@@ -55,7 +55,7 @@
   }
   const workPoolName = computed(() => props.workPool.name)
 
-  const { lastPolled } = useWorkPoolLastPolled(workPoolName, {}, subscriptionOptions)
+  const { lastPolled } = useWorkPoolLastPolled(workPoolName, subscriptionOptions)
 
   const emit = defineEmits<{
     (event: 'update'): void,

--- a/src/components/WorkPoolLastPolled.vue
+++ b/src/components/WorkPoolLastPolled.vue
@@ -13,19 +13,14 @@
   import { computed } from 'vue'
   import { useInterval, useWorkPoolLastPolled } from '@/compositions'
   import { WorkPool } from '@/models'
-  import { mapper } from '@/services'
-  import { WorkspaceDashboardFilter } from '@/types'
 
   const props = defineProps<{
     workPool: WorkPool,
-    filter?: WorkspaceDashboardFilter,
   }>()
 
-  const workPoolName = computed(() => props.workPool.name)
-  const workPoolWorkersFilter = computed(() => mapper.map('WorkspaceDashboardFilter', props.filter, 'WorkPoolWorkersFilter'))
-
   const options = useInterval()
-  const { lastPolled } = useWorkPoolLastPolled(workPoolName, workPoolWorkersFilter, options)
+  const workPoolName = computed(() => props.workPool.name)
+  const { lastPolled } = useWorkPoolLastPolled(workPoolName, options)
 </script>
 
 <style>


### PR DESCRIPTION
# Description
The `useWorkPoolLastPolled` composition accepted a filter which was being used to limit the work queues. But this defeats the point of knowing then the work pool was last polled. Removing that filter to get an accurate time