### PR TITLE
Fix: responsive flow and deployment tables

### DIFF
--- a/src/components/DeploymentsList.vue
+++ b/src/components/DeploymentsList.vue
@@ -15,7 +15,7 @@
       </template>
     </p-list-header>
 
-    <p-table :data="deployments" :columns="columns">
+    <p-table :data="deployments" :columns="columns" class="deployments-list__table">
       <template #selection-heading>
         <p-checkbox v-model="model" @update:model-value="selectAllDeployments" />
       </template>
@@ -220,8 +220,13 @@
   w-20
 }
 
+.deployments-list__table .p-table-data { @apply
+  whitespace-normal
+}
+
 .deployment-list__action { @apply
   text-right
+  whitespace-nowrap
 }
 
 .deployment-list__name-col { @apply
@@ -232,16 +237,11 @@
 .deployment-list__name { @apply
   font-medium
   mr-2
-  whitespace-normal
 }
 
 .deployment-list__created-date { @apply
   text-subdued
   text-xs
-}
-
-.deployments-list__flow-name { @apply
-  whitespace-normal
 }
 
 .deployment-list__menu { @apply

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -15,7 +15,7 @@
       </template>
     </p-list-header>
 
-    <p-table :data="flows" :columns="columns">
+    <p-table :data="flows" :columns="columns" class="flow-list__table">
       <template #selection-heading>
         <p-checkbox v-model="model" @update:model-value="selectAllFlows" />
       </template>
@@ -42,7 +42,7 @@
       </template>
 
       <template #deployments="{ row }">
-        <DeploymentsCount :flow-id="row.id" />
+        <DeploymentsCount :flow-id="row.id" class="flow-list__deployment-count" />
       </template>
 
       <template #latest-runs="{ row }">
@@ -136,7 +136,6 @@
     {
       property: 'name',
       label: 'Name',
-      width: '125px',
     },
     {
       label: 'Last run',
@@ -188,6 +187,10 @@
 </script>
 
 <style>
+.flow-list__table .p-table-data { @apply
+  whitespace-normal
+}
+
 .flow-list__latest-runs-chart { @apply
   h-12
   w-20
@@ -200,7 +203,6 @@
 .flow-list__name-col { @apply
   flex
   flex-col
-  w-80
 }
 
 .flow-list__name { @apply
@@ -210,5 +212,9 @@
 .flow-list__created-date { @apply
   text-subdued
   text-xs
+}
+
+.flow-list__deployment-count { @apply
+  whitespace-nowrap
 }
 </style>


### PR DESCRIPTION
Since introducing more content on these tables, some width assignments and the default no-wrap style for table cells was causing these tables to scroll even at fairly generous widths (13" MBP).

Before:
https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/db13cc46-d894-4b12-b9f0-53fc7961b128

After:
https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/40390bd2-7154-49da-a620-ea8cb9a5c057

