### PR TITLE
BugFix: Use lodash.merge to avoid mutating filter props

### DIFF
--- a/src/components/DeploymentsTable.vue
+++ b/src/components/DeploymentsTable.vue
@@ -81,6 +81,7 @@
 <script lang="ts" setup>
   import { PTable, PTagWrapper, PEmptyResults, PLink, TableColumn } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
+  import merge from 'lodash.merge'
   import { computed, ref } from 'vue'
   import { SearchInput, ResultsCount, DeploymentToggle, FlowRouterLink, DeploymentsDeleteButton, SelectedCount } from '@/components'
   import DeploymentTagsInput from '@/components/DeploymentTagsInput.vue'
@@ -106,14 +107,12 @@
 
   const page = useRouteQueryParam('page', NumberRouteParam, 1)
 
-  const { filter, clear, isCustomFilter } = useDeploymentsFilterFromRoute({
-    ...props.filter,
+  const { filter, clear, isCustomFilter } = useDeploymentsFilterFromRoute(merge({}, props.filter, {
     deployments: {
-      ...props.filter?.deployments,
       nameLike: deploymentNameDebounced,
     },
     limit: 50,
-  })
+  }))
 
   const { deployments, subscriptions, total, pages } = useDeployments(filter, {
     page,

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -88,6 +88,7 @@
 <script lang="ts" setup>
   import { media } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
+  import merge from 'lodash.merge'
   import { computed, ref } from 'vue'
   import { FlowListItem, FlowsDeleteButton, ResultsCount, SearchInput, SelectedCount, FlowsFilterGroup } from '@/components'
   import { useDeploymentsCount, useFlows, useFlowsFilterFromRoute } from '@/compositions'
@@ -132,16 +133,14 @@
 
   const page = useRouteQueryParam<number>('page', NumberRouteParam, 1)
 
-  const { filter: routeFilter, isDefaultFilter, isCustomFilter, clear } = useFlowsFilterFromRoute({
-    ...props.filter,
+  const { filter: routeFilter, isDefaultFilter, isCustomFilter, clear } = useFlowsFilterFromRoute(merge({}, props.filter, {
     flows: {
-      ...props.filter?.flows,
       nameLike,
     },
     deployments: {
       nameLike: deploymentNameLike,
     },
-  })
+  }))
 
   const filter = computed(() => {
     return {

--- a/src/components/FlowsTable.vue
+++ b/src/components/FlowsTable.vue
@@ -75,6 +75,7 @@
 <script lang="ts" setup>
   import { PTable, PEmptyResults, PLink, CheckboxModel, TableColumn } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
+  import merge from 'lodash.merge'
   import { computed, ref } from 'vue'
   import { FlowsDeleteButton, DeploymentsCount, ResultsCount, SearchInput, FlowActivityChart, SelectedCount, FlowRunTagsInput } from '@/components'
   import { useCan, useFlowsFilterFromRoute, useWorkspaceRoutes, useOffsetStickyRootMargin, useFlows } from '@/compositions'
@@ -96,14 +97,12 @@
 
   const flowNameLike = ref<string>()
   const flowNameLikeDebounced = useDebouncedRef(flowNameLike, 1200)
-  const { filter, clear, isCustomFilter } = useFlowsFilterFromRoute({
-    ...props.filter,
+  const { filter, clear, isCustomFilter } = useFlowsFilterFromRoute(merge({}, props.filter, {
     flows: {
-      ...props.filter,
       nameLike: flowNameLikeDebounced,
     },
     limit: 50,
-  })
+  }))
 
   const page = useRouteQueryParam('page', NumberRouteParam, 1)
   const { flows, subscriptions, total, pages } = useFlows(filter, {

--- a/src/components/VariablesTable.vue
+++ b/src/components/VariablesTable.vue
@@ -76,6 +76,7 @@
 <script lang="ts" setup>
   import { PTable, PEmptyResults, CheckboxModel, TableColumn, ClassValue } from '@prefecthq/prefect-design'
   import { useDebouncedRef, useSubscription } from '@prefecthq/vue-compositions'
+  import merge from 'lodash.merge'
   import { computed, ref } from 'vue'
   import { VariablesDeleteButton, VariableMenu, ResultsCount, SearchInput, SelectedCount, VariableTagsInput } from '@/components'
   import { useCan, useOffsetStickyRootMargin, useVariablesFilter, useWorkspaceApi } from '@/compositions'
@@ -103,15 +104,13 @@
   })
   const pages = computed(() => Math.ceil((variablesCount.value ?? DEFAULT_LIMIT) / DEFAULT_LIMIT))
 
-  const { filter, isCustomFilter, clear } = useVariablesFilter({
-    ...props.filter,
+  const { filter, isCustomFilter, clear } = useVariablesFilter(merge({}, props.filter, {
     variables: {
-      ...props.filter?.variables,
       nameLike: variableLikeDebounced,
       valueLike: variableLikeDebounced,
     },
     offset,
-  })
+  }))
 
   const columns: TableColumn<Variable>[] = [
     {


### PR DESCRIPTION
# Description
Several components accept a filter and then spread that filter into a `useSomethingFilter` composition as the base filter. But those compositions (specifically the route versions) directly modify the base filter. This seems to work find when navigating through the app but I noticed that if there were filters in the url and you refreshed the page the page would be broken and there would be an error in the console. Some digging revealed that error is from vue trying to mutate the filters prop, but props are readonly so the proxy trap returned false. 

I was able to fix this by using `merge` to merge props.filter and any additional filters the component applies onto an empty object. This makes sure the values from props.filter are applied without attempting to write to props.filter. And from my testing all the filters work as expected even after a page refresh. 

Before
<img width="1593" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/deed79df-fc3b-40af-b577-096aa2b0ba79">

After
<img width="1591" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/7b27822d-76cf-4fd2-8e2d-cd9ea1fe0113">
