### PR TITLE
Fix: Remove empty state flicker on the dashboard

### DIFF
--- a/src/components/ConcurrencyLimitsPageEmptyState.vue
+++ b/src/components/ConcurrencyLimitsPageEmptyState.vue
@@ -14,10 +14,10 @@
     </template>
 
     <template #actions>
-      <DocumentationButton :to="localization.docs.concurrency" />
       <p-button v-if="can.create.concurrency_limit" primary icon-append="PlusIcon" @click="open">
         Add Concurrency Limit
       </p-button>
+      <DocumentationButton :to="localization.docs.concurrency" />
       <ConcurrencyLimitsCreateModal v-model:showModal="showModal" />
     </template>
   </p-empty-state>

--- a/src/components/ConcurrencyLimitsV2EmptyState.vue
+++ b/src/components/ConcurrencyLimitsV2EmptyState.vue
@@ -13,10 +13,10 @@
     </template>
 
     <template #actions>
-      <DocumentationButton :to="localization.docs.globalConcurrency" />
       <p-button v-if="can.create.concurrency_limit" primary icon-append="PlusIcon" @click="open">
         Add Concurrency Limit
       </p-button>
+      <DocumentationButton :to="localization.docs.globalConcurrency" />
       <ConcurrencyLimitsV2CreateModal v-model:showModal="showModal" />
     </template>
   </p-empty-state>

--- a/src/components/FlowRunsAccordion.vue
+++ b/src/components/FlowRunsAccordion.vue
@@ -9,7 +9,7 @@
       </template>
     </p-accordion>
   </template>
-  <template v-if="!count">
+  <template v-if="!count && loaded">
     <FlowRunStateTypeEmpty :state-type="stateType" />
   </template>
 </template>
@@ -45,7 +45,8 @@
     }
   }
   const options = useInterval()
-  const { count } = useFlowRunsCount(flowRunsFilter, options)
+  const { count, subscription } = useFlowRunsCount(flowRunsFilter, options)
+  const loaded = computed(() => subscription.executed)
   const { flows } = useFlows(flowsFilter, options)
   const flowIds = computed(() => flows.value.map(flow => flow.id))
   const flowsLookup = computed(() => toMap(flows.value, 'id'))

--- a/src/models/FlowRun.ts
+++ b/src/models/FlowRun.ts
@@ -111,7 +111,7 @@ export class FlowRun extends StorageItem implements IFlowRun {
   }
 
   public get duration(): number {
-    return this.estimatedRunTime || this.totalRunTime 
+    return this.estimatedRunTime || this.totalRunTime
   }
 
   public isScheduled(): this is FlowRun & { expectedStartTime: Date } {


### PR DESCRIPTION
Adds a check to make the subscription is fully executed before we show the empty state

Current:

https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/320c28c5-4101-49fb-8dd4-bad03ff816d4

Fix:

https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/a1f358b8-b356-42f7-9c9a-eea5b061cb3c


