### PR TITLE
Bugfix: Remove flow run storage from `useFlowRun` composition

### DIFF
--- a/src/compositions/useFlowRun.ts
+++ b/src/compositions/useFlowRun.ts
@@ -1,9 +1,8 @@
 import { SubscriptionOptions, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { computed, MaybeRefOrGetter, toRef, toValue, watch } from 'vue'
+import { computed, MaybeRefOrGetter, toRef, toValue } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
 import { WorkspaceFlowRunsApi } from '@/services'
-import { useFlowRunStorage } from '@/services/storage'
 import { Getter } from '@/types/reactivity'
 import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
@@ -31,21 +30,7 @@ export function useFlowRun(flowRunId: MaybeRefOrGetter<string | null | undefined
 
   const subscription = useSubscriptionWithDependencies(api.flowRuns.getFlowRun, parameters, options)
 
-  const storage = useFlowRunStorage()
-
-  watch(() => subscription.response, response => {
-    if (response) {
-      storage.add(response)
-    }
-  })
-
-  const flowRun = computed(() => {
-    if (subscription.response) {
-      return storage.get(subscription.response.id)
-    }
-
-    return undefined
-  })
+  const flowRun = computed(() => subscription.response)
 
   return {
     subscription,


### PR DESCRIPTION
For an unknown reason `useSubscriptionWithDependencies` (and probably `useSubscription` as well) is choking on `null` parameters during navigation, throwing an error after the interval period. 

This PR removes storage from the `useFlowRun` composition while we investigate the root cause. I've elected not to remove storage from the `useFlowRuns` composition as I wasn't able to repro similar behavior 

Related [#1654](https://github.com/PrefectHQ/prefect-ui-library/issues/1654)
Resolves [#10461](https://github.com/PrefectHQ/prefect/issues/10461)