### PR TITLE
Enhancement: Schema fields without positions should sink

### DIFF
--- a/src/components/SchemaFormFields.vue
+++ b/src/components/SchemaFormFields.vue
@@ -26,6 +26,6 @@
 
   const sortedSchemaProperties = computed(() => {
     const properties = Object.entries(props.schema.properties ?? {})
-    return properties.sort(([, propA], [, propB]) => (propA?.position ?? 0) - (propB?.position ?? 0))
+    return properties.sort(([, propA], [, propB]) => (propA?.position ?? Infinity) - (propB?.position ?? Infinity))
   })
 </script>


### PR DESCRIPTION
Previously we were giving all schema properties without position keys a position of `0`, which would place them before any ordered properties. This PR changes that behavior to move them to the bottom instead.