### PR TITLE
BugFix: Make sure base job template json is valid

### DIFF
--- a/src/components/WorkPoolBaseJobTemplateFormSection.vue
+++ b/src/components/WorkPoolBaseJobTemplateFormSection.vue
@@ -31,7 +31,9 @@
               the docs.
             </p-link>.
           </p-message>
-          <JsonInput v-model:model-value="localBaseJobTemplateJson" show-format-button @update:model-value="onLocalBaseJobTemplateJsonUpdate" />
+          <p-label :message="jsonError" :state="jsonState">
+            <JsonInput v-model:model-value="localBaseJobTemplateJson" :state="jsonState" show-format-button @update:model-value="onLocalBaseJobTemplateJsonUpdate" />
+          </p-label>
         </div>
       </template>
     </p-tabs>
@@ -39,13 +41,14 @@
 </template>
 
 <script lang="ts" setup>
+  import { useValidation } from '@prefecthq/vue-compositions'
   import { isEqual } from 'lodash'
   import { computed, ref, watch } from 'vue'
   import { SchemaFormFieldsWithValues, JsonInput } from '@/components'
   import { localization } from '@/localization'
   import { getSchemaDefaultValues, mapper } from '@/services'
   import { Schema, SchemaProperties, SchemaValues, WorkerBaseJobTemplate } from '@/types'
-  import { getSchemaWithoutDefaults, mapValues, stringify } from '@/utilities'
+  import { getSchemaWithoutDefaults, isJson, mapValues, stringify } from '@/utilities'
 
 
   const props = defineProps<{
@@ -63,6 +66,7 @@
   }
 
   const localBaseJobTemplateJson = ref<string>(stringify(props.baseJobTemplate))
+  const { state: jsonState, error: jsonError } = useValidation(localBaseJobTemplateJson, isJson('Base Job Template'))
   const localBaseJobTemplate = computed<WorkerBaseJobTemplate | null>(() => {
     try {
       return JSON.parse(localBaseJobTemplateJson.value)


### PR DESCRIPTION
# Description
Adds validation to the base job template "Advanced" tab which allows users to edit via json. 

Closes https://github.com/PrefectHQ/prefect/issues/10536

<img width="993" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/34aebd05-efd5-428e-87b6-a65ce66163f9">
