### PR TITLE
BugFix: Flow runs card overflowing container and breaking layout

### DIFF
--- a/src/components/FlowRunHistoryCard.vue
+++ b/src/components/FlowRunHistoryCard.vue
@@ -43,7 +43,7 @@
 }
 
 .flow-run-history-card__chart { @apply
-  min-h-[20px]
+  h-24
   flex-grow
 }
 </style>

--- a/src/components/FlowRunsBarChart.vue
+++ b/src/components/FlowRunsBarChart.vue
@@ -128,6 +128,7 @@
     const totalTime = expectedStartTimeBefore.getTime() - expectedStartTimeAfter.getTime()
     const bucketSize = totalTime / bars.value
     const buckets: (FlowRun | null)[] = new Array(bars.value).fill(null)
+    const maxBucketIndex = buckets.length - 1
 
     function getEmptyBucket(index: number): number | null {
       if (index < 0) {
@@ -148,7 +149,7 @@
         return
       }
 
-      const bucketIndex = Math.floor((startTime.getTime() - expectedStartTimeAfter.getTime()) / bucketSize)
+      const bucketIndex = Math.min(Math.floor((startTime.getTime() - expectedStartTimeAfter.getTime()) / bucketSize), maxBucketIndex)
       const emptyBucketIndex = getEmptyBucket(bucketIndex)
 
       if (emptyBucketIndex === null) {


### PR DESCRIPTION
# Description
Fixes an issue on the flows page with the flow runs card where the flow runs could overflow the card and also have extremely large heights. Two part fix

1. Add a fixed height to the chart. This mirrors the dashboard implementation and fixes the bars having weird heights.
2. Add a check in the chart itself to prevent runs from being positioned outside of the max number of bars that should be displayed. 

Before
<img width="850" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/cf3a9ddc-c418-4c18-b0bb-11f1062ca5cb">

With fixed height
<img width="453" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/04ac1e82-3615-456f-b82d-aa09abf0649c">

With fixed index
<img width="401" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/0695b277-d1a9-46a7-86d0-12f6be1d5328">
