### PR TITLE
Chore: Remove default value overrides

### DIFF
--- a/src/services/schemas/properties/SchemaPropertyAny.ts
+++ b/src/services/schemas/properties/SchemaPropertyAny.ts
@@ -3,7 +3,7 @@ import { getSchemaValueDefinition, schemaPropertyServiceFactory } from '@/servic
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { getSchemaPropertyDefaultValue, SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue } from '@/types/schemas'
-import { isEmptyObject, sameValue } from '@/utilities'
+import { isEmptyObject } from '@/utilities'
 import { jsonSafeParse } from '@/utilities/jsonSafeParse'
 import { jsonSafeStringify } from '@/utilities/jsonSafeStringify'
 
@@ -72,10 +72,6 @@ export class SchemaPropertyAny extends SchemaPropertyService {
   }
 
   private referenceRequest(value: SchemaValue): SchemaValue {
-    if (this.isDefaultValueForReference(value)) {
-      return undefined
-    }
-
     const definition = getSchemaValueDefinition(this.property, value)
 
     if (definition === null) {
@@ -103,11 +99,4 @@ export class SchemaPropertyAny extends SchemaPropertyService {
 
     throw new Error('Could not find first definition for schema property')
   }
-
-  private isDefaultValueForReference(value: SchemaValue): boolean {
-    const definitions = this.property.anyOf ?? this.property.allOf ?? []
-
-    return definitions.some(definition => sameValue(value, getSchemaPropertyDefaultValue(definition)))
-  }
-
 }

--- a/src/services/schemas/properties/SchemaPropertyService.ts
+++ b/src/services/schemas/properties/SchemaPropertyService.ts
@@ -4,7 +4,6 @@ import { InvalidSchemaValueError } from '@/models/InvalidSchemaValueError'
 import { getSchemaPropertyAttrs, getSchemaPropertyComponentWithDefaultProps, getSchemaPropertyDefaultValidators, schemaPropertyComponentWithProps, SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { schemaHas, SchemaProperty, SchemaPropertyInputAttrs, SchemaPropertyMeta, SchemaValue } from '@/types/schemas'
 import { Require } from '@/types/utilities'
-import { sameValue } from '@/utilities'
 import { isNumberArray, isStringArray } from '@/utilities/arrays'
 import { ComponentDefinition } from '@/utilities/components'
 import { fieldRules, isJson, ValidationMethod, ValidationMethodFactory } from '@/utilities/validation'
@@ -82,10 +81,6 @@ export abstract class SchemaPropertyService {
   }
 
   public mapRequestValue(value: SchemaValue): SchemaValue | undefined {
-    if (this.isDefaultValue(value)) {
-      return undefined
-    }
-
     return this.request(value)
   }
 
@@ -171,9 +166,4 @@ export abstract class SchemaPropertyService {
 
     return options
   }
-
-  protected isDefaultValue(value: SchemaValue): boolean {
-    return sameValue(value, this.default)
-  }
-
 }


### PR DESCRIPTION
Removes request/response mapping logic that remove values that match schema defaults.
I'm not sure what relies on this behavior yet - opening this so we can test.


Potentially resolves: https://github.com/PrefectHQ/prefect/issues/11462
Potentially resolves: https://github.com/PrefectHQ/prefect/issues/10781