### PR TITLE
Fix interval in FlowRunsFilteredList

### DIFF
--- a/src/components/FlowRunFilteredList.vue
+++ b/src/components/FlowRunFilteredList.vue
@@ -71,7 +71,7 @@
   }))
 
   const { flowRuns, total, subscriptions, next } = useFlowRuns(filter, {
-    interval: 3000,
+    interval: 30000,
     mode: 'infinite',
   })
 


### PR DESCRIPTION
# Description
The interval for flow runs was set to 3 seconds when it should be 30 seconds. Which was accidentally changed [here](https://github.com/PrefectHQ/prefect-ui-library/pull/1777/files#diff-b1aa283649729074ab8c72db7cf1838347d6f820d19c0be1b384c7fd24c62893R74). 