### PR TITLE
Enhancement: httpStatus returns false instead of erroring so it can be used in catch blocks

### DIFF
--- a/src/utilities/httpStatus.ts
+++ b/src/utilities/httpStatus.ts
@@ -32,7 +32,7 @@ function getStatusCode(value: unknown): number {
     return getStatusCode(value.response)
   }
 
-  throw 'Invalid argument provided to httpStatus'
+  return 0
 }
 
 export function httpStatus(value: unknown): HttpStatusResponse {


### PR DESCRIPTION
Closes #1867 

Currently, if using `httpStatus` in a catch block, like this:

```typescript
catch (error: unknown) {
  if (axios.isAxiosError(error) && httpStatus(error).is('PaymentRequired')) {
    showToast('The payment method associated with your account is invalid. Please update your payment method.', 'error')
  } else {
    showToast('Something went wrong while trying to update your account plan. Please try again.', 'error')
  }
  console.error(error)
}
```

We also need to guard against receiving other errors using something like `axios.isAxiosError`, otherwise `httpStatus` will error in the catch block and the block won't function properly.

With this update, if `httpStatus` is passed a different error, we'll instead gracefully return functions that will resolve to `false`, allowing us to use this function in `catch` blocks without additional guards.