### PR TITLE
Updates message in work pool empty state page

### DIFF
--- a/src/components/WorkPoolsPageEmptyState.vue
+++ b/src/components/WorkPoolsPageEmptyState.vue
@@ -10,7 +10,7 @@
 
     <template #description>
       Work pools allow you to prioritize and manage deployment runs
-      to be picked up by a corresponding agent.
+      and control the infrastructure they run on.
     </template>
     <template #actions>
       <DocumentationButton :to="localization.docs.workPools" />


### PR DESCRIPTION
The empty state for the work pool page doesn't show up unless a user deletes the default agent work pool, but we plan to create a default work pool for new workspaces unless they specifically use an agent. This PR update the work pool empty state to remove the reference to agents.

Related to https://github.com/PrefectHQ/nebula/issues/5845