### PR TITLE
Bugfix: Copy to new run access check

### DIFF
--- a/src/components/FlowRunMenu.vue
+++ b/src/components/FlowRunMenu.vue
@@ -1,9 +1,7 @@
 <template>
   <p-icon-button-menu>
     <template #default>
-      <router-link v-if="flowRun?.deploymentId" :to="routes.deploymentFlowRunCreate(flowRun.deploymentId, flowRun.parameters)">
-        <p-overflow-menu-item label="Copy to new run" />
-      </router-link>
+      <p-overflow-menu-item v-if="flowRun?.deploymentId && can.run.deployment" label="Copy to new run" :to="routes.deploymentFlowRunCreate(flowRun.deploymentId, flowRun.parameters)" />
       <p-overflow-menu-item v-if="canRetry && showAll" label="Retry" @click="openRetryModal" />
       <p-overflow-menu-item v-if="canResume && showAll" label="Resume" @click="openResumeModal" />
       <p-overflow-menu-item v-if="canPause && showAll" label="Pause" @click="openPauseModal" />


### PR DESCRIPTION
This PR hides the "Copy to new run" link on the flow run menu if the user does not have "run:deployment" privileges; if the user doesn't have those, the deployment flow run create page will 404. 