### PR TITLE
Simplify flow run create form

### DIFF
--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -1,11 +1,8 @@
 <template>
   <p-form class="flow-run-create-form p-background" @submit="submit">
     <p-content class="flow-run-create-form__section">
-      <h3 class="flow-run-create-form__section-header">
-        General
-      </h3>
 
-      <p-label label="Name (Optional)">
+      <p-label label="Run Name">
         <p-text-input v-model="name">
           <template #append>
             <p-button
@@ -17,48 +14,6 @@
           </template>
         </p-text-input>
       </p-label>
-
-      <p-label label="Message (Optional)">
-        <p-textarea v-model="stateMessage" placeholder="Created from the Prefect UI" />
-      </p-label>
-
-      <p-label label="Tags (Optional)">
-        <p-tags-input v-model="tags" :options="deploymentTags" />
-      </p-label>
-
-      <p-label v-if="workPoolName && !workPool?.isPushPool" :label="workQueueComboboxLabel">
-        <WorkPoolQueueCombobox v-model:selected="workQueueName" :work-pool-name="workPoolName" />
-      </p-label>
-
-      <div class="flow-run-create-form__retries">
-        <p-label label="Retries (optional)">
-          <p-number-input v-model="retries" :min="0" />
-        </p-label>
-
-        <p-label label="Retry Delay (optional)">
-          <p-number-input v-model="retryDelay" :min="0" append="Seconds" />
-        </p-label>
-      </div>
-
-      <p-divider v-if="deployment.parameters" />
-
-      <h3 class="flow-run-create-form__section-header">
-        Start
-      </h3>
-
-      <p-button-group v-model="when" :options="whenOptions" small />
-
-      <template v-if="when == 'later'">
-        <div class="flow-run-create-form__row">
-          <p-label label="Date" :message="startErrorMessage" :state="startState">
-            <DateInput v-model="start" show-time />
-          </p-label>
-          <p-label label="Timezone">
-            <TimezoneSelect v-model="timezone" />
-          </p-label>
-        </div>
-      </template>
-
 
       <template v-if="hasParameters">
         <p-divider />
@@ -75,6 +30,48 @@
           </SchemaInput>
         </p-content>
       </template>
+
+      <p-accordion :sections="['Additional Options']">
+        <template #content>
+          <p-label label="Message (Optional)">
+            <p-textarea v-model="stateMessage" placeholder="Created from the Prefect UI" />
+          </p-label>
+          <p-label label="Tags (Optional)">
+            <p-tags-input v-model="tags" :options="deploymentTags" />
+          </p-label>
+
+          <p-label v-if="workPoolName && !workPool?.isPushPool" :label="workQueueComboboxLabel">
+            <WorkPoolQueueCombobox v-model:selected="workQueueName" :work-pool-name="workPoolName" />
+          </p-label>
+
+          <div class="flow-run-create-form__retries">
+            <p-label label="Retries (optional)">
+              <p-number-input v-model="retries" :min="0" />
+            </p-label>
+
+            <p-label label="Retry Delay (optional)">
+              <p-number-input v-model="retryDelay" :min="0" append="Seconds" />
+            </p-label>
+          </div>
+
+          <h3 class="flow-run-create-form__section-header">
+            Start
+          </h3>
+
+          <p-button-group v-model="when" :options="whenOptions" small />
+
+          <template v-if="when == 'later'">
+            <div class="flow-run-create-form__row">
+              <p-label label="Date" :message="startErrorMessage" :state="startState">
+                <DateInput v-model="start" show-time />
+              </p-label>
+              <p-label label="Timezone">
+                <TimezoneSelect v-model="timezone" />
+              </p-label>
+            </div>
+          </template>
+        </template>
+      </p-accordion>
     </p-content>
 
     <template #footer>
@@ -253,5 +250,18 @@
 .flow-run-create-form__retries { @apply
   flex
   gap-4
+}
+
+.p-accordion__heading { @apply
+  text-lg
+  font-semibold
+}
+
+.p-accordion__content { @apply
+  pt-5
+}
+
+.p-accordion__content-padding { @apply
+  space-y-5
 }
 </style>

--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -31,6 +31,23 @@
         </p-content>
       </template>
 
+      <h3 class="flow-run-create-form__section-header">
+        Start
+      </h3>
+
+      <p-button-group v-model="when" :options="whenOptions" small />
+
+      <template v-if="when == 'later'">
+        <div class="flow-run-create-form__row">
+          <p-label label="Date" :message="startErrorMessage" :state="startState">
+            <DateInput v-model="start" show-time />
+          </p-label>
+          <p-label label="Timezone">
+            <TimezoneSelect v-model="timezone" />
+          </p-label>
+        </div>
+      </template>
+
       <p-accordion :sections="['Additional Options']">
         <template #content>
           <p-label label="Message (Optional)">
