### PR TITLE
Update an unpin vue-compositions as a peer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
             "peerDependencies": {
                 "@prefecthq/prefect-design": "^2.0.11",
                 "@prefecthq/vue-charts": "^2.0.3",
-                "@prefecthq/vue-compositions": "1.6.4",
+                "@prefecthq/vue-compositions": "^1.6.6",
                 "vee-validate": "^4.7.0",
                 "vue": "^3.3.4",
                 "vue-router": "^4.0.12"
@@ -1311,9 +1311,9 @@
             }
         },
         "node_modules/@prefecthq/vue-compositions": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.6.4.tgz",
-            "integrity": "sha512-Gg/I+a6/1wPWFZelBtMd6+Sgu6xD7jHSe50Iz6d6X9XrgMqE0o88x3IOGkJGAkP7rknhmdhPzxCa2SCRPwE+jQ==",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.6.6.tgz",
+            "integrity": "sha512-IKEd4y0qgiOyLz5OSRMsjfZiYzxj0ZtOHktspLNZuC355k4pEjUCGq9FRRxYm4isQ6IRHkcskdTiprIjcLgG7g==",
             "peer": true,
             "dependencies": {
                 "jsdom": "^22.0.0"
@@ -8223,9 +8223,9 @@
             }
         },
         "@prefecthq/vue-compositions": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.6.4.tgz",
-            "integrity": "sha512-Gg/I+a6/1wPWFZelBtMd6+Sgu6xD7jHSe50Iz6d6X9XrgMqE0o88x3IOGkJGAkP7rknhmdhPzxCa2SCRPwE+jQ==",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.6.6.tgz",
+            "integrity": "sha512-IKEd4y0qgiOyLz5OSRMsjfZiYzxj0ZtOHktspLNZuC355k4pEjUCGq9FRRxYm4isQ6IRHkcskdTiprIjcLgG7g==",
             "peer": true,
             "requires": {
                 "jsdom": "^22.0.0"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "peerDependencies": {
         "@prefecthq/prefect-design": "^2.0.11",
         "@prefecthq/vue-charts": "^2.0.3",
-        "@prefecthq/vue-compositions": "1.6.4",
+        "@prefecthq/vue-compositions": "^1.6.6",
         "vee-validate": "^4.7.0",
         "vue": "^3.3.4",
         "vue-router": "^4.0.12"


### PR DESCRIPTION
# Description
This got pinned to a specific version when we downgraded as a hot fix. 