### PR TITLE
Fix: Add missing show-all prop to deployments list

### DIFF
--- a/src/components/DeploymentsList.vue
+++ b/src/components/DeploymentsList.vue
@@ -70,7 +70,7 @@
       <template #action="{ row }">
         <div class="deployment-list__action">
           <DeploymentToggle :deployment="row" @update="refresh" />
-          <DeploymentMenu size="xs" :deployment="row" flat @delete="refresh" />
+          <DeploymentMenu size="xs" show-all :deployment="row" flat @delete="refresh" />
         </div>
       </template>
 


### PR DESCRIPTION
Sneaky missing prop for the deployment menu that means the quick run option was hidden on the new table. 