### PR TITLE
Fix:  Use scheduled state name in nextRun composition

### DIFF
--- a/src/components/DeploymentQuickRunOverflowMenuItem.vue
+++ b/src/components/DeploymentQuickRunOverflowMenuItem.vue
@@ -11,7 +11,7 @@
   import { h } from 'vue'
   import { useRouter } from 'vue-router'
   import ToastFlowRunCreate from '@/components/ToastFlowRunCreate.vue'
-  import { useWorkspaceApi, useWorkspaceRoutes, useNextFlowRun, useFlowRunsFilter } from '@/compositions'
+  import { useWorkspaceApi, useWorkspaceRoutes, useNextFlowRun } from '@/compositions'
   import { localization } from '@/localization'
   import { Deployment } from '@/models'
   import { getApiErrorMessage } from '@/utilities/errors'

--- a/src/components/DeploymentQuickRunOverflowMenuItem.vue
+++ b/src/components/DeploymentQuickRunOverflowMenuItem.vue
@@ -25,13 +25,18 @@
   const router = useRouter()
   const routes = useWorkspaceRoutes()
 
-  const { filter: nextRunFilter } = useFlowRunsFilter({
+  // const { filter: nextRunFilter } = useFlowRunsFilter({
+  //   deployments: {
+  //     id: [props.deployment.id],
+  //   },
+  // })
+
+
+  const { subscriptions: nextRunSubscription } = useNextFlowRun(() => ({
     deployments: {
       id: [props.deployment.id],
     },
-  })
-
-  const { subscriptions: nextRunSubscription } = useNextFlowRun(nextRunFilter)
+  }))
 
   const run = async (): Promise<void> => {
     if (props.deployment.parameterOpenApiSchema.required && props.deployment.parameterOpenApiSchema.required.length > 0) {

--- a/src/components/DeploymentQuickRunOverflowMenuItem.vue
+++ b/src/components/DeploymentQuickRunOverflowMenuItem.vue
@@ -24,13 +24,12 @@
   const api = useWorkspaceApi()
   const router = useRouter()
   const routes = useWorkspaceRoutes()
-  const { filter: nextRunFilter } = useFlowRunsFilter({
+
+  const { subscriptions: nextRunSubscription } = useNextFlowRun(() => ({
     deployments: {
       id: [props.deployment.id],
     },
-  })
-
-  const { subscriptions: nextRunSubscription } = useNextFlowRun(nextRunFilter)
+  }))
 
   const run = async (): Promise<void> => {
     if (props.deployment.parameterOpenApiSchema.required && props.deployment.parameterOpenApiSchema.required.length > 0) {

--- a/src/components/DeploymentQuickRunOverflowMenuItem.vue
+++ b/src/components/DeploymentQuickRunOverflowMenuItem.vue
@@ -24,19 +24,13 @@
   const api = useWorkspaceApi()
   const router = useRouter()
   const routes = useWorkspaceRoutes()
-
-  // const { filter: nextRunFilter } = useFlowRunsFilter({
-  //   deployments: {
-  //     id: [props.deployment.id],
-  //   },
-  // })
-
-
-  const { subscriptions: nextRunSubscription } = useNextFlowRun(() => ({
+  const { filter: nextRunFilter } = useFlowRunsFilter({
     deployments: {
       id: [props.deployment.id],
     },
-  }))
+  })
+
+  const { subscriptions: nextRunSubscription } = useNextFlowRun(nextRunFilter)
 
   const run = async (): Promise<void> => {
     if (props.deployment.parameterOpenApiSchema.required && props.deployment.parameterOpenApiSchema.required.length > 0) {

--- a/src/compositions/useNextFlowRun.ts
+++ b/src/compositions/useNextFlowRun.ts
@@ -21,7 +21,9 @@ export function useNextFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | und
     const filterValue = toValue(filter)
     const nextFlowRunFilter: FlowRunsFilter = {
       flowRuns: {
-        expectedStartTimeAfter: now,
+        state: {
+          name: ['Scheduled'],
+        },
       },
       sort: 'EXPECTED_START_TIME_ASC',
       limit: 1,

--- a/src/compositions/useNextFlowRun.ts
+++ b/src/compositions/useNextFlowRun.ts
@@ -17,7 +17,6 @@ export function useNextFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | und
       return null
     }
 
-    const now = new Date()
     const filterValue = toValue(filter)
     const nextFlowRunFilter: FlowRunsFilter = {
       flowRuns: {


### PR DESCRIPTION
The nextRun composition is being used on the deployment page to get the next upcoming run.  However, it isn't actually picking up the next run/updating when the subscription is refreshed after a run is kicked off.  This PR updates the subscription to use the "scheduled" state name instead of filtering by time. 

The composition is also used in the flowListItem which I believe is currently in OSS but not in Cloud.  I can't see a strong reason for that to use time instead of state name - the idea of next run should be consistent across components.  Happy to discuss if I'm missing something there though.  

Current:

https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/c1c651eb-8984-4d92-9be7-1f9368b9eddf

With fix:

https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/bb42ced1-ab37-445d-a1bd-a1c50a277383

