### PR TITLE
add an opt in to render large flow run graphs

### DIFF
--- a/src/components/FlowRunTimeline.vue
+++ b/src/components/FlowRunTimeline.vue
@@ -7,7 +7,7 @@
     aria-label="Flow run timeline graph"
     :style="{ height }"
   >
-    <div class="flow-run-timeline__wrapper">
+    <div v-if="!requireLargeRenderConfirmation" class="flow-run-timeline__wrapper">
       <p-button
         v-if="isFullscreen"
         class="flow-run-timeline__fullscreen-exit"
@@ -57,6 +57,20 @@
         />
       </div>
     </div>
+    <div v-if="requireLargeRenderConfirmation" class="flow-run-timeline__confirmation-wrapper">
+      <div class="flow-run-timeline__confirmation">
+        <p-icon class="flow-run-timeline__confirmation-icon" icon="ExclamationCircleIcon" />
+        <h3 class="flow-run-timeline__confirmation-header">
+          {{ localization.info.flowRunGraphNotDisplayedHeader }}
+        </h3>
+        <p class="flow-run-timeline__confirmation-message">
+          {{ localization.info.flowRunGraphNotDisplayedCopy }}
+        </p>
+        <p-button @click="confirmLargeRender">
+          {{ localization.info.flowRunGraphNotDisplayedCta }}
+        </p-button>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -78,6 +92,7 @@
   import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
   import { FlowRunTimelineOptions } from '@/components'
   import { useFlowRuns, useFlows, useWorkspaceApi } from '@/compositions'
+  import { localization } from '@/localization'
   import { FlowRun, FlowRunsFilter, isRunningStateType, isTerminalStateType } from '@/models'
   import { WorkspaceFlowRunsApi } from '@/services'
   import { formatTimeNumeric, formatTimeShortNumeric, formatDate, mapStateNameToStateType, getStateTypeStyles } from '@/utilities'
@@ -102,6 +117,7 @@
 
   const defaultOptionThresholds = {
     nearestParentLayout: 100,
+    requireLargeRenderConfirmation: 2000,
     hideEdges: 40,
   }
 
@@ -115,6 +131,7 @@
 
   const timelineGraphContainer = ref<HTMLElement | null>(null)
   const timelineGraph = ref<InstanceType<typeof FlowRunTimeline> | null>(null)
+  const requireLargeRenderConfirmation = ref(false)
   const isFullscreen = ref(false)
   const internalSelectedNode = computed<NodeSelectionEvent | null>({
     get() {
@@ -177,6 +194,10 @@
     }
   }
 
+  const confirmLargeRender = (): void => {
+    requireLargeRenderConfirmation.value = false
+  }
+
   const selectNode = (value: NodeSelectionEvent | null): void => {
     internalSelectedNode.value = value
   }
@@ -230,6 +251,10 @@
 
       if (value.length > defaultOptionThresholds.hideEdges) {
         hideEdges.value = true
+      }
+
+      if (value.length > defaultOptionThresholds.requireLargeRenderConfirmation) {
+        requireLargeRenderConfirmation.value = true
       }
 
       unwatchInitialData()
@@ -480,5 +505,36 @@
     transform: scale(1);
     opacity: 1;
   }
+}
+
+.flow-run-timeline__confirmation-wrapper { @apply
+  h-full
+  flex
+  items-center
+  justify-center
+}
+
+.flow-run-timeline__confirmation { @apply
+  text-center
+}
+
+.flow-run-timeline__confirmation-icon { @apply
+  text-subdued
+  mx-auto
+  w-10
+  h-10
+  mb-3
+}
+
+.flow-run-timeline__confirmation-header { @apply
+  text-xl
+  font-semibold
+  mb-2
+}
+
+.flow-run-timeline__confirmation-message { @apply
+  text-subdued
+  px-4
+  mb-4
 }
 </style>

--- a/src/components/FlowRunTimeline.vue
+++ b/src/components/FlowRunTimeline.vue
@@ -57,20 +57,7 @@
         />
       </div>
     </div>
-    <div v-if="requireLargeRenderConfirmation" class="flow-run-timeline__confirmation-wrapper">
-      <div class="flow-run-timeline__confirmation">
-        <p-icon class="flow-run-timeline__confirmation-icon" icon="ExclamationCircleIcon" />
-        <h3 class="flow-run-timeline__confirmation-header">
-          {{ localization.info.flowRunGraphNotDisplayedHeader }}
-        </h3>
-        <p class="flow-run-timeline__confirmation-message">
-          {{ localization.info.flowRunGraphNotDisplayedCopy }}
-        </p>
-        <p-button @click="confirmLargeRender">
-          {{ localization.info.flowRunGraphNotDisplayedCta }}
-        </p-button>
-      </div>
-    </div>
+    <FlowRunTimelineOptIn v-if="requireLargeRenderConfirmation" @confirm="confirmLargeRender" />
   </div>
 </template>
 
