### PR TITLE
Enhancement: Make the work pools wizard more push work pool friendly

### DIFF
--- a/src/components/WorkPoolCreateWizard.vue
+++ b/src/components/WorkPoolCreateWizard.vue
@@ -1,13 +1,13 @@
 <template>
   <p-wizard :steps="steps" last-step-text="Create" show-cancel @submit="submit" @cancel="cancel">
-    <template #work-pool-information>
-      <WorkPoolCreateWizardStepInformation v-model:workPool="workPool" />
-    </template>
     <template #work-pool-infrastructure-type>
       <WorkPoolCreateWizardStepInfrastructureType v-model:workPool="workPool" :workers="availableWorkers" />
     </template>
     <template #work-pool-infrastructure-configuration>
       <WorkPoolCreateWizardStepInfrastructureConfiguration v-model:workPool="workPool" :default-base-job-template="defaultBaseJobTemplate" />
+    </template>
+    <template #work-pool-information>
+      <WorkPoolCreateWizardStepInformation v-model:workPool="workPool" />
     </template>
   </p-wizard>
 </template>
@@ -28,9 +28,9 @@
   const workPool = ref<WorkPoolFormValues>({})
 
   const steps: WizardStep[] = [
-    { title: 'Basic Information', key: 'work-pool-information' },
     { title: 'Infrastructure Type', key: 'work-pool-infrastructure-type' },
     { title: 'Configuration', key: 'work-pool-infrastructure-configuration' },
+    { title: 'Basic Information', key: 'work-pool-information' },
   ]
 
   const api = useWorkspaceApi()

--- a/src/components/WorkPoolCreateWizard.vue
+++ b/src/components/WorkPoolCreateWizard.vue
@@ -7,7 +7,7 @@
       <WorkPoolCreateWizardStepInfrastructureConfiguration v-model:workPool="workPool" :default-base-job-template="defaultBaseJobTemplate" />
     </template>
     <template #work-pool-information>
-      <WorkPoolCreateWizardStepInformation v-model:workPool="workPool" />
+      <WorkPoolCreateWizardStepInformation v-model:workPool="workPool" :workers="availableWorkers" />
     </template>
   </p-wizard>
 </template>
@@ -30,7 +30,7 @@
   const steps: WizardStep[] = [
     { title: 'Infrastructure Type', key: 'work-pool-infrastructure-type' },
     { title: 'Configuration', key: 'work-pool-infrastructure-configuration' },
-    { title: 'Basic Information', key: 'work-pool-information' },
+    { title: 'Details', key: 'work-pool-information' },
   ]
 
   const api = useWorkspaceApi()

--- a/src/components/WorkPoolCreateWizardStepInformation.vue
+++ b/src/components/WorkPoolCreateWizardStepInformation.vue
@@ -61,7 +61,6 @@
 
   const isPushWorkPool = computed(() => {
     const worker = props.workers.find(({ type }) => type === workPool.value.type)
-    console.log('worker', worker)
     return worker?.isPushPool ?? false
   })
 

--- a/src/components/WorkPoolCreateWizardStepInformation.vue
+++ b/src/components/WorkPoolCreateWizardStepInformation.vue
@@ -12,7 +12,7 @@
       </template>
     </p-label>
 
-    <p-label label="Flow Run Concurrency (Optional)">
+    <p-label v-if="!isPushWorkPool" label="Flow Run Concurrency (Optional)">
       <template #default="{ id }">
         <p-number-input :id="id" v-model="concurrencyLimit" placeholder="Unlimited" :min="0" />
       </template>
@@ -24,10 +24,12 @@
   import { useWizardStep } from '@prefecthq/prefect-design'
   import { usePatchRef, useValidation, useValidationObserver } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
+  import { WorkerCollectionItem } from '@/models'
   import { WorkPoolFormValues } from '@/models/WorkPool'
 
   const props = defineProps<{
     workPool: WorkPoolFormValues,
+    workers: WorkerCollectionItem[],
   }>()
 
   const emit = defineEmits<{
@@ -55,6 +57,12 @@
     }
 
     return 'Name is required'
+  })
+
+  const isPushWorkPool = computed(() => {
+    const worker = props.workers.find(({ type }) => type === workPool.value.type)
+    console.log('worker', worker)
+    return worker?.isPushPool ?? false
   })
 
   defineValidate(validate)

--- a/src/maps/workerCollection.ts
+++ b/src/maps/workerCollection.ts
@@ -24,6 +24,7 @@ WorkerCollectionItem[]
       logoUrl: worker_data.logo_url,
       type: worker_data.type,
       isBeta: worker_data.is_beta ?? false,
+      isPushPool: worker_data.is_push_pool ?? false,
     }))
 }
 

--- a/src/models/WorkerCollectionItem.ts
+++ b/src/models/WorkerCollectionItem.ts
@@ -14,6 +14,7 @@ export type WorkerCollectionItem = {
   logoUrl?: string,
   type?: string,
   isBeta?: boolean,
+  isPushPool?: boolean,
 }
 
 export type WorkerColection = Record<string, WorkerCollectionItem>

--- a/src/models/api/WorkerCollectionItemResponse.ts
+++ b/src/models/api/WorkerCollectionItemResponse.ts
@@ -14,6 +14,7 @@ export type WorkerCollectionItemResponse = {
   logo_url?: string,
   type?: string,
   is_beta?: boolean,
+  is_push_pool?: boolean,
 }
 
 export type WorkerCollectionResponse = Record<string, WorkerCollectionItemResponse>


### PR DESCRIPTION
Follow on to #1603 

Currently the first step in the work pool create wizard is to add details.  This PR switches the order around so that details are last. This:
1. Makes the work pool creation wizard consistent with the automations wizard
2. Allows us to hide the concurrency input on the details step for push work pools

This PR also adds the logic to hide the input for push work pools. 

