### PR TITLE
Fix: Improve handling of push pools on the workspace dashboard

### DIFF
--- a/src/components/WorkPoolQueueStatusArray.vue
+++ b/src/components/WorkPoolQueueStatusArray.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="work-pool-queue-status-array">
-    <template v-if="!showTooMany && workPoolQueues.length > 0">
+    <template v-if="!isPushPool && !showTooMany && workPoolQueues.length > 0">
       <WorkPoolQueueStatusIcon
         v-for="workQueue in workPoolQueues"
         :key="workQueue.id"
@@ -9,7 +9,7 @@
         class="work-pool-queue-status-badge__icon"
       />
     </template>
-    <span v-if="!showTooMany && workPoolQueues.length < 1" class="work-pool-queue-status-array__none">N/A</span>
+    <span v-if="isPushPool || !showTooMany && workPoolQueues.length < 1" class="work-pool-queue-status-array__none">N/A</span>
     <span v-if="showTooMany" class="work-pool-queue-status-array__too-many">Too many to show here.</span>
   </div>
 </template>
@@ -37,6 +37,7 @@
 
   const workPoolQueues = computed(() => workPoolQueuesSubscription.response ?? [])
   const showTooMany = computed(() => workPoolQueues.value.length > maxWorkQueues)
+  const isPushPool = computed(() => !!props.workPool.isPushPool)
 </script>
 
 <style>


### PR DESCRIPTION
Push pools do not use work queues and the work queue health indicator for them on the dashboard is misleading.  This removes the indicator and replaces it with N/A as we do with polled in the same tile. 

Before:
<img width="1427" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/0e99d957-f6e7-4e09-a8a7-132c2cc58a2d">

After:
<img width="574" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/63f4125b-70fb-4628-b817-94403c70be6c">