### PR TITLE
Fix usePagination subscription not refreshing first page of results

### DIFF
--- a/src/compositions/usePagination.ts
+++ b/src/compositions/usePagination.ts
@@ -1,6 +1,6 @@
 import { Getter } from '@prefecthq/prefect-design'
 import { SubscriptionOptions, UseSubscription, useSubscription, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { ComputedRef, MaybeRef, Ref, computed, reactive, ref, watch } from 'vue'
+import { ComputedRef, MaybeRef, Ref, computed, onScopeDispose, reactive, ref, watch } from 'vue'
 import { GLOBAL_API_LIMIT } from '@/compositions/useFilterPagination'
 import { UseSubscriptions, useSubscriptions } from '@/compositions/useSubscriptions'
 import { repeat } from '@/utilities/arrays'
@@ -197,6 +197,10 @@ export function usePagination<
 
   watch(page, () => {
     setFetchSubscriptionParameters()
+  })
+
+  onScopeDispose(() => {
+    subscriptions.unsubscribe()
   })
 
   return {

--- a/src/compositions/usePagination.ts
+++ b/src/compositions/usePagination.ts
@@ -161,7 +161,7 @@ export function usePagination<
 
   function getLimit(): number {
     const [filter] = fetchParametersGetter() ?? []
-    const limit = 5
+    const limit = filter?.limit ?? GLOBAL_API_LIMIT
 
     return limit
   }


### PR DESCRIPTION
# Description
Because `usePagination` used nested subscriptions it was easy to end up with the first page of results always being a cache hit even if an interval was used or refresh was called. This causes bugs like new flow runs not showing up on the flow runs page without a manual page refresh. 

Fixing this by removing the nested subscriptions in favor of just tracking an array of subscriptions like we've done in the past. This seems more stable and is actually less complex. 

Closes https://github.com/PrefectHQ/prefect/issues/11126 