### PR TITLE
Add flow run list filters to the url when showing runs in tabs of other pages

### DIFF
--- a/src/components/DeploymentsTable.vue
+++ b/src/components/DeploymentsTable.vue
@@ -97,6 +97,7 @@
 
   const props = defineProps<{
     filter?: DeploymentsFilter,
+    prefix?: string,
   }>()
 
   const emit = defineEmits<{
@@ -118,7 +119,7 @@
       nameLike: deploymentNameDebounced,
     },
     limit: 50,
-  }))
+  }), props.prefix)
 
   const { deployments, subscriptions, total, pages } = useDeployments(filter, {
     page,

--- a/src/compositions/useNextFlowRun.ts
+++ b/src/compositions/useNextFlowRun.ts
@@ -1,3 +1,4 @@
+import { SubscriptionOptions } from '@prefecthq/vue-compositions'
 import merge from 'lodash.merge'
 import { computed, ComputedRef, MaybeRefOrGetter, toValue } from 'vue'
 import { useCan } from '@/compositions/useCan'
@@ -8,7 +9,7 @@ export type UseNextFlowRun = Pick<UseFlowRuns, 'subscriptions'> & {
   flowRun: ComputedRef<FlowRun | undefined>,
 }
 
-export function useNextFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | undefined>): UseNextFlowRun {
+export function useNextFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | undefined>, options?: SubscriptionOptions): UseNextFlowRun {
   const can = useCan()
 
   const getter = (): FlowRunsFilter | null => {
@@ -29,7 +30,7 @@ export function useNextFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | und
     return merge({}, filterValue, nextFlowRunFilter)
   }
 
-  const { flowRuns, subscriptions } = useFlowRuns(getter)
+  const { flowRuns, subscriptions } = useFlowRuns(getter, options)
   const flowRun = computed(() => flowRuns.value.at(0))
 
   return {


### PR DESCRIPTION
# Description
Closes https://github.com/PrefectHQ/prefect-ui-library/issues/1758

Simplifies and cleans up the FlowRunFilteredList component to allow for
- Simpler filter management (no more separate prop for "states", everything is based on the filter itself)
- Filters are always stored in the url (while supporting a prefix so filters don't cross over to different tabs)
- Consistent selection devx (previously this component had switched the prop from `selectable` to `disableSelection`. 

## Note
This is a breaking change and needs implementation in OSS and cloud
- [Cloud PR](https://github.com/PrefectHQ/nebula-ui/pull/3757)
- [OSS PR](https://github.com/PrefectHQ/prefect/pull/11203)
