### PR TITLE
Allow BlockDocumentMenu to be inject/provided.

### DIFF
--- a/src/components/BlockDocumentMenu.vue
+++ b/src/components/BlockDocumentMenu.vue
@@ -3,6 +3,8 @@
     <copy-overflow-menu-item label="Copy Name" :item="blockDocument.name" />
     <p-overflow-menu-item v-if="can.update.block" label="Edit" @click="editBlock" />
     <p-overflow-menu-item v-if="can.delete.block" label="Delete" @click="openDeleteBlockModal" />
+
+    <slot v-bind="{ blockDocument }" />
   </p-icon-button-menu>
 
   <ConfirmDeleteModal

--- a/src/components/BlockDocumentsTable.vue
+++ b/src/components/BlockDocumentsTable.vue
@@ -54,14 +54,13 @@
 <script lang="ts" setup>
   import { media, TableColumn, PEmptyResults } from '@prefecthq/prefect-design'
   import { computed, ref } from 'vue'
-  import BlockDocumentMenu from '@/components/BlockDocumentMenu.vue'
   import BlockSchemaCapabilities from '@/components/BlockSchemaCapabilities.vue'
   import BlockSchemaCapabilitySelect from '@/components/BlockSchemaCapabilitySelect.vue'
   import BlockTypeSelect from '@/components/BlockTypeSelect.vue'
   import LogoImage from '@/components/LogoImage.vue'
   import ResultsCount from '@/components/ResultsCount.vue'
   import SearchInput from '@/components/SearchInput.vue'
-  import { useWorkspaceRoutes } from '@/compositions'
+  import { useComponent, useWorkspaceRoutes } from '@/compositions'
   import { BlockDocument } from '@/models/BlockDocument'
 
   const props = defineProps<{
@@ -72,6 +71,7 @@
     (event: 'delete'): void,
   }>()
 
+  const { BlockDocumentMenu } = useComponent()
   const routes = useWorkspaceRoutes()
   const searchTerm = ref('')
   const selectedCapability = ref<string | null>(null)

--- a/src/components/PageHeadingBlock.vue
+++ b/src/components/PageHeadingBlock.vue
@@ -8,9 +8,8 @@
 
 <script lang="ts" setup>
   import { BreadCrumbs } from '@prefecthq/prefect-design'
-  import BlockDocumentMenu from '@/components/BlockDocumentMenu.vue'
   import PageHeading from '@/components/PageHeading.vue'
-  import { useWorkspaceRoutes } from '@/compositions'
+  import { useComponent, useWorkspaceRoutes } from '@/compositions'
   import { BlockDocument } from '@/models/BlockDocument'
 
   const props = defineProps<{
@@ -22,6 +21,7 @@
   }>()
 
   const routes = useWorkspaceRoutes()
+  const { BlockDocumentMenu } = useComponent()
 
   const crumbs: BreadCrumbs = [
     { text: 'Blocks', to: routes.blocks() },


### PR DESCRIPTION
Similar to #1690.

Let consumers override the `<BlockDocumentMenu />` across all uses in other components via `useComponent`.