### PR TITLE
Enhancement: Better error displays

### DIFF
--- a/src/components/ConcurrencyLimitV2Toggle.vue
+++ b/src/components/ConcurrencyLimitV2Toggle.vue
@@ -11,7 +11,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { ConcurrencyV2Limit } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     limit: ConcurrencyV2Limit,
@@ -48,8 +48,8 @@
       concurrencyLimitSubscription.refresh()
       emit('update')
     } catch (error) {
-      const errMessage = getErrorMessage(error, localization.error.updateConcurrencyLimit)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.updateConcurrencyLimit)
+      showToast(message, 'error')
       console.error(error)
     } finally {
       loading.value = false

--- a/src/components/ConcurrencyLimitV2Toggle.vue
+++ b/src/components/ConcurrencyLimitV2Toggle.vue
@@ -11,6 +11,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { ConcurrencyV2Limit } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     limit: ConcurrencyV2Limit,
@@ -47,8 +48,8 @@
       concurrencyLimitSubscription.refresh()
       emit('update')
     } catch (error) {
-      const message = localization.error.updateConcurrencyLimit
-      showToast(message, 'error')
+      const errMessage = getErrorMessage(error, localization.error.updateConcurrencyLimit)
+      showToast(errMessage, 'error')
       console.error(error)
     } finally {
       loading.value = false

--- a/src/components/ConcurrencyLimitsCreateModal.vue
+++ b/src/components/ConcurrencyLimitsCreateModal.vue
@@ -31,7 +31,7 @@
   import { useForm } from '@/compositions/useForm'
   import { localization } from '@/localization'
   import { ConcurrencyLimitCreate } from '@/models/ConcurrencyLimitCreate'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
   import { isRequired, isGreaterThan, fieldRules } from '@/utilities/validation'
 
   const props = defineProps<{
@@ -68,8 +68,8 @@
       showToast(localization.success.createConcurrencyLimit, 'success')
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.error.createConcurrencyLimit)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.createConcurrencyLimit)
+      showToast(message, 'error')
     } finally {
       resetForm()
       internalShowModal.value = false

--- a/src/components/ConcurrencyLimitsCreateModal.vue
+++ b/src/components/ConcurrencyLimitsCreateModal.vue
@@ -31,8 +31,8 @@
   import { useForm } from '@/compositions/useForm'
   import { localization } from '@/localization'
   import { ConcurrencyLimitCreate } from '@/models/ConcurrencyLimitCreate'
-  import { isRequired, isGreaterThan, fieldRules } from '@/utilities/validation'
   import { getErrorMessage } from '@/utilities/errors'
+  import { isRequired, isGreaterThan, fieldRules } from '@/utilities/validation'
 
   const props = defineProps<{
     showModal: boolean,

--- a/src/components/ConcurrencyLimitsCreateModal.vue
+++ b/src/components/ConcurrencyLimitsCreateModal.vue
@@ -32,6 +32,7 @@
   import { localization } from '@/localization'
   import { ConcurrencyLimitCreate } from '@/models/ConcurrencyLimitCreate'
   import { isRequired, isGreaterThan, fieldRules } from '@/utilities/validation'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -67,7 +68,8 @@
       showToast(localization.success.createConcurrencyLimit, 'success')
     } catch (error) {
       console.error(error)
-      showToast(localization.error.createConcurrencyLimit, 'error')
+      const errMessage = getErrorMessage(error, localization.error.createConcurrencyLimit)
+      showToast(errMessage, 'error')
     } finally {
       resetForm()
       internalShowModal.value = false

--- a/src/components/ConcurrencyLimitsV2CreateModal.vue
+++ b/src/components/ConcurrencyLimitsV2CreateModal.vue
@@ -36,8 +36,8 @@
   import { computed, ref } from 'vue'
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
-  import { isRequired, isGreaterThanZeroOrNull } from '@/utilities/formValidation'
   import { getErrorMessage } from '@/utilities/errors'
+  import { isRequired, isGreaterThanZeroOrNull } from '@/utilities/formValidation'
 
   const props = defineProps<{
     showModal: boolean,

--- a/src/components/ConcurrencyLimitsV2CreateModal.vue
+++ b/src/components/ConcurrencyLimitsV2CreateModal.vue
@@ -36,7 +36,7 @@
   import { computed, ref } from 'vue'
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
   import { isRequired, isGreaterThanZeroOrNull } from '@/utilities/formValidation'
 
   const props = defineProps<{
@@ -89,8 +89,8 @@
         showToast(localization.success.createConcurrencyLimit, 'success')
       } catch (error) {
         console.error(error)
-        const errMessage = getErrorMessage(error, localization.error.createConcurrencyLimit)
-        showToast(errMessage, 'error')
+        const message = getApiErrorMessage(error, localization.error.createConcurrencyLimit)
+        showToast(message, 'error')
       } finally {
         reset()
         internalShowModal.value = false

--- a/src/components/ConcurrencyLimitsV2CreateModal.vue
+++ b/src/components/ConcurrencyLimitsV2CreateModal.vue
@@ -37,6 +37,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { isRequired, isGreaterThanZeroOrNull } from '@/utilities/formValidation'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -88,7 +89,8 @@
         showToast(localization.success.createConcurrencyLimit, 'success')
       } catch (error) {
         console.error(error)
-        showToast(localization.error.createConcurrencyLimit, 'error')
+        const errMessage = getErrorMessage(error, localization.error.createConcurrencyLimit)
+        showToast(errMessage, 'error')
       } finally {
         reset()
         internalShowModal.value = false

--- a/src/components/ConcurrencyLimitsV2UpdateModal.vue
+++ b/src/components/ConcurrencyLimitsV2UpdateModal.vue
@@ -37,6 +37,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { ConcurrencyV2Limit } from '@/models/ConcurrencyV2Limit'
+  import { getErrorMessage } from '@/utilities/errors'
   import { isRequired, isGreaterThanZeroOrNull } from '@/utilities/formValidation'
 
   const props = defineProps<{
@@ -93,7 +94,8 @@
         showToast(localization.success.updateConcurrencyLimit, 'success')
       } catch (error) {
         console.error(error)
-        showToast(localization.error.updateConcurrencyLimit, 'error')
+        const errMessage = getErrorMessage(error, localization.error.updateConcurrencyLimit)
+        showToast(errMessage, 'error')
       } finally {
         reset()
         internalShowModal.value = false

--- a/src/components/ConcurrencyLimitsV2UpdateModal.vue
+++ b/src/components/ConcurrencyLimitsV2UpdateModal.vue
@@ -37,7 +37,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { ConcurrencyV2Limit } from '@/models/ConcurrencyV2Limit'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
   import { isRequired, isGreaterThanZeroOrNull } from '@/utilities/formValidation'
 
   const props = defineProps<{
@@ -94,8 +94,8 @@
         showToast(localization.success.updateConcurrencyLimit, 'success')
       } catch (error) {
         console.error(error)
-        const errMessage = getErrorMessage(error, localization.error.updateConcurrencyLimit)
-        showToast(errMessage, 'error')
+        const message = getApiErrorMessage(error, localization.error.updateConcurrencyLimit)
+        showToast(message, 'error')
       } finally {
         reset()
         internalShowModal.value = false

--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -93,6 +93,7 @@
   import { localization } from '@/localization'
   import { Schedule, Deployment } from '@/models'
   import { formatDateTimeNumeric } from '@/utilities/dates'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     deployment: Deployment,
@@ -149,7 +150,8 @@
       showToast(successMessage, 'success')
     } catch (error) {
       console.error(error)
-      showToast(errorMessage, 'error')
+      const errMessage = getErrorMessage(error, errorMessage)
+      showToast(errMessage, 'error')
     } finally {
       updateScheduleLoading.value = false
     }

--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -93,7 +93,7 @@
   import { localization } from '@/localization'
   import { Schedule, Deployment } from '@/models'
   import { formatDateTimeNumeric } from '@/utilities/dates'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     deployment: Deployment,
@@ -150,8 +150,8 @@
       showToast(successMessage, 'success')
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, errorMessage)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, errorMessage)
+      showToast(message, 'error')
     } finally {
       updateScheduleLoading.value = false
     }

--- a/src/components/DeploymentQuickRunOverflowMenuItem.vue
+++ b/src/components/DeploymentQuickRunOverflowMenuItem.vue
@@ -14,7 +14,7 @@
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { Deployment } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     deployment: Deployment,
@@ -45,8 +45,8 @@
         })
         showToast(toastMessage, 'success')
       } catch (error) {
-        const errMessage = getErrorMessage(error, localization.error.scheduleFlowRun)
-        showToast(errMessage, 'error')
+        const message = getApiErrorMessage(error, localization.error.scheduleFlowRun)
+        showToast(message, 'error')
         console.error(error)
       }
     }

