### PR TITLE
swap `estimatedRunTime` to be preferred for `duration`

### DIFF
--- a/src/models/FlowRun.ts
+++ b/src/models/FlowRun.ts
@@ -111,7 +111,7 @@ export class FlowRun extends StorageItem implements IFlowRun {
   }
 
   public get duration(): number {
-    return this.totalRunTime || this.estimatedRunTime
+    return this.estimatedRunTime || this.totalRunTime 
   }
 
   public isScheduled(): this is FlowRun & { expectedStartTime: Date } {

--- a/src/models/TaskRun.ts
+++ b/src/models/TaskRun.ts
@@ -84,6 +84,6 @@ export class TaskRun implements ITaskRun {
   }
 
   public get duration(): number {
-    return (this.estimatedRunTime && this.estimatedRunTime > 0 ? this.estimatedRunTime : this.totalRunTime) ?? 0;
+    return (this.estimatedRunTime && this.estimatedRunTime > 0 ? this.estimatedRunTime : this.totalRunTime) ?? 0
   }
 }

--- a/src/models/TaskRun.ts
+++ b/src/models/TaskRun.ts
@@ -84,6 +84,6 @@ export class TaskRun implements ITaskRun {
   }
 
   public get duration(): number {
-    return (this.totalRunTime && this.totalRunTime > 0 ? this.totalRunTime : this.estimatedRunTime) ?? 0
+    return (this.estimatedRunTime && this.estimatedRunTime > 0 ? this.estimatedRunTime : this.totalRunTime) ?? 0;
   }
 }


### PR DESCRIPTION
closes: https://github.com/PrefectHQ/nebula/issues/5778

Swaps `estimated_run_time` to take preference over `total_run_time`.

`total_run_time`: Is the total amount of time a flow/task run has spent in `RUNNING`. This is updated after a run has _left_ the `RUNNING` state.

`estimated_run_time`: If a state is not in `RUNNING` this is just the `total_run_time`. If a state is in `RUNNING`, this is the the `total_run_time` + the delta between when the run entered `RUNNING` and now.

This will correctly update the duration field in the UI when a run is still in progress after a retry. Previously because `total_run_time` was preferred, an in process run on it's second attempt would have it's duration updated while it was still in progress.

Examples: Note the `total_run_time` and `estimated_run_time` in the api responses and the `duration` on the page.
![Screenshot 2023-10-09 at 12 35 14 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/40362401/7c085b72-f311-4305-b3ab-e8674ea88628)
![Screenshot 2023-10-09 at 12 35 14 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/40362401/8f69e5a2-66ec-43f0-977a-4eea8ab6f393)