@@ -53,23 +70,6 @@
               <p-number-input v-model="retryDelay" :min="0" append="Seconds" />
             </p-label>
           </div>
-
-          <h3 class="flow-run-create-form__section-header">
-            Start
-          </h3>
-
-          <p-button-group v-model="when" :options="whenOptions" small />
-
-          <template v-if="when == 'later'">
-            <div class="flow-run-create-form__row">
-              <p-label label="Date" :message="startErrorMessage" :state="startState">
-                <DateInput v-model="start" show-time />
-              </p-label>
-              <p-label label="Timezone">
-                <TimezoneSelect v-model="timezone" />
-              </p-label>
-            </div>
-          </template>
         </template>
       </p-accordion>
     </p-content>

--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -1,7 +1,6 @@
 <template>
   <p-form class="flow-run-create-form p-background" @submit="submit">
     <p-content class="flow-run-create-form__section">
-
       <p-label label="Run Name">
         <p-text-input v-model="name">
           <template #append>
@@ -47,27 +46,34 @@
       </template>
 
       <p-accordion :sections="['Additional Options']">
+        <template #heading="{ section }">
+          <span class="flow-run-create-form__options-heading">
+            {{ section }}
+          </span>
+        </template>
         <template #content>
-          <p-label label="Message (Optional)">
-            <p-textarea v-model="stateMessage" placeholder="Created from the Prefect UI" />
-          </p-label>
-          <p-label label="Tags (Optional)">
-            <p-tags-input v-model="tags" :options="deploymentTags" />
-          </p-label>
-
-          <p-label v-if="workPoolName && !workPool?.isPushPool" :label="workQueueComboboxLabel">
-            <WorkPoolQueueCombobox v-model:selected="workQueueName" :work-pool-name="workPoolName" />
-          </p-label>
-
-          <div class="flow-run-create-form__retries">
-            <p-label label="Retries (optional)">
-              <p-number-input v-model="retries" :min="0" />
+          <p-content class="flow-run-create-form__options">
+            <p-label label="Message (Optional)">
+              <p-textarea v-model="stateMessage" placeholder="Created from the Prefect UI" />
+            </p-label>
+            <p-label label="Tags (Optional)">
+              <p-tags-input v-model="tags" :options="deploymentTags" />
             </p-label>
 
-            <p-label label="Retry Delay (optional)">
-              <p-number-input v-model="retryDelay" :min="0" append="Seconds" />
+            <p-label v-if="workPoolName && !workPool?.isPushPool" :label="workQueueComboboxLabel">
+              <WorkPoolQueueCombobox v-model:selected="workQueueName" :work-pool-name="workPoolName" />
             </p-label>
-          </div>
+
+            <div class="flow-run-create-form__retries">
+              <p-label label="Retries (optional)">
+                <p-number-input v-model="retries" :min="0" />
+              </p-label>
+
+              <p-label label="Retry Delay (optional)">
+                <p-number-input v-model="retryDelay" :min="0" append="Seconds" />
+              </p-label>
+            </div>
+          </p-content>
         </template>
       </p-accordion>
     </p-content>
@@ -250,20 +256,12 @@
   gap-4
 }
 
-.p-accordion__heading { @apply
+.flow-run-create-form__options-heading { @apply
   text-lg
   font-semibold
 }
 
-.p-content { @apply
-  pb-3
-}
-
-.p-accordion__content { @apply
+.flow-run-create-form__options { @apply
   pt-5
-}
-
-.p-accordion__content-padding { @apply
-  space-y-5
 }
 </style>

--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -257,6 +257,10 @@
   font-semibold
 }
 
+.p-content { @apply
+  pb-3
+}
+
 .p-accordion__content { @apply
   pt-5
 }

--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -31,9 +31,7 @@
         </p-content>
       </template>
 
-      <h3 class="flow-run-create-form__section-header">
-        Start
-      </h3>
+      <h3>Start</h3>
 
       <p-button-group v-model="when" :options="whenOptions" small />
 


### PR DESCRIPTION
This PR reduces the visual clutter when creating a run for a deployment:
- removes "General" as a heading
- only displays "Run Name" and "Parameters" by default (the most commonly figured fields)
- all other options (tags, retries, work queues, start times, message) are hidden under a new collapsable section called "Additional Options"

This simplifies the experience of creating a run for the majority of use cases while still preserving the full functionality of options for more complex situations.

Screenshot of the new default look:
<img width="1727" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/13255838/64db1416-fef0-426b-b2f9-23968d331eaa">

Screenshot of the expanded view for a deployment with no work pool (couldn't capture everything):
<img width="1712" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/13255838/03f04ae8-4a03-4d01-82f0-bb988986ad14">

As an added benefit, the third step in the onboarding tutorial looks nice and clean:
<img width="1703" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/13255838/3e43aa15-38f4-4c10-8940-b3bc5aad342c">