--- a/src/components/DeploymentQuickRunOverflowMenuItem.vue
+++ b/src/components/DeploymentQuickRunOverflowMenuItem.vue
@@ -14,6 +14,7 @@
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { Deployment } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     deployment: Deployment,
@@ -44,7 +45,8 @@
         })
         showToast(toastMessage, 'success')
       } catch (error) {
-        showToast(localization.error.scheduleFlowRun, 'error')
+        const errMessage = getErrorMessage(error, localization.error.scheduleFlowRun)
+        showToast(errMessage, 'error')
         console.error(error)
       }
     }

--- a/src/components/DeploymentToggle.vue
+++ b/src/components/DeploymentToggle.vue
@@ -11,6 +11,7 @@
   import { useCan } from '@/compositions/useCan'
   import { localization } from '@/localization'
   import { Deployment } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     deployment: Deployment,
@@ -50,9 +51,10 @@
 
       emit('update')
     } catch (error) {
-      const message = value ? localization.error.activateDeployment : localization.error.pauseDeployment
+      const defaultMessage = value ? localization.error.activateDeployment : localization.error.pauseDeployment
 
-      showToast(message)
+      const errMessage = getErrorMessage(error, defaultMessage)
+      showToast(errMessage, 'error')
 
       console.error(error)
     } finally {

--- a/src/components/DeploymentToggle.vue
+++ b/src/components/DeploymentToggle.vue
@@ -11,7 +11,7 @@
   import { useCan } from '@/compositions/useCan'
   import { localization } from '@/localization'
   import { Deployment } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     deployment: Deployment,
@@ -53,8 +53,8 @@
     } catch (error) {
       const defaultMessage = value ? localization.error.activateDeployment : localization.error.pauseDeployment
 
-      const errMessage = getErrorMessage(error, defaultMessage)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, defaultMessage)
+      showToast(message, 'error')
 
       console.error(error)
     } finally {

--- a/src/components/DeploymentsDeleteButton.vue
+++ b/src/components/DeploymentsDeleteButton.vue
@@ -22,6 +22,7 @@
   import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
+  import { getErrorMessage } from '@/utilities/errors'
 
   defineProps<{
     selected: string[],
@@ -50,7 +51,8 @@
       showToast(toastMessage, 'success')
       emit('delete')
     } catch (error) {
-      showToast(localization.error.delete('deployments'), 'error')
+      const errMessage = getErrorMessage(error, localization.error.delete('deployments'))
+      showToast(errMessage, 'error')
     } finally {
       close()
     }

--- a/src/components/DeploymentsDeleteButton.vue
+++ b/src/components/DeploymentsDeleteButton.vue
@@ -22,7 +22,7 @@
   import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   defineProps<{
     selected: string[],
@@ -51,8 +51,8 @@
       showToast(toastMessage, 'success')
       emit('delete')
     } catch (error) {
-      const errMessage = getErrorMessage(error, localization.error.delete('deployments'))
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.delete('deployments'))
+      showToast(message, 'error')
     } finally {
       close()
     }

--- a/src/components/FlowRunCancelModal.vue
+++ b/src/components/FlowRunCancelModal.vue
@@ -27,6 +27,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { StateUpdateDetails } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -66,7 +67,8 @@
       showToast(localization.success.cancelFlowRun, 'success')
     } catch (error) {
       console.error(error)
-      showToast(localization.error.cancelFlowRun, 'error')
+      const errMessage = getErrorMessage(error, localization.error.cancelFlowRun)
+      showToast(errMessage, 'error')
     }
   }
 </script>

--- a/src/components/FlowRunCancelModal.vue
+++ b/src/components/FlowRunCancelModal.vue
@@ -27,7 +27,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { StateUpdateDetails } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -67,8 +67,8 @@
       showToast(localization.success.cancelFlowRun, 'success')
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.error.cancelFlowRun)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.cancelFlowRun)
+      showToast(message, 'error')
     }
   }
 </script>

