### PR TITLE
wrap long deployment names

### DIFF
--- a/src/components/DeploymentsList.vue
+++ b/src/components/DeploymentsList.vue
@@ -27,9 +27,9 @@
       <template #deployment-name="{ row }">
         <div class="deployment-list__name-col">
           <span>
-            <DeploymentStatusIcon v-if="can.access.deploymentStatus" :status="row.status" />
             <p-link :to="routes.deployment(row.id)" class="deployment-list__name">
-              <span>{{ row.name }}</span>
+              {{ row.name }}
+              <DeploymentStatusIcon v-if="can.access.deploymentStatus" :status="row.status" />
             </p-link>
           </span>
           <span class="deployment-list__created-date">Created {{ formatDateTimeNumeric(row.created) }}</span>
@@ -37,7 +37,7 @@
       </template>
 
       <template #flow-name="{ row }">
-        <FlowRouterLink :flow-id="row.flowId" />
+        <FlowRouterLink :flow-id="row.flowId" class="deployments-list__flow-name" />
       </template>
 
       <template #schedule="{ row }">
@@ -233,12 +233,17 @@
 
 .deployment-list__name { @apply
   font-medium
-  ml-2
+  mr-2
+  whitespace-normal
 }
 
 .deployment-list__created-date { @apply
   text-subdued
   text-xs
+}
+
+.deployments-list__flow-name { @apply
+  whitespace-normal
 }
 
 .deployment-list__menu { @apply


### PR DESCRIPTION
Wraps long names so the table doesn't blow out or cause scrolling in cells:

With regular/short names
<img width="1512" alt="Screenshot 2023-12-15 at 8 42 52 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/6633ab73-1150-4933-bcd6-43194e6cd079">

With long names
<img width="1512" alt="Screenshot 2023-12-15 at 8 44 22 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/87f5a0d0-a3c9-4c6a-a727-dbbe3f64d7f1">

Responsive behavior
https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/3edc603d-c604-49ad-8fac-776e3cb34f9e


CC @zhen0 PR'ing to your [PR](https://github.com/PrefectHQ/prefect-ui-library/pull/1944/files)