### PR TITLE
BugFix: Fix empty json input causes flow errors

### DIFF
--- a/src/services/schemas/properties/SchemaPropertyArray.ts
+++ b/src/services/schemas/properties/SchemaPropertyArray.ts
@@ -5,6 +5,7 @@ import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue } from '@/types/schemas'
 import { parseUnknownJson } from '@/utilities/parseUnknownJson'
 import { stringifyUnknownJson } from '@/utilities/stringifyUnknownJson'
+import { isEmptyString } from '@/utilities/strings'
 
 export class SchemaPropertyArray extends SchemaPropertyService {
 
@@ -28,6 +29,10 @@ export class SchemaPropertyArray extends SchemaPropertyService {
 
   protected request(value: SchemaValue): unknown {
     if (this.componentIs(JsonInput)) {
+      if (isEmptyString(value)) {
+        return undefined
+      }
+
       return parseUnknownJson(value)
     }
 


### PR DESCRIPTION
# Description
Leaving a field blank should mean that no value is sent for that parameter. However with an array if you filled out the field and then deleted the value (returning it to an empty state) an empty string (`""`) would incorrectly be sent for that parameter. 

So the run being created would error because it was expecting a list and it was given a string. 

Related to https://github.com/PrefectHQ/nebula/issues/5433

<img width="1224" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/a327077e-25d9-402f-880f-88b63f542bbc">