--- a/src/components/FlowRunMenu.vue
+++ b/src/components/FlowRunMenu.vue
@@ -59,6 +59,7 @@
   import { localization } from '@/localization'
   import { FlowRunsFilter, isPausedStateType, isRunningStateType, isStuckStateType, isTerminalStateType, StateUpdateDetails } from '@/models'
   import { deleteItem } from '@/utilities'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     flowRunId: string,
@@ -143,7 +144,8 @@
       showToast(localization.success.changeFlowRunState, 'success')
     } catch (error) {
       console.error(error)
-      showToast(localization.error.changeFlowRunState, 'error')
+      const errMessage = getErrorMessage(error, localization.error.changeFlowRunState)
+      showToast(errMessage, 'error')
     }
   }
 

--- a/src/components/FlowRunMenu.vue
+++ b/src/components/FlowRunMenu.vue
@@ -59,7 +59,7 @@
   import { localization } from '@/localization'
   import { FlowRunsFilter, isPausedStateType, isRunningStateType, isStuckStateType, isTerminalStateType, StateUpdateDetails } from '@/models'
   import { deleteItem } from '@/utilities'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     flowRunId: string,
@@ -144,8 +144,8 @@
       showToast(localization.success.changeFlowRunState, 'success')
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.error.changeFlowRunState)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.changeFlowRunState)
+      showToast(message, 'error')
     }
   }
 

--- a/src/components/FlowRunPauseModal.vue
+++ b/src/components/FlowRunPauseModal.vue
@@ -30,6 +30,7 @@
   import { StateUpdateDetails } from '@/models'
   import { fieldRules, isGreaterThan, isRequired } from '@/utilities'
   import { secondsToApproximateString } from '@/utilities/seconds'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -77,7 +78,8 @@
       showToast(localization.success.pauseFlowRun, 'success')
     } catch (error) {
       console.error(error)
-      showToast(localization.error.pauseFlowRun, 'error')
+      const errMessage = getErrorMessage(error, localization.error.pauseFlowRun)
+      showToast(errMessage, 'error')
     }
   })
 </script>

--- a/src/components/FlowRunPauseModal.vue
+++ b/src/components/FlowRunPauseModal.vue
@@ -29,7 +29,7 @@
   import { localization } from '@/localization'
   import { StateUpdateDetails } from '@/models'
   import { fieldRules, isGreaterThan, isRequired } from '@/utilities'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
   import { secondsToApproximateString } from '@/utilities/seconds'
 
   const props = defineProps<{
@@ -78,8 +78,8 @@
       showToast(localization.success.pauseFlowRun, 'success')
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.error.pauseFlowRun)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.pauseFlowRun)
+      showToast(message, 'error')
     }
   })
 </script>

--- a/src/components/FlowRunPauseModal.vue
+++ b/src/components/FlowRunPauseModal.vue
@@ -29,8 +29,8 @@
   import { localization } from '@/localization'
   import { StateUpdateDetails } from '@/models'
   import { fieldRules, isGreaterThan, isRequired } from '@/utilities'
-  import { secondsToApproximateString } from '@/utilities/seconds'
   import { getErrorMessage } from '@/utilities/errors'
+  import { secondsToApproximateString } from '@/utilities/seconds'
 
   const props = defineProps<{
     showModal: boolean,

--- a/src/components/FlowRunResumeModal.vue
+++ b/src/components/FlowRunResumeModal.vue
@@ -22,7 +22,7 @@
   import StateBadge from '@/components/StateBadge.vue'
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -55,8 +55,8 @@
       showToast(localization.success.resumeFlowRun, 'success')
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.error.resumeFlowRun)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.resumeFlowRun)
+      showToast(message, 'error')
     }
   }
 </script>

--- a/src/components/FlowRunResumeModal.vue
+++ b/src/components/FlowRunResumeModal.vue
@@ -22,6 +22,7 @@
   import StateBadge from '@/components/StateBadge.vue'
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -54,7 +55,8 @@
       showToast(localization.success.resumeFlowRun, 'success')
     } catch (error) {
       console.error(error)
-      showToast(localization.error.resumeFlowRun, 'error')
+      const errMessage = getErrorMessage(error, localization.error.resumeFlowRun)
+      showToast(errMessage, 'error')
     }
   }
 </script>

--- a/src/components/FlowRunRetryModal.vue
+++ b/src/components/FlowRunRetryModal.vue
@@ -15,6 +15,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { FlowRun } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     flowRun: FlowRun,
@@ -55,7 +56,8 @@
       showToast(localization.success.retryRun, 'success')
     } catch (error) {
       console.error(error)
-      showToast(localization.error.retryRun, 'error')
+      const errMessage = getErrorMessage(error, localization.error.retryRun)
+      showToast(errMessage, 'error')
     } finally {
       retryingRun.value = false
       internalValue.value = false

--- a/src/components/FlowRunRetryModal.vue
+++ b/src/components/FlowRunRetryModal.vue
@@ -15,7 +15,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { FlowRun } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     flowRun: FlowRun,
@@ -56,8 +56,8 @@
       showToast(localization.success.retryRun, 'success')
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.error.retryRun)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.retryRun)
+      showToast(message, 'error')
     } finally {
       retryingRun.value = false
       internalValue.value = false

--- a/src/components/FlowRunsDeleteButton.vue
+++ b/src/components/FlowRunsDeleteButton.vue
@@ -16,7 +16,7 @@
   import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   defineProps<{
     selected: string[],
@@ -47,8 +47,8 @@
       showToast(toastMessage, 'success')
       emit('delete')
     } catch (error) {
-      const errMessage = getErrorMessage(error, localization.error.delete('Flow Run'))
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.delete('Flow Run'))
+      showToast(message, 'error')
     }
   }
 </script>

--- a/src/components/FlowRunsDeleteButton.vue
+++ b/src/components/FlowRunsDeleteButton.vue
@@ -16,6 +16,7 @@
   import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
+  import { getErrorMessage } from '@/utilities/errors'
 
   defineProps<{
     selected: string[],
@@ -46,7 +47,8 @@
       showToast(toastMessage, 'success')
       emit('delete')
     } catch (error) {
-      showToast(localization.error.delete('Flow Run'), 'error')
+      const errMessage = getErrorMessage(error, localization.error.delete('Flow Run'))
+      showToast(errMessage, 'error')
     }
   }
 </script>

