### PR TITLE
Update axios to 1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@prefecthq/graphs": "2.1.7",
                 "@types/lodash.isequal": "4.5.8",
-                "axios": "0.27.2",
+                "axios": "1.6.2",
                 "cronstrue": "^2.43.0",
                 "d3": "7.8.5",
                 "date-fns": "2.30.0",
@@ -2543,12 +2543,13 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
             "dependencies": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/balanced-match": {
@@ -6009,6 +6010,11 @@
                 "node": ">=6"
             }
         },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        },
         "node_modules/psl": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -9188,12 +9194,13 @@
             "dev": true
         },
         "axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
             "requires": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "balanced-match": {
@@ -11686,6 +11693,11 @@
             "version": "1.29.0",
             "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
             "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
+        },
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "psl": {
             "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "dependencies": {
         "@prefecthq/graphs": "2.1.7",
         "@types/lodash.isequal": "4.5.8",
-        "axios": "0.27.2",
+        "axios": "1.6.2",
         "cronstrue": "^2.43.0",
         "d3": "7.8.5",
         "date-fns": "2.30.0",

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -1,5 +1,5 @@
 import { asArray } from '@prefecthq/prefect-design'
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosRequestHeaders, AxiosResponse } from 'axios'
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, RawAxiosRequestHeaders } from 'axios'
 import { MaybeArray } from '@/types/utilities'
 import { isDefined } from '@/utilities/variables'
 
@@ -10,14 +10,14 @@ export type PrefectConfig = {
 
 type ConfigFunction<R, T extends PrefectConfig = PrefectConfig> = (config: T) => R
 export type ApiBaseUrl<T extends PrefectConfig = PrefectConfig> = string | ConfigFunction<string, T>
-export type ApiHeaders<T extends PrefectConfig = PrefectConfig> = AxiosRequestHeaders | ConfigFunction<AxiosRequestHeaders, T>
+export type ApiHeaders<T extends PrefectConfig = PrefectConfig> = RawAxiosRequestHeaders | ConfigFunction<RawAxiosRequestHeaders, T>
 
 export const getPrefectBaseUrl: ApiBaseUrl = (config) => config.baseUrl
 
-export const getPrefectUIHeaders: ApiHeaders = { 'X-PREFECT-UI': true }
+export const getPrefectUIHeaders: RawAxiosRequestHeaders = { 'X-PREFECT-UI': true }
 
 export const getAuthorizationHeaders: ApiHeaders = (config) => {
-  const value: AxiosRequestHeaders = {}
+  const value: RawAxiosRequestHeaders = {}
 
   if (config.token) {
     value.Authorization = `bearer ${config.token}`
@@ -44,10 +44,10 @@ export class Api<T extends PrefectConfig = PrefectConfig> {
     return this.apiBaseUrl(this.apiConfig)
   }
 
-  protected composeHeaders(): AxiosRequestHeaders {
+  protected composeHeaders(): RawAxiosRequestHeaders {
     const array = asArray(this.apiHeaders)
 
-    return array.reduce<AxiosRequestHeaders>((headers, header) => {
+    return array.reduce<RawAxiosRequestHeaders>((headers, header) => {
       const value = typeof header === 'function' ? header(this.apiConfig) : header
 
       return {

--- a/src/utilities/errors.ts
+++ b/src/utilities/errors.ts
@@ -1,8 +1,8 @@
-import axios from 'axios'
+import { isAxiosError } from 'axios'
 import { isRecord, isString } from '@/utilities'
 
 export function getApiErrorMessage(error: unknown, defaultErrorMessage: string): string {
-  if (!axios.isAxiosError(error)) {
+  if (!isAxiosError(error)) {
     return defaultErrorMessage
   }
 


### PR DESCRIPTION
# Description
We didn't update to axios 1.x.x when it first came out because we wanted to wait for that version to be proven/stable and we weren't having any issues with 0.27.2

But now we have an open [security alert](https://github.com/PrefectHQ/prefect-ui-library/security/dependabot/12) that's fixed by updating and axios is now on 1.6.2. 

Update was trivial and only a type change was needed. I tested this locally with nebula-ui (which also has axios as a dependency and is still on 0.27.2) and everything worked as far as I could tell. 