### PR TITLE
Enhancement: Deployment combobox option alignment

### DIFF
--- a/demo/compositions/useFlowRunsMock.ts
+++ b/demo/compositions/useFlowRunsMock.ts
@@ -5,13 +5,21 @@ import { repeat } from '@/utilities/arrays'
 
 export function useFlowRunMock(override?: Partial<FlowRun>): FlowRun {
   const flow = mocker.create('flow')
-  const deployment = mocker.create('deployment')
-  const workQueue = mocker.create('workQueue')
+
+  const workPool = mocker.create('workPool')
+
+  const deployment = mocker.create('deployment', [
+    {
+      flowId: flow.id,
+      workPoolName: workPool.name,
+    },
+  ])
+
   const flowRun = mocker.create('flowRun', [
     {
       flowId: flow.id,
       deploymentId: deployment.id,
-      workQueueName: workQueue.name,
+      workPoolName: workPool.name,
       ...override,
     },
   ])
@@ -28,7 +36,7 @@ export function useFlowRunMock(override?: Partial<FlowRun>): FlowRun {
     artifacts: [result],
     flows: [flow],
     deployments: [deployment],
-    workQueues: [workQueue],
+    workPools: [workPool],
     flowRuns: [flowRun],
   })
 

--- a/demo/sections/flowRuns/FlowRunsFilterGroup.vue
+++ b/demo/sections/flowRuns/FlowRunsFilterGroup.vue
@@ -9,18 +9,9 @@
 <script lang="ts" setup>
   import FlowRunsFilterGroup from '@/components/FlowRunsFilterGroup.vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
-  import { useSeeds } from '@/demo/compositions/useSeeds'
-  import { mocker } from '@/services'
+  import { useFlowRunsMock } from '@/demo/compositions/useFlowRunsMock'
 
-  const flowRuns = mocker.createMany('flowRun', 200)
-  const flows = mocker.createMany('flow', 25)
-  const deployments = mocker.createMany('deployment', 8)
-
-  useSeeds({
-    flowRuns,
-    flows,
-    deployments,
-  })
+  useFlowRunsMock(50)
 </script>
 
 <style>

--- a/src/components/DeploymentComboboxOption.vue
+++ b/src/components/DeploymentComboboxOption.vue
@@ -20,7 +20,7 @@
   }>()
 
   const element = ref<HTMLDivElement>()
-  const { flow } = useFlow(props.flowId)
+  const { flow } = useFlow(() => props.flowId)
 </script>
 
 <style>

--- a/src/components/DeploymentComboboxOption.vue
+++ b/src/components/DeploymentComboboxOption.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="element" class="deployment-combobox-option">
+  <div class="deployment-combobox-option">
     <template v-if="flow">
       <span class="deployment-combobox-option__flow-name">
         {{ flow.name }}
@@ -11,7 +11,6 @@
 </template>
 
 <script lang="ts" setup>
-  import { ref } from 'vue'
   import { useFlow } from '@/compositions'
 
   const props = defineProps<{
@@ -19,7 +18,6 @@
     deploymentName?: string,
   }>()
 
-  const element = ref<HTMLDivElement>()
   const { flow } = useFlow(() => props.flowId)
 </script>
 

--- a/src/components/DeploymentComboboxOption.vue
+++ b/src/components/DeploymentComboboxOption.vue
@@ -1,48 +1,37 @@
 <template>
   <div ref="element" class="deployment-combobox-option">
-    <span v-if="visible && flowResponse" class="deployment-combobox-option--flow-name">
-      {{ flowResponse.name }}
-      <p-icon icon="ChevronRightIcon" size="small" class="deployment-combobox-option--chevron" />
-    </span>
+    <template v-if="flow">
+      <span class="deployment-combobox-option__flow-name">
+        {{ flow.name }}
+      </span>
+      <p-icon icon="ChevronRightIcon" size="small" class="deployment-combobox-option__chevron" />
+    </template>
     {{ deploymentName }}
   </div>
 </template>
 
 <script lang="ts" setup>
-  import { useVisibilityObserver, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-  import { computed, ref } from 'vue'
-  import { useWorkspaceApi } from '@/compositions'
+  import { ref } from 'vue'
+  import { useFlow } from '@/compositions'
 
   const props = defineProps<{
     flowId: string,
     deploymentName?: string,
   }>()
 
-  const api = useWorkspaceApi()
   const element = ref<HTMLDivElement>()
-  const { visible } = useVisibilityObserver(element, { disconnectWhenVisible: true })
-
-
-  const flowId = computed(() => props.flowId)
-  const flowArgs = computed<Parameters<typeof api.flows.getFlow> | null>(() => {
-    if (!visible.value) {
-      return null
-    }
-    return [flowId.value]
-  })
-
-  const flowSubscription = useSubscriptionWithDependencies(api.flows.getFlow, flowArgs)
-  const flowResponse = computed(() => flowSubscription.response)
+  const { flow } = useFlow(props.flowId)
 </script>
 
 <style>
-.deployment-combobox-option {
-  @apply flex items-center
+.deployment-combobox-option { @apply
+  flex
+  gap-1
+  items-center
 }
-.deployment-combobox-option--flow-name {
-  @apply inline-flex items-center
-}
-.deployment-combobox-option--chevron {
-  @apply w-3 h-3 mr-1
+
+.deployment-combobox-option__chevron { @apply
+  w-3
+  h-3
 }
 </style>


### PR DESCRIPTION
This PR:
- fixes an issue with the `useFlowRunsMock` composition where the deployments and flows created for downstream flow runs had no relation and so would break demos
- fixes alignment and visibility issues with deployment combobox options

I've simplified the `DeploymentComboboxOption` quite bit because it was overly complicated attempting to account for visibility and wasn't using any of our new compositions. Should be much more straight forward now


Before:
![Screenshot 2023-10-10 at 7 15 53 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/3baef8c0-9293-4cc5-9f76-fe4dc3a98998)



After:
![Screenshot 2023-10-10 at 7 16 44 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/926f8a2c-e701-4e64-bfdb-8b86d5870621)