--- a/src/components/FlowsDeleteButton.vue
+++ b/src/components/FlowsDeleteButton.vue
@@ -22,6 +22,7 @@
   import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
+  import { getErrorMessage } from '@/utilities/errors'
 
   defineProps<{
     selected: string[],
@@ -50,7 +51,8 @@
       showToast(toastMessage, 'success')
       emit('delete')
     } catch (error) {
-      showToast(localization.error.delete('flows'), 'error')
+      const errMessage = getErrorMessage(error, localization.error.delete('flows'))
+      showToast(errMessage, 'error')
     } finally {
       close()
     }

--- a/src/components/FlowsDeleteButton.vue
+++ b/src/components/FlowsDeleteButton.vue
@@ -22,7 +22,7 @@
   import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   defineProps<{
     selected: string[],
@@ -51,8 +51,8 @@
       showToast(toastMessage, 'success')
       emit('delete')
     } catch (error) {
-      const errMessage = getErrorMessage(error, localization.error.delete('flows'))
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.delete('flows'))
+      showToast(message, 'error')
     } finally {
       close()
     }

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -55,6 +55,7 @@
   import { getSchemaDefaultValues } from '@/services/schemas/utilities'
   import { FormAction } from '@/types/buttons'
   import { SchemaValues } from '@/types/schemas'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     notification?: Notification,
@@ -205,7 +206,8 @@
       emit('update:notification', notification)
       emit('submit', notification)
     } catch (err) {
-      showToast(localization.error.submitNotification)
+      const errMessage = getErrorMessage(err, localization.error.submitNotification)
+      showToast(errMessage, 'error')
     }
   })
 

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -55,7 +55,7 @@
   import { getSchemaDefaultValues } from '@/services/schemas/utilities'
   import { FormAction } from '@/types/buttons'
   import { SchemaValues } from '@/types/schemas'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     notification?: Notification,
@@ -206,8 +206,8 @@
       emit('update:notification', notification)
       emit('submit', notification)
     } catch (err) {
-      const errMessage = getErrorMessage(err, localization.error.submitNotification)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(err, localization.error.submitNotification)
+      showToast(message, 'error')
     }
   })
 

--- a/src/components/NotificationToggle.vue
+++ b/src/components/NotificationToggle.vue
@@ -11,7 +11,7 @@
   import { useCan } from '@/compositions/useCan'
   import { localization } from '@/localization'
   import { Notification } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     notification: Notification,
@@ -47,8 +47,8 @@
       emit('update')
     } catch (error) {
       const defaultMessage = value ? localization.error.activateNotification : localization.error.pauseNotification
-      const errMessage = getErrorMessage(error, defaultMessage)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, defaultMessage)
+      showToast(message, 'error')
 
       console.error(error)
     } finally {

--- a/src/components/NotificationToggle.vue
+++ b/src/components/NotificationToggle.vue
@@ -11,6 +11,7 @@
   import { useCan } from '@/compositions/useCan'
   import { localization } from '@/localization'
   import { Notification } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     notification: Notification,
@@ -45,9 +46,9 @@
       showToast(message, 'success')
       emit('update')
     } catch (error) {
-      const message = value ? localization.error.activateNotification : localization.error.pauseNotification
-
-      showToast(message, 'error')
+      const defaultMessage = value ? localization.error.activateNotification : localization.error.pauseNotification
+      const errMessage = getErrorMessage(error, defaultMessage)
+      showToast(errMessage, 'error')
 
       console.error(error)
     } finally {

--- a/src/components/PageHeadingTaskRun.vue
+++ b/src/components/PageHeadingTaskRun.vue
@@ -38,6 +38,7 @@
   import { localization } from '@/localization'
   import { isTerminalStateType, StateUpdateDetails } from '@/models'
   import { deleteItem } from '@/utilities'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     taskRunId: string,
@@ -98,7 +99,8 @@
       showToast(localization.success.changeTaskRunState, 'success')
     } catch (error) {
       console.error(error)
-      showToast(localization.error.changeTaskRunState, 'error')
+      const errMessage = getErrorMessage(error, localization.error.changeTaskRunState)
+      showToast(errMessage, 'error')
     }
   }
 </script>

--- a/src/components/PageHeadingTaskRun.vue
+++ b/src/components/PageHeadingTaskRun.vue
@@ -38,7 +38,7 @@
   import { localization } from '@/localization'
   import { isTerminalStateType, StateUpdateDetails } from '@/models'
   import { deleteItem } from '@/utilities'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     taskRunId: string,
@@ -99,8 +99,8 @@
       showToast(localization.success.changeTaskRunState, 'success')
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.error.changeTaskRunState)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.changeTaskRunState)
+      showToast(message, 'error')
     }
   }
 </script>

--- a/src/components/QuickRunParametersModal.vue
+++ b/src/components/QuickRunParametersModal.vue
@@ -26,6 +26,7 @@
   import { localization } from '@/localization'
   import { Deployment, DeploymentFlowRunCreate } from '@/models'
   import { SchemaValues } from '@/types/schemas'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -85,7 +86,8 @@
       const toastMessage = h(ToastFlowRunCreate, { flowRun, flowRunRoute: routes.flowRun, router, immediate: true })
       showToast(toastMessage, 'success')
     } catch (error) {
-      showToast(localization.error.scheduleFlowRun, 'error')
+      const errMessage = getErrorMessage(error, localization.error.scheduleFlowRun)
+      showToast(errMessage, 'error')
       console.error(error)
     }
   }

--- a/src/components/QuickRunParametersModal.vue
+++ b/src/components/QuickRunParametersModal.vue
@@ -26,7 +26,7 @@
   import { localization } from '@/localization'
   import { Deployment, DeploymentFlowRunCreate } from '@/models'
   import { SchemaValues } from '@/types/schemas'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -86,8 +86,8 @@
       const toastMessage = h(ToastFlowRunCreate, { flowRun, flowRunRoute: routes.flowRun, router, immediate: true })
       showToast(toastMessage, 'success')
     } catch (error) {
-      const errMessage = getErrorMessage(error, localization.error.scheduleFlowRun)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.scheduleFlowRun)
+      showToast(message, 'error')
       console.error(error)
     }
   }

--- a/src/components/SaveFilterModal.vue
+++ b/src/components/SaveFilterModal.vue
@@ -28,8 +28,8 @@
   import { useForm } from '@/compositions/useForm'
   import { localization } from '@/localization'
   import { SavedSearch } from '@/models/SavedSearch'
