### PR TITLE
Enhancement: Avoid refetch of deployment within deployment menu.

### DIFF
--- a/src/components/DeploymentCustomRunOverflowMenuItem.vue
+++ b/src/components/DeploymentCustomRunOverflowMenuItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <router-link v-if="deployment" :to="routes.deploymentFlowRunCreate(deploymentId, deployment.rawParameters)">
+  <router-link :to="routes.deploymentFlowRunCreate(deployment.id, deployment.rawParameters)">
     <p-overflow-menu-item>
       <slot>
         Custom run
@@ -9,14 +9,12 @@
 </template>
 
 <script lang="ts" setup>
-  import { toRefs } from 'vue'
-  import { useDeployment, useWorkspaceRoutes } from '@/compositions'
+  import { useWorkspaceRoutes } from '@/compositions'
+  import { Deployment } from '@/models'
 
-  const props = defineProps<{
-    deploymentId: string,
+  defineProps<{
+    deployment: Deployment,
   }>()
 
-  const { deploymentId } = toRefs(props)
   const routes = useWorkspaceRoutes()
-  const { deployment } = useDeployment(deploymentId)
 </script>

--- a/src/components/DeploymentMenu.vue
+++ b/src/components/DeploymentMenu.vue
@@ -2,7 +2,7 @@
   <p-icon-button-menu v-bind="$attrs">
     <DeploymentQuickRunOverflowMenuItem v-if="deployment.can.run && showAll" :deployment="deployment" :open-modal="openParametersModal" />
 
-    <DeploymentCustomRunOverflowMenuItem v-if="deployment.can.run && showAll" :deployment-id="deployment.id" />
+    <DeploymentCustomRunOverflowMenuItem v-if="deployment.can.run && showAll" :deployment="deployment" />
 
     <copy-overflow-menu-item label="Copy ID" :item="deployment.id" />
 

--- a/src/components/RunMenu.vue
+++ b/src/components/RunMenu.vue
@@ -13,7 +13,7 @@
     </template>
     <p-overflow-menu class="run-menu__overflow-menu" @click="close">
       <DeploymentQuickRunOverflowMenuItem :deployment="deployment" :open-modal="openParametersModal" />
-      <DeploymentCustomRunOverflowMenuItem :deployment-id="deployment.id" />
+      <DeploymentCustomRunOverflowMenuItem :deployment="deployment" />
     </p-overflow-menu>
   </p-pop-over>
   <QuickRunParametersModal v-model:showModal="showParametersModal" :deployment="deployment" />


### PR DESCRIPTION
This PR changes the `<DeploymentCustomRunOverflowMenuItem />` component's props to take a full deployment object instead of just an id. 

The reason for the change is so that when rendering a list of deployments - each with a `<DeploymentMenu />`, each deployment doesn't need to be refetched when opening the menu. Right now _everytime you click the overflow button_, a fetch is made to load /deployments/filter with deployment_ids: [oneDeploymentId]. In cloud, because of object ACLs, everytime you click the overflow button, a request is made to deployments _and_ to `/my-access` to load the can for each. We already have a fully loaded `deployment` object though so this PR just passes that through as a prop. 

Of note, the other menu items here already take in a full deployment object rather than just an id (`DeploymentQuickRunOverflowMenuItem`)