### PR TITLE
Fix: Add truncate to log rows for task run names

### DIFF
--- a/src/components/LogRow.vue
+++ b/src/components/LogRow.vue
@@ -62,7 +62,7 @@
   shrink-0
   text-right
   pl-1
-  overflow-auto
+  truncate
 }
 
 .log-row__logger { @apply

--- a/src/components/LogRow.vue
+++ b/src/components/LogRow.vue
@@ -62,6 +62,7 @@
   shrink-0
   text-right
   pl-1
+  overflow-auto
 }
 
 .log-row__logger { @apply


### PR DESCRIPTION
Before:
<img width="1157" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/51d8252a-1767-428e-8519-8e364d51b6e5">

After:
<img width="1007" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/b0f140f5-59e1-4e57-8f55-5941dcbd2a14">
<img width="188" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/298329d7-19a3-4271-bc11-36f43edcc3cf">

Resolves https://github.com/PrefectHQ/nebula-ui/issues/3170