-  import { isRequired, withMessage, isValidIf } from '@/utilities/validation'
   import { getErrorMessage } from '@/utilities/errors'
+  import { isRequired, withMessage, isValidIf } from '@/utilities/validation'
 
   const props = defineProps<{
     showModal: boolean,

--- a/src/components/SaveFilterModal.vue
+++ b/src/components/SaveFilterModal.vue
@@ -29,6 +29,7 @@
   import { localization } from '@/localization'
   import { SavedSearch } from '@/models/SavedSearch'
   import { isRequired, withMessage, isValidIf } from '@/utilities/validation'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -91,7 +92,8 @@
       emit('saved', savedSearch)
     } catch (error) {
       console.error(error)
-      showToast(localization.error.createSavedSearch, 'error')
+      const errMessage = getErrorMessage(error, localization.error.createSavedSearch)
+      showToast(errMessage, 'error')
     }
   }
 </script>

--- a/src/components/SaveFilterModal.vue
+++ b/src/components/SaveFilterModal.vue
@@ -28,7 +28,7 @@
   import { useForm } from '@/compositions/useForm'
   import { localization } from '@/localization'
   import { SavedSearch } from '@/models/SavedSearch'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
   import { isRequired, withMessage, isValidIf } from '@/utilities/validation'
 
   const props = defineProps<{
@@ -92,8 +92,8 @@
       emit('saved', savedSearch)
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.error.createSavedSearch)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.createSavedSearch)
+      showToast(message, 'error')
     }
   }
 </script>

--- a/src/components/SavedFiltersDeleteModal.vue
+++ b/src/components/SavedFiltersDeleteModal.vue
@@ -15,6 +15,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { SavedSearch } from '@/models/SavedSearch'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -49,7 +50,8 @@
       }
     } catch (error) {
       console.error(error)
-      showToast(localization.error.deleteSavedSearch, 'error')
+      const errMessage = getErrorMessage(error, localization.error.deleteSavedSearch)
+      showToast(errMessage, 'error')
     }
   }
 </script>

--- a/src/components/SavedFiltersDeleteModal.vue
+++ b/src/components/SavedFiltersDeleteModal.vue
@@ -15,7 +15,7 @@
   import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { SavedSearch } from '@/models/SavedSearch'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -50,8 +50,8 @@
       }
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.error.deleteSavedSearch)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.deleteSavedSearch)
+      showToast(message, 'error')
     }
   }
 </script>

--- a/src/components/VariableCreateModal.vue
+++ b/src/components/VariableCreateModal.vue
@@ -33,7 +33,7 @@
   import { localization } from '@/localization'
   import { Variable, VariableCreate, MAX_VARIABLE_NAME_LENGTH, MAX_VARIABLE_VALUE_LENGTH } from '@/models'
   import { isSnakeCase, isLessThanOrEqual, isRequired, isString } from '@/utilities'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -127,8 +127,8 @@
         reset()
       } catch (error) {
         console.error(error)
-        const errMessage = getErrorMessage(error, localization.error.createVariable)
-        showToast(errMessage, 'error')
+        const message = getApiErrorMessage(error, localization.error.createVariable)
+        showToast(message, 'error')
       }
     }
   }

--- a/src/components/VariableCreateModal.vue
+++ b/src/components/VariableCreateModal.vue
@@ -33,6 +33,7 @@
   import { localization } from '@/localization'
   import { Variable, VariableCreate, MAX_VARIABLE_NAME_LENGTH, MAX_VARIABLE_VALUE_LENGTH } from '@/models'
   import { isSnakeCase, isLessThanOrEqual, isRequired, isString } from '@/utilities'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     showModal: boolean,
@@ -126,7 +127,8 @@
         reset()
       } catch (error) {
         console.error(error)
-        showToast(localization.error.createVariable, 'error')
+        const errMessage = getErrorMessage(error, localization.error.createVariable)
+        showToast(errMessage, 'error')
       }
     }
   }

--- a/src/components/VariableEditModal.vue
+++ b/src/components/VariableEditModal.vue
@@ -33,7 +33,7 @@
   import { localization } from '@/localization'
   import { Variable, VariableEdit, MAX_VARIABLE_NAME_LENGTH, MAX_VARIABLE_VALUE_LENGTH } from '@/models'
   import { isSnakeCase, isRequired, isString, isLessThanOrEqual } from '@/utilities'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     variable: Variable,
@@ -126,8 +126,8 @@
         emit('update', variable)
       } catch (error) {
         console.error(error)
-        const errMessage = getErrorMessage(error, localization.error.editVariable)
-        showToast(errMessage, 'error')
+        const message = getApiErrorMessage(error, localization.error.editVariable)
+        showToast(message, 'error')
       }
     }
   }

--- a/src/components/VariableEditModal.vue
+++ b/src/components/VariableEditModal.vue
@@ -33,6 +33,7 @@
   import { localization } from '@/localization'
   import { Variable, VariableEdit, MAX_VARIABLE_NAME_LENGTH, MAX_VARIABLE_VALUE_LENGTH } from '@/models'
   import { isSnakeCase, isRequired, isString, isLessThanOrEqual } from '@/utilities'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     variable: Variable,
@@ -125,7 +126,8 @@
         emit('update', variable)
       } catch (error) {
         console.error(error)
-        showToast(localization.error.editVariable, 'error')
+        const errMessage = getErrorMessage(error, localization.error.editVariable)
+        showToast(errMessage, 'error')
       }
     }
   }

--- a/src/components/VariableMenu.vue
+++ b/src/components/VariableMenu.vue
@@ -31,6 +31,7 @@
   import { useWorkspaceApi, useCan, useShowModal } from '@/compositions'
   import { localization } from '@/localization'
   import { Variable } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   defineProps<{
     variable: Variable,
@@ -57,7 +58,8 @@
       emit('delete', id)
     } catch (error) {
       console.error(error)
-      showToast(localization.error.delete(localization.info.variable.toLowerCase()), 'error')
+      const errMessage = getErrorMessage(error, localization.info.variable.toLowerCase())
+      showToast(errMessage, 'error')
     }
   }
 

--- a/src/components/VariableMenu.vue
+++ b/src/components/VariableMenu.vue
@@ -31,7 +31,7 @@
   import { useWorkspaceApi, useCan, useShowModal } from '@/compositions'
   import { localization } from '@/localization'
   import { Variable } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   defineProps<{
     variable: Variable,
@@ -58,8 +58,8 @@
       emit('delete', id)
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.info.variable.toLowerCase())
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.info.variable.toLowerCase())
+      showToast(message, 'error')
     }
   }
 