@@ -91,8 +78,8 @@
   import { UseSubscription, useDebouncedRef, useSubscription } from '@prefecthq/vue-compositions'
   import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
   import { FlowRunTimelineOptions } from '@/components'
+  import FlowRunTimelineOptIn from '@/components/FlowRunTimelineOptIn.vue'
   import { useFlowRuns, useFlows, useWorkspaceApi } from '@/compositions'
-  import { localization } from '@/localization'
   import { FlowRun, FlowRunsFilter, isRunningStateType, isTerminalStateType } from '@/models'
   import { WorkspaceFlowRunsApi } from '@/services'
   import { formatTimeNumeric, formatTimeShortNumeric, formatDate, mapStateNameToStateType, getStateTypeStyles } from '@/utilities'
@@ -505,36 +492,5 @@
     transform: scale(1);
     opacity: 1;
   }
-}
-
-.flow-run-timeline__confirmation-wrapper { @apply
-  h-full
-  flex
-  items-center
-  justify-center
-}
-
-.flow-run-timeline__confirmation { @apply
-  text-center
-}
-
-.flow-run-timeline__confirmation-icon { @apply
-  text-subdued
-  mx-auto
-  w-10
-  h-10
-  mb-3
-}
-
-.flow-run-timeline__confirmation-header { @apply
-  text-xl
-  font-semibold
-  mb-2
-}
-
-.flow-run-timeline__confirmation-message { @apply
-  text-subdued
-  px-4
-  mb-4
 }
 </style>

--- a/src/components/FlowRunTimelineOptIn.vue
+++ b/src/components/FlowRunTimelineOptIn.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="flow-run-timeline-opt-in">
+    <div class="flow-run-timeline-opt-in__confirmation">
+      <p-icon class="flow-run-timeline-opt-in__confirmation-icon" icon="ExclamationCircleIcon" />
+      <h3 class="flow-run-timeline-opt-in__confirmation-header">
+        {{ localization.info.flowRunGraphNotDisplayedHeader }}
+      </h3>
+      <p class="flow-run-timeline-opt-in__confirmation-message">
+        {{ localization.info.flowRunGraphNotDisplayedCopy }}
+      </p>
+      <p-button @click="confirm">
+        {{ localization.info.flowRunGraphNotDisplayedCta }}
+      </p-button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { localization } from '@/localization'
+
+  const emit = defineEmits<{
+    (event: 'confirm'): void,
+  }>()
+
+  const confirm = (): void => {
+    emit('confirm')
+  }
+</script>
+
+<style>
+.flow-run-timeline-opt-in { @apply
+  h-full
+  flex
+  items-center
+  justify-center
+}
+
+.flow-run-timeline-opt-in__confirmation { @apply
+  text-center
+}
+
+.flow-run-timeline-opt-in__confirmation-icon { @apply
+  text-subdued
+  mx-auto
+  w-10
+  h-10
+  mb-3
+}
+
+.flow-run-timeline-opt-in__confirmation-header { @apply
+  text-xl
+  font-semibold
+  mb-2
+}
+
+.flow-run-timeline-opt-in__confirmation-message { @apply
+  text-subdued
+  px-4
+  mb-4
+}
+</style>

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -187,5 +187,8 @@ export const en = {
     workPoolInfrastructureConfigurationInstructions: 'Below you can configure workers\' behavior when executing flow runs from this work pool. You can use the editor in the **Advanced** section to modify the existing configuration options if you need additional configuration options.\nIf you don\'t need to change the default behavior, hit **Create** to create your work pool!',
     workPoolInfrastructureConfigurationAgent: 'Prefect Agents handle infrastructure configuration via infrastructure blocks attached to deployments. You can hit **Create** to create this work pool and then head over to the **Blocks** tab to create an infrastructure block for your deployments.\nTo learn more about how to configure infrastructure for Prefect Agents, check out the [docs](https://docs.prefect.io/latest/concepts/infrastructure/).',
     disableFlowRunCancel: 'Only runs created from a deployment can be cancelled',
+    flowRunGraphNotDisplayedHeader: 'Graph not displayed',
+    flowRunGraphNotDisplayedCopy: 'Displaying this large graph may crash this web browser tab. Display anyway?',
+    flowRunGraphNotDisplayedCta: 'Display graph',
   },
 }


### PR DESCRIPTION
Resolves https://github.com/PrefectHQ/prefect/issues/10610

If a graph has more than 2k nodes, prevent the graph from drawing unless the user opts in to prevent potentially bogging down and browser crashing.

<img width="1512" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/1deb3558-f29e-4465-808b-9018eaeab684">
