### PR TITLE
Enhancement: Sorts tags alphabetically within tag inputs

### DIFF
--- a/src/components/DeploymentTagsInput.vue
+++ b/src/components/DeploymentTagsInput.vue
@@ -34,7 +34,7 @@
   const options = computed(() => {
     const tags = deployments.value.flatMap(deployment => deployment.tags ?? [])
 
-    return unique(tags)
+    return unique(tags).sort((tagA, tagB) => tagA.localeCompare(tagB))
   })
 </script>
 

--- a/src/components/FlowRunTagsInput.vue
+++ b/src/components/FlowRunTagsInput.vue
@@ -34,7 +34,7 @@
   const options = computed(() => {
     const tags = flowRuns.value.flatMap(run => run.tags ?? [])
 
-    return unique(tags)
+    return unique(tags).sort((tagA, tagB) => tagA.localeCompare(tagB))
   })
 </script>
 

--- a/src/components/VariableTagsInput.vue
+++ b/src/components/VariableTagsInput.vue
@@ -2,7 +2,7 @@
   <p-tags-input
     v-model="internalValue"
     :placeholder="localization.info.addTagPlaceholder"
-    :options="tags"
+    :options="options"
     :empty-message="localization.info.all"
   />
 </template>
@@ -35,5 +35,10 @@
   })
 
   const { variables } = useVariables(filter)
-  const tags = computed(() => unique(variables.value?.flatMap(variable => variable.tags) ?? []))
+
+  const options = computed(() => {
+    const tags = variables.value?.flatMap(variable => variable.tags) ?? []
+
+    return unique(tags).sort((tagA, tagB) => tagA.localeCompare(tagB))
+  })
 </script>


### PR DESCRIPTION
# Description
Sorts tags alphabetically in tag input components. The sorting only applies to the dropdown and does not effect the order in which tags are displayed in the input itself which remains selection order. 

Closes https://github.com/PrefectHQ/prefect/issues/11226