--- a/src/components/VariablesDeleteButton.vue
+++ b/src/components/VariablesDeleteButton.vue
@@ -15,7 +15,7 @@
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { toPluralString } from '@/utilities'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     variableIds: string[],
@@ -45,8 +45,8 @@
       showToast(successMessage, 'success')
       emit('delete')
     } catch (error) {
-      const errMessage = getErrorMessage(error, localization.error.delete(localization.info.variables))
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.delete(localization.info.variables))
+      showToast(message, 'error')
     } finally {
       close()
     }

--- a/src/components/VariablesDeleteButton.vue
+++ b/src/components/VariablesDeleteButton.vue
@@ -15,6 +15,7 @@
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { toPluralString } from '@/utilities'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     variableIds: string[],
@@ -44,7 +45,8 @@
       showToast(successMessage, 'success')
       emit('delete')
     } catch (error) {
-      showToast(localization.error.delete(localization.info.variables), 'error')
+      const errMessage = getErrorMessage(error, localization.error.delete(localization.info.variables))
+      showToast(errMessage, 'error')
     } finally {
       close()
     }

--- a/src/components/WorkPoolCreateForm.vue
+++ b/src/components/WorkPoolCreateForm.vue
@@ -55,7 +55,7 @@
   import { localization } from '@/localization'
   import { WorkPoolCreate } from '@/models'
   import { WorkerBaseJobTemplate } from '@/types'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const api = useWorkspaceApi()
   const router = useRouter()
@@ -124,8 +124,8 @@
 
         router.push(routes.workPool(name))
       } catch (error) {
-        const errMessage = getErrorMessage(error, localization.error.createWorkPool)
-        showToast(errMessage, 'error')
+        const message = getApiErrorMessage(error, localization.error.createWorkPool)
+        showToast(message, 'error')
         console.error(error)
       }
     }

--- a/src/components/WorkPoolCreateForm.vue
+++ b/src/components/WorkPoolCreateForm.vue
@@ -55,6 +55,7 @@
   import { localization } from '@/localization'
   import { WorkPoolCreate } from '@/models'
   import { WorkerBaseJobTemplate } from '@/types'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const api = useWorkspaceApi()
   const router = useRouter()
@@ -123,7 +124,8 @@
 
         router.push(routes.workPool(name))
       } catch (error) {
-        showToast(localization.error.createWorkPool, 'error')
+        const errMessage = getErrorMessage(error, localization.error.createWorkPool)
+        showToast(errMessage, 'error')
         console.error(error)
       }
     }

--- a/src/components/WorkPoolCreateWizard.vue
+++ b/src/components/WorkPoolCreateWizard.vue
@@ -21,6 +21,7 @@
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPoolCreate, WorkPoolFormValues } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const router = useRouter()
   const routes = useWorkspaceRoutes()
@@ -59,8 +60,9 @@
 
       router.push(routes.workPool(name))
     } catch (error) {
-      showToast(localization.error.createWorkPool, 'error')
       console.error(error)
+      const errMessage = getErrorMessage(error, localization.error.createWorkPool)
+      showToast(errMessage, 'error')
     }
 
 

--- a/src/components/WorkPoolCreateWizard.vue
+++ b/src/components/WorkPoolCreateWizard.vue
@@ -21,7 +21,7 @@
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPoolCreate, WorkPoolFormValues } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const router = useRouter()
   const routes = useWorkspaceRoutes()
@@ -61,8 +61,8 @@
       router.push(routes.workPool(name))
     } catch (error) {
       console.error(error)
-      const errMessage = getErrorMessage(error, localization.error.createWorkPool)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.createWorkPool)
+      showToast(message, 'error')
     }
 
 

--- a/src/components/WorkPoolEditForm.vue
+++ b/src/components/WorkPoolEditForm.vue
@@ -47,6 +47,7 @@
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPool, WorkPoolEdit } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPool: WorkPool,
@@ -82,7 +83,8 @@
         showToast(localization.success.updateWorkPool, 'success')
         router.push(routes.workPool(props.workPool.name))
       } catch (error) {
-        showToast(localization.error.updateWorkPool, 'error')
+        const errMessage = getErrorMessage(error, localization.error.updateWorkPool)
+        showToast(errMessage, 'error')
         console.error(error)
       }
     }

--- a/src/components/WorkPoolEditForm.vue
+++ b/src/components/WorkPoolEditForm.vue
@@ -47,7 +47,7 @@
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPool, WorkPoolEdit } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPool: WorkPool,
@@ -83,8 +83,8 @@
         showToast(localization.success.updateWorkPool, 'success')
         router.push(routes.workPool(props.workPool.name))
       } catch (error) {
-        const errMessage = getErrorMessage(error, localization.error.updateWorkPool)
-        showToast(errMessage, 'error')
+        const message = getApiErrorMessage(error, localization.error.updateWorkPool)
+        showToast(message, 'error')
         console.error(error)
       }
     }

--- a/src/components/WorkPoolQueueCreateForm.vue
+++ b/src/components/WorkPoolQueueCreateForm.vue
@@ -45,7 +45,7 @@
   import { SubmitButton, WorkPoolQueuePriorityLabel } from '@/components'
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPoolName: string,
@@ -99,8 +99,8 @@
 
       router.push(routes.workPoolQueue(props.workPoolName, name))
     } catch (error) {
-      const errMessage = getErrorMessage(error, localization.error.createWorkPoolQueue)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.createWorkPoolQueue)
+      showToast(message, 'error')
       console.error(error)
     }
 

--- a/src/components/WorkPoolQueueCreateForm.vue
+++ b/src/components/WorkPoolQueueCreateForm.vue
@@ -45,6 +45,7 @@
   import { SubmitButton, WorkPoolQueuePriorityLabel } from '@/components'
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPoolName: string,
@@ -98,7 +99,8 @@
 
       router.push(routes.workPoolQueue(props.workPoolName, name))
     } catch (error) {
-      showToast(localization.error.createWorkPoolQueue, 'error')
+      const errMessage = getErrorMessage(error, localization.error.createWorkPoolQueue)
+      showToast(errMessage, 'error')
       console.error(error)
     }
 

