### PR TITLE
Fix flows don't trigger custom filter options.

### DIFF
--- a/src/components/SavedFilters.vue
+++ b/src/components/SavedFilters.vue
@@ -43,7 +43,7 @@
     get() {
       const inRoute: SavedSearchFilter = {
         state: filter.flowRuns.state.name ?? [],
-        flow: filter.flows.name ?? [],
+        flow: filter.flows.id ?? [],
         deployment: filter.deployments.id ?? [],
         workPool: filter.workPools.name ?? [],
         tag: filter.flowRuns.tags.name ?? [],


### PR DESCRIPTION
# Description
This looks like a bug to me. If this is actually intended then feel free to close and ignore. 

The functionality to filter by flow(s) _works_ and even selecting pre-saved filters that included flows correctly sets the filter, but what doesn't is being able to save new filters using **only** flows and the UI doesn't correctly map pre-saved filters that include flows so when selected a saved filter that includes flows, the SavedFilter select shows "Custom" instead of the selected filter. 

## Steps to reproduce:
1. Go to Flow Runs
<img width="1244" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/fa0bd1fc-7d67-4eb5-932b-c3dccda31b75">

2. Select at least 1 flow to filter by

| Actual | Expected |
| --- | --- |
| <img width="860" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/236fa195-5efc-4716-a223-4df8ad9d7d96"> | <img width="856" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/d8442197-c0fe-4c1f-8e99-3ecacaecf44f"> |

3. Save a filter that includes flows and then select that filter. Notice the filtering _works_ but the dropdown shows "Custom" instead of the filter you just selected

| Actual | Expected |
| --- | --- |
| <img width="867" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/b97d5b4b-9f82-4054-aebe-d3330ce00367"> | <img width="872" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/447c48eb-1b23-4576-b797-a02ab238c79d"> |

This also means I can't save filters that only include flows
| Actual | Expected |
| --- | --- |
| <img width="873" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/eb72634c-8791-4be2-ab81-2a9954c24547"> | <img width="870" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/fbf72a39-6a61-4803-a7c0-c0974eb2c028"> |
