### PR TITLE
Fix: Hide flow run concurrency on editing push work pools

### DIFF
--- a/src/components/WorkPoolEditForm.vue
+++ b/src/components/WorkPoolEditForm.vue
@@ -13,7 +13,7 @@
         </template>
       </p-label>
 
-      <p-label label="Flow Run Concurrency (Optional)">
+      <p-label v-if="!isPushWorkPool" label="Flow Run Concurrency (Optional)">
         <template #default="{ id }">
           <p-number-input :id="id" v-model="concurrencyLimit" placeholder="Unlimited" :min="0" />
         </template>
@@ -52,6 +52,8 @@
   const props = defineProps<{
     workPool: WorkPool,
   }>()
+
+  const isPushWorkPool = computed(() => !!props.workPool.isPushPool)
 
   const api = useWorkspaceApi()
   const router = useRouter()

--- a/src/components/WorkPoolEditForm.vue
+++ b/src/components/WorkPoolEditForm.vue
@@ -13,7 +13,7 @@
         </template>
       </p-label>
 
-      <p-label v-if="!isPushWorkPool" label="Flow Run Concurrency (Optional)">
+      <p-label v-if="!workPool.isPushPool" label="Flow Run Concurrency (Optional)">
         <template #default="{ id }">
           <p-number-input :id="id" v-model="concurrencyLimit" placeholder="Unlimited" :min="0" />
         </template>
@@ -53,7 +53,6 @@
     workPool: WorkPool,
   }>()
 
-  const isPushWorkPool = computed(() => !!props.workPool.isPushPool)
 
   const api = useWorkspaceApi()
   const router = useRouter()


### PR DESCRIPTION
Push work pools do not allow concurrency limits. We hide the concurrency limit on creation of push work pools but it is still visible on edit.  This PR checks if a work pool is push type and hides the concurrency limit input. 