### PR TITLE
Expose initName as a prop for FlowRunCreateForm

### DIFF
--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -109,7 +109,7 @@
     deployment: Deployment,
     // these must be the unmapped SchemaValues
     parameters?: SchemaValues,
-    initName?: string,
+    name?: string,
   }>()
 
   const generateRandomName = (): string => {
@@ -152,7 +152,7 @@
   const tags = ref<string[]>(props.deployment.tags ?? [])
   const retries = ref<number | null>(null)
   const retryDelay = ref<number | null>(null)
-  const name = ref<string>(props.initName ?? generateRandomName())
+  const name = ref<string>(props.name ?? generateRandomName())
   const parameters = ref<SchemaValues>(combinedParameters.value)
   const stateMessage = ref<string>('')
   const workQueueName = ref<string | null>(props.deployment.workQueueName)

--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -109,6 +109,7 @@
     deployment: Deployment,
     // these must be the unmapped SchemaValues
     parameters?: SchemaValues,
+    initName?: string,
   }>()
 
   const generateRandomName = (): string => {
@@ -151,7 +152,7 @@
   const tags = ref<string[]>(props.deployment.tags ?? [])
   const retries = ref<number | null>(null)
   const retryDelay = ref<number | null>(null)
-  const name = ref<string>(generateRandomName())
+  const name = ref<string>(props.initName ?? generateRandomName())
   const parameters = ref<SchemaValues>(combinedParameters.value)
   const stateMessage = ref<string>('')
   const workQueueName = ref<string | null>(props.deployment.workQueueName)


### PR DESCRIPTION
Small PR that exposes a new optional prop on FlowRunCreateForm called `initName`; when provided, is set as the run name (and it can still be overwritten / randomly generated with the button).

We can leverage this in the last onboarding step to be suggestive of how someone might use this field, and I wouldn't be surprised if came up with other uses for it as well.