### PR TITLE
Enhancement: Make logs view more mobile friendly

### DIFF
--- a/src/components/LogRow.vue
+++ b/src/components/LogRow.vue
@@ -45,6 +45,15 @@
   grid-template-columns: 84px minmax(0, 1fr) 150px;
 }
 
+@media (max-width: 768px) {
+  .log-row { @apply
+  grid
+  py-2;
+  grid-template-columns: none;
+  grid-template-rows: 20px minmax(0, 1fr) 50px;
+}
+}
+
 .log-row__leading { @apply
   select-none;
 }


### PR DESCRIPTION
Currently our logs view gets pretty squished on a small screen.  This PR adds a media query with more friendly handling for smaller screens. 

Current:
<img width="324" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/841c72d1-512e-480e-bfd5-04b36c086ceb">

With update:
<img width="334" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/db5adf09-9399-4601-8c04-136f182986b4">
