### PR TITLE
Make the viewport prop optional in FlowRunGraph to match the RunGraph component

### DIFF
--- a/src/components/FlowRunGraph.vue
+++ b/src/components/FlowRunGraph.vue
@@ -29,9 +29,9 @@
 
   const props = defineProps<{
     flowRun: FlowRun,
-    viewport: ViewportDateRange,
     fullscreen: boolean,
     selected: NodeSelection | null,
+    viewport?: ViewportDateRange,
   }>()
 
   const emit = defineEmits<{


### PR DESCRIPTION
# Description
Slight discrepancy in the FlowRunGraph component that is preventing the implementation in oss/cloud from passing type validation. 