### PR TITLE
Completes -> Completed

### DIFF
--- a/src/components/DashboardWorkPoolCard.vue
+++ b/src/components/DashboardWorkPoolCard.vue
@@ -30,7 +30,7 @@
         </div>
       </DashboardWorkPoolCardDetail>
 
-      <DashboardWorkPoolCardDetail label="Completes">
+      <DashboardWorkPoolCardDetail label="Completed">
         <DashboardWorkPoolFlowRunCompleteness :work-pool="workPool" :filter="flowRunsFilter" />
       </DashboardWorkPoolCardDetail>
     </dl>


### PR DESCRIPTION
This work pool header has a typo, showing "Completes" instead of "Completed" for the % of completed runs.