### PR TITLE
Make requests to GET endpoints when only a single value is batched

### DIFF
--- a/src/services/BatchProcessor/BatchProcessor.ts
+++ b/src/services/BatchProcessor/BatchProcessor.ts
@@ -2,7 +2,7 @@ import { BatchLookupError } from '@/models/BatchLookupError'
 import { MaybePromise } from '@/types'
 
 export type BatchCallbackLookup<V, R> = (value: V) => MaybePromise<R>
-export type BatchCallback<V, R> = (values: V[]) => MaybePromise<Map<V, R>> | BatchCallbackLookup<V, R>
+export type BatchCallback<V, R> = (values: V[]) => MaybePromise<Map<V, R> | BatchCallbackLookup<V, R>>
 export type BatchOptions = {
   maxBatchSize?: number,
   maxWaitMilliseconds?: number,

--- a/src/services/WorkspaceArtifactsApi.ts
+++ b/src/services/WorkspaceArtifactsApi.ts
@@ -22,12 +22,28 @@ export class WorkspaceArtifactsApi extends WorkspaceApi implements IWorkspaceArt
   protected override routePrefix = '/artifacts'
 
   private readonly batcher = new BatchProcessor<string, Artifact>(async ids => {
+    if (ids.length === 1) {
+      const [id] = ids
+      const { data } = await this.get<ArtifactResponse>(`/${id}`)
+
+      return () => mapper.map('ArtifactResponse', data, 'Artifact')
+    }
+
     const artifacts = await this.getArtifacts({ artifacts: { id: ids } })
+
     return toMap(artifacts, 'id')
   }, { maxBatchSize: 200 })
 
   private readonly keyBatcher = new BatchProcessor<string, ArtifactCollection>(async keys => {
+    if (keys.length === 1) {
+      const [key] = keys
+      const { data } = await this.get<ArtifactCollectionResponse>(`/${key}/latest`)
+
+      return () => mapper.map('ArtifactCollectionResponse', data, 'ArtifactCollection')
+    }
+
     const collections = await this.getArtifactCollections({ artifacts: { key: keys } })
+
     return toMap(collections, 'key')
   }, { maxBatchSize: 200 })
 

--- a/src/services/WorkspaceBlockDocumentsApi.ts
+++ b/src/services/WorkspaceBlockDocumentsApi.ts
@@ -22,6 +22,13 @@ export class WorkspaceBlockDocumentsApi extends WorkspaceApi implements IWorkspa
   protected override routePrefix = '/block_documents'
 
   private readonly batcher = new BatchProcessor<string, BlockDocument>(async ids => {
+    if (ids.length === 1) {
+      const [id] = ids
+      const { data } = await this.get<BlockDocumentResponse>(`/${id}`)
+
+      return () => mapper.map('BlockDocumentResponse', data, 'BlockDocument')
+    }
+
     const blockDocuments = await this.getBlockDocuments({
       blockDocuments: {
         id: ids,

--- a/src/services/WorkspaceDeploymentsApi.ts
+++ b/src/services/WorkspaceDeploymentsApi.ts
@@ -26,6 +26,13 @@ export class WorkspaceDeploymentsApi extends WorkspaceApi implements IWorkspaceD
   protected override routePrefix = '/deployments'
 
   private readonly batcher = new BatchProcessor<string, Deployment>(async ids => {
+    if (ids.length === 1) {
+      const [id] = ids
+      const { data } = await this.get<DeploymentResponse>(`/${id}`)
+
+      return () => mapper.map('DeploymentResponse', data, 'Deployment')
+    }
+
     const deployments = await this.getDeployments({
       deployments: {
         id: ids,

--- a/src/services/WorkspaceFlowRunsApi.ts
+++ b/src/services/WorkspaceFlowRunsApi.ts
@@ -29,6 +29,13 @@ export class WorkspaceFlowRunsApi extends WorkspaceApi implements IWorkspaceFlow
   protected override routePrefix = '/flow_runs'
 
   private readonly batcher = new BatchProcessor<string, FlowRun>(async ids => {
+    if (ids.length === 1) {
+      const [id] = ids
+      const { data } = await this.get<FlowRunResponse>(`/${id}`)
+
+      return () => mapper.map('FlowRunResponse', data, 'FlowRun')
+    }
+
     const flowRuns = await this.getFlowRuns({
       flowRuns: {
         id: ids,

--- a/src/services/WorkspaceFlowsApi.ts
+++ b/src/services/WorkspaceFlowsApi.ts
@@ -17,6 +17,13 @@ export class WorkspaceFlowsApi extends WorkspaceApi implements IWorkspaceFlowsAp
   protected override routePrefix = '/flows'
 
   private readonly batcher = new BatchProcessor<string, Flow>(async ids => {
+    if (ids.length === 1) {
+      const [id] = ids
+      const { data } = await this.get<FlowResponse>(`${id}`)
+
+      return () => mapper.map('FlowResponse', data, 'Flow')
+    }
+
     const flows = await this.getFlows({
       flows: {
         id: ids,

--- a/src/services/WorkspaceTaskRunsApi.ts
+++ b/src/services/WorkspaceTaskRunsApi.ts
@@ -22,6 +22,13 @@ export class WorkspaceTaskRunsApi extends WorkspaceApi implements IWorkspaceTask
   protected override routePrefix = '/task_runs'
 
   private readonly batcher = new BatchProcessor<string, TaskRun>(async ids => {
+    if (ids.length === 1) {
+      const [id] = ids
+      const { data } = await this.get<TaskRunResponse>(`/${id}`)
+
+      return () => mapper.map('TaskRunResponse', data, 'TaskRun')
+    }
+
     const taskRuns = await this.getTaskRuns({
       taskRuns: {
         id: ids,

--- a/src/services/WorkspaceWorkQueuesApi.ts
+++ b/src/services/WorkspaceWorkQueuesApi.ts
@@ -24,6 +24,13 @@ export class WorkspaceWorkQueuesApi extends WorkspaceApi implements IWorkspaceWo
   protected override routePrefix = '/work_queues'
 
   private readonly isBatcher = new BatchProcessor<string, WorkQueue>(async ids => {
+    if (ids.length === 1) {
+      const [id] = ids
+      const { data } = await this.get<WorkQueueResponse>(`/${id}`)
+
+      return () => mapper.map('WorkQueueResponse', data, 'WorkQueue')
+    }
+
     const workQueues = await this.getWorkQueues({
       workQueues: {
         id: ids,
@@ -34,6 +41,13 @@ export class WorkspaceWorkQueuesApi extends WorkspaceApi implements IWorkspaceWo
   }, { maxBatchSize: 200 })
 
   private readonly nameBatcher = new BatchProcessor<string, WorkQueue>(async names => {
+    if (names.length === 1) {
+      const [name] = names
+      const { data } = await this.get<WorkQueueResponse>(`/name/${name}`)
+
+      return () => mapper.map('WorkQueueResponse', data, 'WorkQueue')
+    }
+
     const workQueues = await this.getWorkQueues({
       workQueues: {
         name: names,


### PR DESCRIPTION
# Description
We use request batchers to reduce the number of requests being made. So if a single page requests 5 different flow runs only one `flow_runs/filter` request is made. 

Previously we would also hit the `flow_runs/filter` endpoint even if only a single flow run was batched. This applies to everywhere we use batchers. Updating the logic in each batcher to check for single id requests and hit the more efficient GET endpoints. 