### PR TITLE
Chore: Update release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     paths: 
       - package.json
     branches:
-      - rebrand
+      - main
       
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,60 +5,42 @@ on:
     paths: 
       - package.json
     branches:
-      - main
-
+      - rebrand
+      
 jobs:
-
-  version-change-check:
-    name: Check Package Version
-    runs-on: ubuntu-latest
-
-    steps: 
-      - uses: actions/checkout@v2
-
-      - name: Check Package Version
-        uses: EndBug/version-check@v2.1.0
-        id: check
-        with: 
-          diff-search: true
-          file-name: ./package.json
-
-      - name: Cancel
-        if: steps.check.outputs.changed == 'false'
-        uses: andymckay/cancel-action@0.2
 
   build-and-publish:
     name: Build & Publish Release
     runs-on: ubuntu-latest
-    needs: [version-change-check]
     environment: 'prod'
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
       
       - name: Install dependencies
-        run: npm ci install
+        run: npm ci
 
       - name: Build package
         run: npm run build
 
       - name: Publish Package
         id: publish
-        uses: JS-DevTools/npm-publish@v1
+        uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}
           access: public
-
-      - name: Create Release
-        uses: actions/create-release@v1
+          strategy: upgrade
+      
+      - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.publish.outputs.version }}
-          release_name: Release ${{ steps.publish.outputs.version }}
+          tag: ${{ steps.publish.outputs.version }}
+        run: |
+          gh release create "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="Release ${tag#v}" \
+              --generate-notes


### PR DESCRIPTION
# Description
Updates the release action to match what we've been using for beta releases. That workflow works quite a bit better and we haven't had any issues with it so going to use that for stable releases. 