### PR TITLE
Maintenance: Add slots to empty state actions section

### DIFF
--- a/src/components/DeploymentsPageEmptyState.vue
+++ b/src/components/DeploymentsPageEmptyState.vue
@@ -15,7 +15,9 @@
     </template>
 
     <template #actions>
-      <DocumentationButton :to="localization.docs.deployments" />
+      <slot name="actions">
+        <DocumentationButton :to="localization.docs.deployments" />
+      </slot>
     </template>
   </p-empty-state>
 </template>

--- a/src/components/FlowRunsPageEmptyState.vue
+++ b/src/components/FlowRunsPageEmptyState.vue
@@ -13,9 +13,11 @@
     </template>
 
     <template #actions>
-      <DocumentationButton :to="localization.docs.gettingStarted">
-        Get Started
-      </DocumentationButton>
+      <slot name="actions">
+        <DocumentationButton :to="localization.docs.gettingStarted">
+          Get Started
+        </DocumentationButton>
+      </slot>
     </template>
   </p-empty-state>
 </template>

--- a/src/components/FlowsPageEmptyState.vue
+++ b/src/components/FlowsPageEmptyState.vue
@@ -14,7 +14,9 @@
     </template>
 
     <template #actions>
-      <DocumentationButton :to="localization.docs.flows" />
+      <slot name="actions">
+        <DocumentationButton :to="localization.docs.flows" />
+      </slot>
     </template>
   </p-empty-state>
 </template>


### PR DESCRIPTION
Adds slots to some of our empty states so we can add extra action options in Cloud

I expect this will be helpful for https://github.com/PrefectHQ/nebula-ui/pull/3251 or a fast follow up