### PR TITLE
Enhancement: use count limit instead of time on flow and deployment histograms

### DIFF
--- a/src/components/DeploymentsList.vue
+++ b/src/components/DeploymentsList.vue
@@ -54,11 +54,10 @@
         {{ row.appliedBy }}
       </template>
 
-      <template #activity="{ row }">
+      <template #latest-runs="{ row }">
         <MiniDeploymentHistory
-          class="deployment-list__activity-chart"
+          class="deployment-list__latest-runs-chart"
           :deployment-id="row.id"
-          :time-span-in-seconds="secondsInDay"
         />
       </template>
 
@@ -101,7 +100,6 @@
 <script lang="ts" setup>
   import { CheckboxModel, TableColumn, media } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
-  import { secondsInDay } from 'date-fns/constants'
   import merge from 'lodash.merge'
   import { computed, ref } from 'vue'
   import {
@@ -176,7 +174,7 @@
       visible: media.md,
     },
     {
-      label: 'Activity',
+      label: 'Latest runs',
       visible: media.md,
     },
     {
@@ -217,7 +215,7 @@
 </script>
 
 <style>
-.deployment-list__activity-chart { @apply
+.deployment-list__latest-runs-chart { @apply
   h-12
   w-20
 }

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -45,11 +45,10 @@
         <DeploymentsCount :flow-id="row.id" />
       </template>
 
-      <template #activity="{ row }">
+      <template #latest-runs="{ row }">
         <MiniFlowHistory
-          class="flow-list__activity-chart"
+          class="flow-list__latest-runs-chart"
           :flow-id="row.id"
-          :time-span-in-seconds="secondsInDay"
         />
       </template>
 
@@ -84,7 +83,6 @@
 <script lang="ts" setup>
   import { CheckboxModel, TableColumn } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
-  import { secondsInDay } from 'date-fns/constants'
   import merge from 'lodash.merge'
   import { computed, ref } from 'vue'
   import {
@@ -150,7 +148,7 @@
       label: 'Deployments',
     },
     {
-      label: 'Activity',
+      label: 'Latest runs',
     },
     {
       label: 'Action',
@@ -190,7 +188,7 @@
 </script>
 
 <style>
-.flow-list__activity-chart { @apply
+.flow-list__latest-runs-chart { @apply
   h-12
   w-20
 }

--- a/src/components/FlowRunsBarChart.vue
+++ b/src/components/FlowRunsBarChart.vue
@@ -119,9 +119,9 @@
   }
 
   function organizeFlowRunsWithGaps(flowRuns: FlowRun[]): (FlowRun | null)[] {
-    const { expectedStartTimeAfter, expectedStartTimeBefore } = toValue(props.filter).flowRuns ?? {}
+    const { expectedStartTimeAfter, expectedStartTimeBefore } = toValue(props.filter).flowRuns ?? getTimeRangeFromFlows(flowRuns)
 
-    if (!expectedStartTimeBefore || !expectedStartTimeAfter) {
+    if (!expectedStartTimeAfter || !expectedStartTimeBefore) {
       return []
     }
 
@@ -160,6 +160,27 @@
     })
 
     return buckets
+  }
+
+  function getTimeRangeFromFlows(flowRuns: FlowRun[]): { expectedStartTimeAfter: Date, expectedStartTimeBefore: Date } {
+    return flowRuns.reduce((acc, flowRun) => {
+      if (!flowRun.startTime) {
+        return acc
+      }
+
+      if (flowRun.startTime.getTime() < acc.expectedStartTimeAfter.getTime()) {
+        acc.expectedStartTimeAfter = flowRun.startTime
+      }
+
+      if (flowRun.startTime.getTime() > acc.expectedStartTimeBefore.getTime()) {
+        acc.expectedStartTimeBefore = flowRun.startTime
+      }
+
+      return acc
+    }, {
+      expectedStartTimeAfter: new Date(),
+      expectedStartTimeBefore: new Date(),
+    })
   }
 </script>
 

--- a/src/components/FlowRunsBarChart.vue
+++ b/src/components/FlowRunsBarChart.vue
@@ -120,15 +120,18 @@
     return flowRun.id
   }
 
-  function organizeFlowRunsWithGaps(flowRuns: FlowRun[]): (FlowRun | null)[] {
-    const flowRunsFilter = toValue(props.filter).flowRuns
-    const { expectedStartTimeAfter, expectedStartTimeBefore } = flowRunsFilter?.expectedStartTimeAfter && flowRunsFilter.expectedStartTimeBefore
-      ? flowRunsFilter
-      : getTimeRangeFromFlows(flowRuns)
+  function getTimeRange(flowRuns: FlowRun[]): { expectedStartTimeAfter: Date, expectedStartTimeBefore: Date } {
+    const { expectedStartTimeAfter, expectedStartTimeBefore } = toValue(props.filter).flowRuns ?? {}
 
-    if (!expectedStartTimeAfter || !expectedStartTimeBefore) {
-      return []
+    if (expectedStartTimeAfter && expectedStartTimeBefore) {
+      return { expectedStartTimeAfter, expectedStartTimeBefore }
     }
+
+    return getTimeRangeFromFlows(flowRuns)
+  }
+
+  function organizeFlowRunsWithGaps(flowRuns: FlowRun[]): (FlowRun | null)[] {
+    const { expectedStartTimeAfter, expectedStartTimeBefore } = getTimeRange(flowRuns)
 
     const totalTime = expectedStartTimeBefore.getTime() - expectedStartTimeAfter.getTime()
     const bucketSize = totalTime / bars.value

--- a/src/components/FlowRunsBarChart.vue
+++ b/src/components/FlowRunsBarChart.vue
@@ -20,7 +20,7 @@
   import { ClassValue, toPixels, positions, usePopOverGroup } from '@prefecthq/prefect-design'
   import { useDebouncedRef, useElementRect } from '@prefecthq/vue-compositions'
   import { scaleSymlog } from 'd3'
-  import { subSeconds } from 'date-fns'
+  import { max, min, subSeconds } from 'date-fns'
   import { secondsInDay } from 'date-fns/constants'
   import merge from 'lodash.merge'
   import { StyleValue, computed, ref, toValue } from 'vue'
@@ -168,31 +168,14 @@
   }
 
   function getTimeRangeFromFlows(flowRuns: FlowRun[]): { expectedStartTimeAfter: Date, expectedStartTimeBefore: Date } {
-    const now = new Date()
-    const minimumSeconds = secondsInDay
+    const maxDate = new Date()
+    const minDate = subSeconds(maxDate, secondsInDay)
+    const startTimes: Date[] = flowRuns.filter((flowRun) => flowRun.startTime).map((flowRun) => flowRun.startTime!)
 
-    const timeRange = flowRuns.reduce((acc, flowRun) => {
-      if (!flowRun.startTime) {
-        return acc
-      }
-
-      const startTime = flowRun.startTime.getTime()
-
-      if (startTime < acc.expectedStartTimeAfter.getTime()) {
-        acc.expectedStartTimeAfter = flowRun.startTime
-      }
-
-      if (startTime > acc.expectedStartTimeBefore.getTime()) {
-        acc.expectedStartTimeBefore = flowRun.startTime
-      }
-
-      return acc
-    }, {
-      expectedStartTimeAfter: subSeconds(now, minimumSeconds),
-      expectedStartTimeBefore: now,
-    })
-
-    return timeRange
+    return {
+      expectedStartTimeAfter: min([minDate, ...startTimes]),
+      expectedStartTimeBefore: max([maxDate, ...startTimes]),
+    }
   }
 </script>
 

--- a/src/components/MiniDeploymentHistory.vue
+++ b/src/components/MiniDeploymentHistory.vue
@@ -13,7 +13,7 @@
 
   const props = defineProps<{
     deploymentId: string,
-    timeSpanInSeconds: number,
+    timeSpanInSeconds?: number,
   }>()
 
   const deploymentStats = computed(() => ({

--- a/src/components/MiniFlowHistory.vue
+++ b/src/components/MiniFlowHistory.vue
@@ -14,7 +14,7 @@
 
   const props = defineProps<{
     flowId: string,
-    timeSpanInSeconds: number,
+    timeSpanInSeconds?: number,
   }>()
 
   const flowStats = computed<FlowStatsFilter>(() => ({

--- a/src/components/MiniFlowHistory.vue
+++ b/src/components/MiniFlowHistory.vue
@@ -19,7 +19,7 @@
 
   const flowStats = computed<FlowStatsFilter>(() => ({
     flowId: props.flowId,
-    range: { type: 'span', seconds: props.timeSpanInSeconds },
+    range: props.timeSpanInSeconds ? { type: 'span', seconds: props.timeSpanInSeconds } : undefined,
   }))
 
   const flowRunsFilter = computed(() => mapper.map('FlowStatsFilter', flowStats.value, 'FlowRunsFilter'))

--- a/src/maps/deploymentStatsFilter.ts
+++ b/src/maps/deploymentStatsFilter.ts
@@ -4,32 +4,40 @@ import { MapFunction } from '@/services/Mapper'
 import { DeploymentStatsFilter } from '@/types/deployment'
 
 export const mapDeploymentStatsFilterToFlowRunsFilter: MapFunction<DeploymentStatsFilter, FlowRunsFilter> = function(source) {
-  const now = new Date()
-
   const filter: FlowRunsFilter = {
     deployments: {
       id: [source.deploymentId],
     },
-    flowRuns: {
-      expectedStartTimeAfter: subSeconds(now, source.timeSpanInSeconds),
-      expectedStartTimeBefore: now,
-    },
+  }
+
+  if (source.timeSpanInSeconds) {
+    const now = new Date()
+
+    filter.flowRuns = {
+      startTimeAfter: subSeconds(now, source.timeSpanInSeconds),
+      startTimeBefore: now,
+    }
   }
 
   return filter
 }
 
 export const mapDeploymentStatsFilterToTaskRunsFilter: MapFunction<DeploymentStatsFilter, TaskRunsFilter> = function(source) {
-  const now = new Date()
-
-  return {
+  const filter: TaskRunsFilter = {
     flows: {
       id: [source.deploymentId],
     },
-    taskRuns: {
+  }
+
+  if (source.timeSpanInSeconds) {
+    const now = new Date()
+
+    filter.taskRuns = {
       startTimeAfter: subSeconds(now, source.timeSpanInSeconds),
       startTimeBefore: now,
-    },
+    }
   }
+
+  return filter
 }
 

--- a/src/maps/deploymentStatsFilter.ts
+++ b/src/maps/deploymentStatsFilter.ts
@@ -1,4 +1,3 @@
-import { subSeconds } from 'date-fns'
 import { FlowRunsFilter } from '@/models'
 import { MapFunction } from '@/services/Mapper'
 import { DeploymentStatsFilter } from '@/types/deployment'
@@ -11,7 +10,6 @@ export const mapDeploymentStatsFilterToFlowRunsFilter: MapFunction<DeploymentSta
       id: [source.deploymentId],
     },
     flowRuns: {
-      startTimeAfter: source.timeSpanInSeconds ? subSeconds(now, source.timeSpanInSeconds) : undefined,
       startTimeBefore: now,
     },
   }

--- a/src/maps/deploymentStatsFilter.ts
+++ b/src/maps/deploymentStatsFilter.ts
@@ -4,23 +4,16 @@ import { MapFunction } from '@/services/Mapper'
 import { DeploymentStatsFilter } from '@/types/deployment'
 
 export const mapDeploymentStatsFilterToFlowRunsFilter: MapFunction<DeploymentStatsFilter, FlowRunsFilter> = function(source) {
+  const now = new Date()
+
   const filter: FlowRunsFilter = {
     deployments: {
       id: [source.deploymentId],
     },
-  }
-
-  if (source.timeSpanInSeconds) {
-    const now = new Date()
-
-    filter.flowRuns = {
-      startTimeAfter: subSeconds(now, source.timeSpanInSeconds),
+    flowRuns: {
+      startTimeAfter: source.timeSpanInSeconds ? subSeconds(now, source.timeSpanInSeconds) : undefined,
       startTimeBefore: now,
-    }
-  } else {
-    filter.flowRuns = {
-      startTimeNull: false,
-    }
+    },
   }
 
   return filter

--- a/src/maps/deploymentStatsFilter.ts
+++ b/src/maps/deploymentStatsFilter.ts
@@ -1,5 +1,5 @@
 import { subSeconds } from 'date-fns'
-import { FlowRunsFilter, TaskRunsFilter } from '@/models'
+import { FlowRunsFilter } from '@/models'
 import { MapFunction } from '@/services/Mapper'
 import { DeploymentStatsFilter } from '@/types/deployment'
 
@@ -17,27 +17,11 @@ export const mapDeploymentStatsFilterToFlowRunsFilter: MapFunction<DeploymentSta
       startTimeAfter: subSeconds(now, source.timeSpanInSeconds),
       startTimeBefore: now,
     }
-  }
-
-  return filter
-}
-
-export const mapDeploymentStatsFilterToTaskRunsFilter: MapFunction<DeploymentStatsFilter, TaskRunsFilter> = function(source) {
-  const filter: TaskRunsFilter = {
-    flows: {
-      id: [source.deploymentId],
-    },
-  }
-
-  if (source.timeSpanInSeconds) {
-    const now = new Date()
-
-    filter.taskRuns = {
-      startTimeAfter: subSeconds(now, source.timeSpanInSeconds),
-      startTimeBefore: now,
+  } else {
+    filter.flowRuns = {
+      startTimeNull: false,
     }
   }
 
   return filter
 }
-

--- a/src/maps/flowStatsFilter.ts
+++ b/src/maps/flowStatsFilter.ts
@@ -31,4 +31,6 @@ export const mapFlowStatsFilterToTaskRunsFilter: MapFunction<FlowStatsFilter, Ta
       startTimeBefore: endDate,
     },
   }
+
+  return filter
 }

--- a/src/maps/flowStatsFilter.ts
+++ b/src/maps/flowStatsFilter.ts
@@ -4,16 +4,15 @@ import { MapFunction } from '@/services/Mapper'
 import { FlowStatsFilter } from '@/types/flow'
 
 export const mapFlowStatsFilterToFlowRunsFilter: MapFunction<FlowStatsFilter, FlowRunsFilter> = function(source) {
+  const range = source.range ? this.map('DateRangeSelectValue', source.range, 'DateRange') : null
 
-
-  const { startDate, endDate } = this.map('DateRangeSelectValue', source.range, 'DateRange')
   const filter: FlowRunsFilter = {
     flows: {
       id: [source.flowId],
     },
     flowRuns: {
-      expectedStartTimeAfter: startDate,
-      expectedStartTimeBefore: endDate,
+      expectedStartTimeAfter: range?.startDate,
+      expectedStartTimeBefore: range?.endDate ?? new Date(),
     },
   }
 
@@ -21,14 +20,15 @@ export const mapFlowStatsFilterToFlowRunsFilter: MapFunction<FlowStatsFilter, Fl
 }
 
 export const mapFlowStatsFilterToTaskRunsFilter: MapFunction<FlowStatsFilter, TaskRunsFilter> = function(source) {
-  const { startDate, endDate } = this.map('DateRangeSelectValue', source.range, 'DateRange')
+  const range = source.range ? this.map('DateRangeSelectValue', source.range, 'DateRange') : null
+
   return {
     flows: {
       id: [source.flowId],
     },
     taskRuns: {
-      startTimeAfter: startDate,
-      startTimeBefore: endDate,
+      startTimeAfter: range?.startDate,
+      startTimeBefore: range?.endDate ?? new Date(),
     },
   }
 }

--- a/src/maps/flowStatsFilter.ts
+++ b/src/maps/flowStatsFilter.ts
@@ -31,6 +31,4 @@ export const mapFlowStatsFilterToTaskRunsFilter: MapFunction<FlowStatsFilter, Ta
       startTimeBefore: endDate,
     },
   }
-
-  return filter
 }

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -1,5 +1,5 @@
 export type DeploymentStatsFilter = {
-  timeSpanInSeconds: number,
+  timeSpanInSeconds?: number,
   deploymentId: string,
 }
 

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -1,5 +1,4 @@
 export type DeploymentStatsFilter = {
-  timeSpanInSeconds?: number,
   deploymentId: string,
 }
 

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -3,5 +3,4 @@ import { DateRangeSelectValue } from '@prefecthq/prefect-design'
 export type FlowStatsFilter = {
   range: NonNullable<DateRangeSelectValue>,
   flowId: string,
-
 }

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -1,6 +1,6 @@
 import { DateRangeSelectValue } from '@prefecthq/prefect-design'
 
 export type FlowStatsFilter = {
-  range: NonNullable<DateRangeSelectValue>,
+  range?: NonNullable<DateRangeSelectValue>,
   flowId: string,
 }


### PR DESCRIPTION
Recently we added the flow run history mini histogram chart for on the Flow and Deployment list pages. We opted to use a 24 hour period, but some users found this confusing. For flows that have a run cadence in the hours or days, they'd see no runs and wonder what went wrong, the 24 hour period was not communicated to them.

To fix this, since the notion of time on the x-axis of this history graph is fluid anyway, this PR ditches the fixed time range for these instances. Instead of runs in the past 24 hours, it'll simply show last `n` runs. Sometimes there aren't enough runs to fill the graph, so it'll still go through the process of inserting empty bars to communicate some rough notion of time. A minimum of 24 hours is used so that, if you run a flow twice in a row, you don't end up with something like a bar, 6 gaps, then the last bar.

Before:
<img width="1512" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/8a702137-1940-4fc2-9ef7-ad4249ee682a">

After:
<img width="1512" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/5ed9db8d-398f-44e0-89f9-3ce095fadfed">

