### PR TITLE
Fix schema object properties with empty strings

### DIFF
--- a/src/services/schemas/properties/SchemaPropertyObject.ts
+++ b/src/services/schemas/properties/SchemaPropertyObject.ts
@@ -2,7 +2,7 @@ import { JsonInput } from '@/components'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps, getSchemaPropertyRequestValue, getSchemaPropertyResponseValue } from '@/services/schemas/utilities'
 import { SchemaValue, isSchemaValues, SchemaValues } from '@/types/schemas'
-import { isEmptyObject, isNullish, mapValues, parseUnknownJson, stringifyUnknownJson } from '@/utilities'
+import { isEmptyObject, isEmptyString, isNullish, mapValues, parseUnknownJson, stringifyUnknownJson } from '@/utilities'
 
 export class SchemaPropertyObject extends SchemaPropertyService {
 
@@ -24,6 +24,10 @@ export class SchemaPropertyObject extends SchemaPropertyService {
 
   protected request(value: SchemaValue): unknown {
     if (this.componentIs(JsonInput)) {
+      if (isEmptyString(value)) {
+        return undefined
+      }
+
       return parseUnknownJson(value)
     }
 


### PR DESCRIPTION
# Description
When a json input is used for editing a property of type `object` a JsonInput is used which produces an empty string if a value is cleared by the user. Which isn't a valid value to send to the api and produces validation errors. Removing empty strings in the request mapper fixes this and is also how we're handling this same problem for [arrays](https://github.com/PrefectHQ/prefect-ui-library/blob/main/src/services/schemas/properties/SchemaPropertyArray.ts#L34). 

Closes https://github.com/PrefectHQ/prefect/issues/11221