### PR TITLE
Chore: Add deprecation message for work queue health icons

### DIFF
--- a/src/components/WorkPoolQueueStatusIcon.vue
+++ b/src/components/WorkPoolQueueStatusIcon.vue
@@ -2,7 +2,7 @@
   <p-tooltip
     v-if="workPoolQueue && workQueueStatus"
     class="work-queue-status-icon"
-    :text="tooltipText"
+    text="Work queue health is deprecated and will be removed in a future release. Please use work pool status instead."
   >
     <div v-if="status.state === 'healthy'" class="work-queue-status-icon--healthy" />
     <p-icon


### PR DESCRIPTION
We are deprecating work queue health in favor of work pool status. This adds a message to the work queue health icon tooltip to inform users that it will be removed.

![Screenshot 2023-09-07 at 8 38 18 AM](https://github.com/PrefectHQ/prefect-ui-library/assets/12350579/8dd267ac-02da-4334-8df9-9b05275e9529)
