### PR TITLE
BugFix: `useTabs` doesn't pick up incorrect or not visible tabs on mount

### DIFF
--- a/src/compositions/useTabs.ts
+++ b/src/compositions/useTabs.ts
@@ -29,7 +29,7 @@ export function useTabs(tabs: MaybeRef<ConditionalTab[]>, tab?: MaybeRef<string 
     }
 
     tabRef.value = firstVisibleTab.value
-  })
+  }, { immediate: true })
 
   return {
     tabs: visibleTabs,


### PR DESCRIPTION
# Description
Adding `immediate: true` to the tabs watcher so that even if the selected tab isn't visible (or incorrect) on mount a tab will always be visible. 

Closes https://github.com/PrefectHQ/nebula-ui/issues/3265