### PR TITLE
Enhancement: add 'All except scheduled' option to tags select

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "javascript.format.enable": false,
     "eslint.alwaysShowStatus": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "eslint.options": {
         "extensions": [

--- a/src/components/FlowRunFilteredList.vue
+++ b/src/components/FlowRunFilteredList.vue
@@ -6,8 +6,8 @@
       <FlowRunsDeleteButton v-if="can.delete.flow_run" :selected="selected" @delete="deleteFlowRuns" />
 
       <template #controls>
-        <SearchInput v-model="searchTerm" placeholder="Search by run name" label="Search by run name" />
-        <StateNameSelect v-model:selected="filter.flowRuns.state.name" multiple empty-message="All run states" />
+        <SearchInput v-model="searchTerm" placeholder="Search by run name" label="Search by run name" class="flow-run-filtered-list__search" />
+        <StateNameSelect v-model:selected="filter.flowRuns.state.name" multiple empty-message="All run states" exclude-scheduled />
       </template>
 
       <template #sort>
@@ -78,3 +78,9 @@
     subscriptions.refresh()
   }
 </script>
+
+<style>
+.flow-run-filtered-list__search { @apply
+  min-w-[224px]
+}
+</style>

--- a/src/components/FlowRunFilteredList.vue
+++ b/src/components/FlowRunFilteredList.vue
@@ -7,7 +7,7 @@
 
       <template #controls>
         <SearchInput v-model="searchTerm" placeholder="Search by run name" label="Search by run name" class="flow-run-filtered-list__search" />
-        <StateNameSelect v-model:selected="filter.flowRuns.state.name" multiple empty-message="All run states" exclude-scheduled />
+        <StateNameSelect v-model:selected="filter.flowRuns.state.name" multiple empty-message="All run states" />
       </template>
 
       <template #sort>

--- a/src/components/FlowRunTaskRuns.vue
+++ b/src/components/FlowRunTaskRuns.vue
@@ -3,7 +3,7 @@
     <p-list-header sticky>
       <ResultsCount :count="count" label="Task run" />
       <template #controls>
-        <SearchInput v-model="searchTerm" placeholder="Search by run name" label="Search by run name" />
+        <SearchInput v-model="searchTerm" placeholder="Search by run name" label="Search by run name" class="flow-run-task-runs__search" />
         <StateNameSelect v-model:selected="states" empty-message="All states" />
       </template>
       <template #sort>
@@ -73,3 +73,9 @@
     searchTerm.value = ''
   }
 </script>
+
+<style>
+.flow-run-task-runs__search { @apply
+  min-w-[224px]
+}
+</style>

--- a/src/components/StateNameSelect.vue
+++ b/src/components/StateNameSelect.vue
@@ -1,22 +1,37 @@
 <template>
   <p-select v-model="internalValue" class="state-name-select" v-bind="{ options, multiple, emptyMessage }">
     <template #option="{ option }">
-      <StateBadge :state="getStateFromTagValue(option.value)" />
+      <template v-if="option.value === allExceptScheduled">
+        All except scheduled
+      </template>
+      <template v-else>
+        <StateBadge :state="getStateFromTagValue(option.value)" />
+      </template>
     </template>
     <template #tag="{ value, dismiss }">
-      <StateBadge
-        class="state-name-select__option state-name-select__option--multiple"
-        :state="getStateFromTagValue(value)"
-        dismissible
-        @dismiss="dismiss"
-      />
+      <template v-if="value === allExceptScheduled">
+        All except scheduled
+      </template>
+      <template v-else>
+        <StateBadge
+          class="state-name-select__option state-name-select__option--multiple"
+          :state="getStateFromTagValue(value)"
+          dismissible
+          @dismiss="dismiss"
+        />
+      </template>
     </template>
     <template #default="{ value }">
-      <StateBadge
-        class="state-name-select__option"
-        :state="getStateFromTagValue(value)"
-        flat
-      />
+      <template v-if="value === allExceptScheduled">
+        All except scheduled
+      </template>
+      <template v-else>
+        <StateBadge
+          class="state-name-select__option"
+          :state="getStateFromTagValue(value)"
+          flat
+        />
+      </template>
     </template>
   </p-select>
 </template>
@@ -28,6 +43,8 @@
   import { StateBadgeState } from '@/types/stateBadge'
   import { prefectStateNames } from '@/types/states'
   import { mapStateNameToStateType } from '@/utilities'
+
+  const allExceptScheduled = 'allExceptScheduled'
 
   const props = defineProps<{
     selected: string | string[] | null | undefined,
@@ -43,28 +60,51 @@
 
   const internalValue = computed({
     get() {
+      const isAllExceptScheduled = props.selected?.length === prefectStateNames.length - 1
+        && !props.selected.includes('Scheduled')
+
+      if (isAllExceptScheduled) {
+        return allExceptScheduled
+      }
+
       return props.selected ?? null
     },
     set(value: string | string[] | null) {
       if (!value) {
         emits('update:selected', null)
       } else if (multiple.value) {
-        emits('update:selected', isArray(value) ? value : [value])
+        const values = isArray(value) ? value : [value]
+
+        if (values.includes(allExceptScheduled)) {
+          emits('update:selected', prefectStateNames.filter((stateName) => stateName !== 'Scheduled'))
+        } else {
+          emits('update:selected', values)
+        }
       } else {
         emits('update:selected', value)
       }
     },
   })
 
-  const options = computed<SelectOption[]>(() => prefectStateNames.map((stateName) => {
-    const { name, type } = mapStateNameToStateType(stateName)
+  const options = computed<SelectOption[]>(() => {
+    const stateNames = prefectStateNames.map((stateName) => {
+      const { name, type } = mapStateNameToStateType(stateName)
 
-    return {
-      label: name,
-      value: name,
-      type,
-    }
-  }))
+      return {
+        label: name,
+        value: name,
+        type,
+      }
+    })
+
+    return [
+      {
+        label: 'All except scheduled',
+        value: allExceptScheduled,
+      },
+      ...stateNames,
+    ]
+  })
 
   const getStateFromTagValue = (value: unknown): StateBadgeState | null => {
     if (typeof value == 'string') {


### PR DESCRIPTION
Adds an option for selecting all but "scheduled". This allows the default filter set to look nicer on the deployments page and makes selecting all but scheduled much easier on other pages.

https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/632173b9-abd9-49c3-a321-cbf95954c24e

Note – On the deployment page, since "all except scheduled" is the default, it sort of forces it back on if you uncheck it. Open to feedback there, but I feel like most folks won't do that.