### PR TITLE
Fix: harden some header styles

### DIFF
--- a/src/components/FlowRunsFilterGroup.vue
+++ b/src/components/FlowRunsFilterGroup.vue
@@ -71,8 +71,10 @@
 .flow-runs-filter-group__row { @apply
   flex
   flex-wrap
-  md:flex-nowrap
   gap-2
+  md:grid
+  md:grid-flow-col
+  md:auto-cols-fr
 }
 
 .flow-runs-filter-group__search { @apply

--- a/src/components/PageHeading.vue
+++ b/src/components/PageHeading.vue
@@ -38,10 +38,8 @@
 <style>
 .page-heading { @apply
   flex
-  flex-col
-  md:flex-row
-  md:items-center
   gap-2
+  items-center
 }
 
 .page-heading__leading { @apply

--- a/src/components/PageHeading.vue
+++ b/src/components/PageHeading.vue
@@ -38,8 +38,10 @@
 <style>
 .page-heading { @apply
   flex
+  flex-col
+  md:flex-row
+  md:items-center
   gap-2
-  items-center
 }
 
 .page-heading__leading { @apply
@@ -57,15 +59,13 @@
 }
 
 .page-heading__trailing { @apply
-  flex-grow
   flex
+  flex-grow
   items-center
-  self-start
-  gap-2
   justify-end
-  w-fit
-  md:w-fit
-  md:justify-end
+  gap-2
+  min-w-0
+  max-w-full
 }
 
 .page-heading__crumbs--xs { @apply

--- a/src/components/ResultsCount.vue
+++ b/src/components/ResultsCount.vue
@@ -19,5 +19,6 @@
 .results-count { @apply
   text-subdued
   text-base
+  whitespace-nowrap
 }
 </style>


### PR DESCRIPTION
- Updates the flow run page filters to use better grid styling so the updated tags input can't blow out the layout when growing in size.
- Updates PageHeading so it won't blow out when containing wide content.
- Makes it so ResultsCount doesn't wrap. This makes it so the actions column is instead forced to shrink in PListHeader