--- a/src/components/WorkPoolQueueEditForm.vue
+++ b/src/components/WorkPoolQueueEditForm.vue
@@ -48,6 +48,7 @@
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPoolQueue } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPoolName: string,
@@ -96,7 +97,8 @@
         showToast(localization.success.updateWorkPoolQueue, 'success')
         router.push(routes.workPoolQueue(props.workPoolName, values.name))
       } catch (error) {
-        showToast(localization.error.updateWorkPool, 'error')
+        const errMessage = getErrorMessage(error, localization.error.updateWorkPool)
+        showToast(errMessage, 'error')
         console.error(error)
       }
     }

--- a/src/components/WorkPoolQueueEditForm.vue
+++ b/src/components/WorkPoolQueueEditForm.vue
@@ -48,7 +48,7 @@
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPoolQueue } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPoolName: string,
@@ -97,8 +97,8 @@
         showToast(localization.success.updateWorkPoolQueue, 'success')
         router.push(routes.workPoolQueue(props.workPoolName, values.name))
       } catch (error) {
-        const errMessage = getErrorMessage(error, localization.error.updateWorkPool)
-        showToast(errMessage, 'error')
+        const message = getApiErrorMessage(error, localization.error.updateWorkPool)
+        showToast(message, 'error')
         console.error(error)
       }
     }

--- a/src/components/WorkPoolQueueToggle.vue
+++ b/src/components/WorkPoolQueueToggle.vue
@@ -10,6 +10,7 @@
   import { useCan, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPoolQueue } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPoolName: string,
@@ -50,8 +51,9 @@
 
       emit('update')
     } catch (error) {
-      const message = value ? localization.error.pauseWorkPoolQueue : localization.error.activateWorkPoolQueue
-      showToast(message)
+      const defaultMessage = value ? localization.error.pauseWorkPoolQueue : localization.error.activateWorkPoolQueue
+      const errMessage = getErrorMessage(error, defaultMessage)
+      showToast(errMessage, 'error')
 
       console.error(error)
     }

--- a/src/components/WorkPoolQueueToggle.vue
+++ b/src/components/WorkPoolQueueToggle.vue
@@ -10,7 +10,7 @@
   import { useCan, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPoolQueue } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPoolName: string,
@@ -52,8 +52,8 @@
       emit('update')
     } catch (error) {
       const defaultMessage = value ? localization.error.pauseWorkPoolQueue : localization.error.activateWorkPoolQueue
-      const errMessage = getErrorMessage(error, defaultMessage)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, defaultMessage)
+      showToast(message, 'error')
 
       console.error(error)
     }

--- a/src/components/WorkPoolQueuesDeleteButton.vue
+++ b/src/components/WorkPoolQueuesDeleteButton.vue
@@ -17,6 +17,7 @@
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPoolQueue } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPoolName: string,
@@ -45,7 +46,8 @@
       showToast(toastMessage, 'success')
       emit('delete')
     } catch (error) {
-      showToast(localization.error.delete('work queues'), 'error')
+      const errMessage = getErrorMessage(error, localization.error.delete('work queues'))
+      showToast(errMessage, 'error')
     } finally {
       close()
     }

--- a/src/components/WorkPoolQueuesDeleteButton.vue
+++ b/src/components/WorkPoolQueuesDeleteButton.vue
@@ -17,7 +17,7 @@
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPoolQueue } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPoolName: string,
@@ -46,8 +46,8 @@
       showToast(toastMessage, 'success')
       emit('delete')
     } catch (error) {
-      const errMessage = getErrorMessage(error, localization.error.delete('work queues'))
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.delete('work queues'))
+      showToast(message, 'error')
     } finally {
       close()
     }

--- a/src/components/WorkPoolToggle.vue
+++ b/src/components/WorkPoolToggle.vue
@@ -10,7 +10,7 @@
   import { useCan, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPool } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPool: WorkPool,
@@ -47,8 +47,8 @@
       emit('update')
     } catch (error) {
       const defaultMessage = value ? localization.error.pauseWorkPool : localization.error.activateWorkPool
-      const errMessage = getErrorMessage(error, defaultMessage)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, defaultMessage)
+      showToast(message, 'error')
 
       console.error(error)
     }

--- a/src/components/WorkPoolToggle.vue
+++ b/src/components/WorkPoolToggle.vue
@@ -10,6 +10,7 @@
   import { useCan, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkPool } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workPool: WorkPool,
@@ -45,8 +46,9 @@
 
       emit('update')
     } catch (error) {
-      const message = value ? localization.error.pauseWorkPool : localization.error.activateWorkPool
-      showToast(message)
+      const defaultMessage = value ? localization.error.pauseWorkPool : localization.error.activateWorkPool
+      const errMessage = getErrorMessage(error, defaultMessage)
+      showToast(errMessage, 'error')
 
       console.error(error)
     }

--- a/src/components/WorkQueueToggle.vue
+++ b/src/components/WorkQueueToggle.vue
@@ -12,7 +12,7 @@
   import { useCan } from '@/compositions/useCan'
   import { localization } from '@/localization'
   import { WorkQueue } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workQueue: WorkQueue,
@@ -57,8 +57,8 @@
       emit('update')
     } catch (error) {
       const defaultMessage = value ? localization.error.activateWorkQueue : localization.error.pauseWorkQueue
-      const errMessage = getErrorMessage(error, defaultMessage)
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, defaultMessage)
+      showToast(message, 'error')
 
       console.error(error)
     } finally {

--- a/src/components/WorkQueueToggle.vue
+++ b/src/components/WorkQueueToggle.vue
@@ -12,6 +12,7 @@
   import { useCan } from '@/compositions/useCan'
   import { localization } from '@/localization'
   import { WorkQueue } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
     workQueue: WorkQueue,
@@ -55,9 +56,9 @@
       workQueueSubscription.refresh()
       emit('update')
     } catch (error) {
-      const message = value ? localization.error.activateWorkQueue : localization.error.pauseWorkQueue
-
-      showToast(message, 'error')
+      const defaultMessage = value ? localization.error.activateWorkQueue : localization.error.pauseWorkQueue
+      const errMessage = getErrorMessage(error, defaultMessage)
+      showToast(errMessage, 'error')
 
       console.error(error)
     } finally {

--- a/src/components/WorkQueuesDeleteButton.vue
+++ b/src/components/WorkQueuesDeleteButton.vue
@@ -17,6 +17,7 @@
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkQueue } from '@/models'
+  import { getErrorMessage } from '@/utilities/errors'
 
   defineProps<{
     selected: WorkQueue[],
@@ -44,7 +45,8 @@
       showToast(toastMessage, 'success')
       emit('delete')
     } catch (error) {
-      showToast(localization.error.delete('work queues'), 'error')
+      const errMessage = getErrorMessage(error, localization.error.delete('work queues'))
+      showToast(errMessage, 'error')
     } finally {
       close()
     }

