### PR TITLE
Fix unit tests job name from "Build package" to "Run tests"

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,5 +47,5 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Build package
+      - name: Run tests
         run: npm run test


### PR DESCRIPTION
# Description
Just fixing a copy paste error