--- a/src/components/WorkQueuesDeleteButton.vue
+++ b/src/components/WorkQueuesDeleteButton.vue
@@ -17,7 +17,7 @@
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { WorkQueue } from '@/models'
-  import { getErrorMessage } from '@/utilities/errors'
+  import { getApiErrorMessage } from '@/utilities/errors'
 
   defineProps<{
     selected: WorkQueue[],
@@ -45,8 +45,8 @@
       showToast(toastMessage, 'success')
       emit('delete')
     } catch (error) {
-      const errMessage = getErrorMessage(error, localization.error.delete('work queues'))
-      showToast(errMessage, 'error')
+      const message = getApiErrorMessage(error, localization.error.delete('work queues'))
+      showToast(message, 'error')
     } finally {
       close()
     }

--- a/src/utilities/delete.ts
+++ b/src/utilities/delete.ts
@@ -2,6 +2,7 @@ import { showToast } from '@prefecthq/prefect-design'
 import { Action } from '@prefecthq/vue-compositions'
 import { localization } from '@/localization'
 import { asArray } from '@/utilities/arrays'
+import { getErrorMessage } from '@/utilities/errors'
 
 export type ItemType = 'Flow' | 'Deployment' | 'Flow run' | 'Work queue' | 'Block' | 'Notification' | 'Task run' | 'Concurrency Limit' | 'Work pool'
 type MaybeSingleParam<T extends Action, Params = Parameters<T>> = Params extends [unknown] ? Params[0] | Params : Params
@@ -15,7 +16,8 @@ export async function deleteItem<T extends Action>(args: MaybeSingleParam<T>, en
     showToast(localization.success.delete(type), 'success')
     return result
   } catch (error) {
-    showToast(localization.error.delete(type.toLowerCase()), 'error')
+    const errMessage = getErrorMessage(error, localization.error.delete(type.toLowerCase()))
+    showToast(errMessage, 'error')
 
     console.error(error)
   }

--- a/src/utilities/delete.ts
+++ b/src/utilities/delete.ts
@@ -2,7 +2,7 @@ import { showToast } from '@prefecthq/prefect-design'
 import { Action } from '@prefecthq/vue-compositions'
 import { localization } from '@/localization'
 import { asArray } from '@/utilities/arrays'
-import { getErrorMessage } from '@/utilities/errors'
+import { getApiErrorMessage } from '@/utilities/errors'
 
 export type ItemType = 'Flow' | 'Deployment' | 'Flow run' | 'Work queue' | 'Block' | 'Notification' | 'Task run' | 'Concurrency Limit' | 'Work pool'
 type MaybeSingleParam<T extends Action, Params = Parameters<T>> = Params extends [unknown] ? Params[0] | Params : Params
@@ -16,8 +16,8 @@ export async function deleteItem<T extends Action>(args: MaybeSingleParam<T>, en
     showToast(localization.success.delete(type), 'success')
     return result
   } catch (error) {
-    const errMessage = getErrorMessage(error, localization.error.delete(type.toLowerCase()))
-    showToast(errMessage, 'error')
+    const message = getApiErrorMessage(error, localization.error.delete(type.toLowerCase()))
+    showToast(message, 'error')
 
     console.error(error)
   }

--- a/src/utilities/errors.ts
+++ b/src/utilities/errors.ts
@@ -1,19 +1,16 @@
-export function getErrorMessage(error: unknown, defaultErrorMessage: string): string {
-  let errorJson
+import axios from 'axios'
+import { isRecord, isString } from '@/utilities'
 
-  if (typeof error === 'string') {
-    try {
-      errorJson = JSON.parse(error)
-    } catch (parseError) {
-      // Error is not a valid JSON string
-      return defaultErrorMessage
-    }
-  } else if (typeof error === 'object' && error !== null) {
-    errorJson = error
-  } else {
+export function getErrorMessage(error: unknown, defaultErrorMessage: string): string {
+  if (!axios.isAxiosError(error)) {
     return defaultErrorMessage
   }
 
-  const detail = JSON.parse(errorJson?.request?.response ?? '')?.detail
-  return detail || defaultErrorMessage
+  const data = error.response?.data
+
+  if (isRecord(data) && isString(data.detail)) {
+    return data.detail
+  }
+
+  return defaultErrorMessage
 }

--- a/src/utilities/errors.ts
+++ b/src/utilities/errors.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import { isRecord, isString } from '@/utilities'
 
-export function getErrorMessage(error: unknown, defaultErrorMessage: string): string {
+export function getApiErrorMessage(error: unknown, defaultErrorMessage: string): string {
   if (!axios.isAxiosError(error)) {
     return defaultErrorMessage
   }

--- a/src/utilities/errors.ts
+++ b/src/utilities/errors.ts
@@ -1,0 +1,19 @@
+export function getErrorMessage(error: unknown, defaultErrorMessage: string): string {
+  let errorJson
+
+  if (typeof error === 'string') {
+    try {
+      errorJson = JSON.parse(error)
+    } catch (parseError) {
+      // Error is not a valid JSON string
+      return defaultErrorMessage
+    }
+  } else if (typeof error === 'object' && error !== null) {
+    errorJson = error
+  } else {
+    return defaultErrorMessage
+  }
+
+  const detail = JSON.parse(errorJson?.request?.response ?? '')?.detail
+  return detail || defaultErrorMessage
+}


### PR DESCRIPTION
This PR introduces a new utility for parsing errors returned from the API; we use the `details` field in many of our error handling responses as a way to communicate useful information to the user, but the UI has never displayed those messages to users.  This leads to confusing situations that put the user in a very difficult and hard to debug state.

With this PR, if the backend returns a `detail` field we will use and display it, otherwise we fall back to the current error messages that we've been displaying.

There are still failure modes for which this won't help, but we can handle many (though never all) of those in the backend with global error handlers that populate the `detail` field on the response.

If you want to see this in action, try to create a block or a work pool that starts with the name "prefect"