### PR TITLE
Revert "Merge pull request #1965 from PrefectHQ/enhancement/use-limit-on-mini-histogram"

### DIFF
--- a/src/components/DeploymentsList.vue
+++ b/src/components/DeploymentsList.vue
@@ -54,10 +54,11 @@
         {{ row.appliedBy }}
       </template>
 
-      <template #latest-runs="{ row }">
+      <template #activity="{ row }">
         <MiniDeploymentHistory
-          class="deployment-list__latest-runs-chart"
+          class="deployment-list__activity-chart"
           :deployment-id="row.id"
+          :time-span-in-seconds="secondsInDay"
         />
       </template>
 
@@ -100,6 +101,7 @@
 <script lang="ts" setup>
   import { CheckboxModel, TableColumn, media } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
+  import { secondsInDay } from 'date-fns/constants'
   import merge from 'lodash.merge'
   import { computed, ref } from 'vue'
   import {
@@ -174,7 +176,7 @@
       visible: media.md,
     },
     {
-      label: 'Latest runs',
+      label: 'Activity',
       visible: media.md,
     },
     {
@@ -215,7 +217,7 @@
 </script>
 
 <style>
-.deployment-list__latest-runs-chart { @apply
+.deployment-list__activity-chart { @apply
   h-12
   w-20
 }

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -45,10 +45,11 @@
         <DeploymentsCount :flow-id="row.id" class="flow-list__deployment-count" />
       </template>
 
-      <template #latest-runs="{ row }">
+      <template #activity="{ row }">
         <MiniFlowHistory
-          class="flow-list__latest-runs-chart"
+          class="flow-list__activity-chart"
           :flow-id="row.id"
+          :time-span-in-seconds="secondsInDay"
         />
       </template>
 
@@ -83,6 +84,7 @@
 <script lang="ts" setup>
   import { CheckboxModel, TableColumn } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
+  import { secondsInDay } from 'date-fns/constants'
   import merge from 'lodash.merge'
   import { computed, ref } from 'vue'
   import {
@@ -147,7 +149,7 @@
       label: 'Deployments',
     },
     {
-      label: 'Latest runs',
+      label: 'Activity',
     },
     {
       label: 'Action',

--- a/src/components/FlowRunsBarChart.vue
+++ b/src/components/FlowRunsBarChart.vue
@@ -20,8 +20,6 @@
   import { ClassValue, toPixels, positions, usePopOverGroup } from '@prefecthq/prefect-design'
   import { useDebouncedRef, useElementRect } from '@prefecthq/vue-compositions'
   import { scaleSymlog } from 'd3'
-  import { max, min, subSeconds } from 'date-fns'
-  import { secondsInDay } from 'date-fns/constants'
   import merge from 'lodash.merge'
   import { StyleValue, computed, ref, toValue } from 'vue'
   import FlowRunPopoverContent from '@/components/FlowRunPopOverContent.vue'
@@ -120,18 +118,12 @@
     return flowRun.id
   }
 
-  function getTimeRange(flowRuns: FlowRun[]): { expectedStartTimeAfter: Date, expectedStartTimeBefore: Date } {
+  function organizeFlowRunsWithGaps(flowRuns: FlowRun[]): (FlowRun | null)[] {
     const { expectedStartTimeAfter, expectedStartTimeBefore } = toValue(props.filter).flowRuns ?? {}
 
-    if (expectedStartTimeAfter && expectedStartTimeBefore) {
-      return { expectedStartTimeAfter, expectedStartTimeBefore }
+    if (!expectedStartTimeBefore || !expectedStartTimeAfter) {
+      return []
     }
-
-    return getTimeRangeFromFlows(flowRuns)
-  }
-
-  function organizeFlowRunsWithGaps(flowRuns: FlowRun[]): (FlowRun | null)[] {
-    const { expectedStartTimeAfter, expectedStartTimeBefore } = getTimeRange(flowRuns)
 
     const totalTime = expectedStartTimeBefore.getTime() - expectedStartTimeAfter.getTime()
     const bucketSize = totalTime / bars.value
@@ -168,17 +160,6 @@
     })
 
     return buckets
-  }
-
-  function getTimeRangeFromFlows(flowRuns: FlowRun[]): { expectedStartTimeAfter: Date, expectedStartTimeBefore: Date } {
-    const maxDate = new Date()
-    const minDate = subSeconds(maxDate, secondsInDay)
-    const startTimes: Date[] = flowRuns.filter((flowRun) => flowRun.startTime).map((flowRun) => flowRun.startTime!)
-
-    return {
-      expectedStartTimeAfter: min([minDate, ...startTimes]),
-      expectedStartTimeBefore: max([maxDate, ...startTimes]),
-    }
   }
 </script>
 

--- a/src/components/MiniDeploymentHistory.vue
+++ b/src/components/MiniDeploymentHistory.vue
@@ -13,7 +13,7 @@
 
   const props = defineProps<{
     deploymentId: string,
-    timeSpanInSeconds?: number,
+    timeSpanInSeconds: number,
   }>()
 
   const deploymentStats = computed(() => ({

--- a/src/components/MiniFlowHistory.vue
+++ b/src/components/MiniFlowHistory.vue
@@ -14,12 +14,12 @@
 
   const props = defineProps<{
     flowId: string,
-    timeSpanInSeconds?: number,
+    timeSpanInSeconds: number,
   }>()
 
   const flowStats = computed<FlowStatsFilter>(() => ({
     flowId: props.flowId,
-    range: props.timeSpanInSeconds ? { type: 'span', seconds: props.timeSpanInSeconds } : undefined,
+    range: { type: 'span', seconds: props.timeSpanInSeconds },
   }))
 
   const flowRunsFilter = computed(() => mapper.map('FlowStatsFilter', flowStats.value, 'FlowRunsFilter'))

--- a/src/maps/deploymentStatsFilter.ts
+++ b/src/maps/deploymentStatsFilter.ts
@@ -1,4 +1,5 @@
-import { FlowRunsFilter } from '@/models'
+import { subSeconds } from 'date-fns'
+import { FlowRunsFilter, TaskRunsFilter } from '@/models'
 import { MapFunction } from '@/services/Mapper'
 import { DeploymentStatsFilter } from '@/types/deployment'
 
@@ -10,9 +11,25 @@ export const mapDeploymentStatsFilterToFlowRunsFilter: MapFunction<DeploymentSta
       id: [source.deploymentId],
     },
     flowRuns: {
-      startTimeBefore: now,
+      expectedStartTimeAfter: subSeconds(now, source.timeSpanInSeconds),
+      expectedStartTimeBefore: now,
     },
   }
 
   return filter
 }
+
+export const mapDeploymentStatsFilterToTaskRunsFilter: MapFunction<DeploymentStatsFilter, TaskRunsFilter> = function(source) {
+  const now = new Date()
+
+  return {
+    flows: {
+      id: [source.deploymentId],
+    },
+    taskRuns: {
+      startTimeAfter: subSeconds(now, source.timeSpanInSeconds),
+      startTimeBefore: now,
+    },
+  }
+}
+

--- a/src/maps/flowStatsFilter.ts
+++ b/src/maps/flowStatsFilter.ts
@@ -4,15 +4,16 @@ import { MapFunction } from '@/services/Mapper'
 import { FlowStatsFilter } from '@/types/flow'
 
 export const mapFlowStatsFilterToFlowRunsFilter: MapFunction<FlowStatsFilter, FlowRunsFilter> = function(source) {
-  const range = source.range ? this.map('DateRangeSelectValue', source.range, 'DateRange') : null
 
+
+  const { startDate, endDate } = this.map('DateRangeSelectValue', source.range, 'DateRange')
   const filter: FlowRunsFilter = {
     flows: {
       id: [source.flowId],
     },
     flowRuns: {
-      expectedStartTimeAfter: range?.startDate,
-      expectedStartTimeBefore: range?.endDate ?? new Date(),
+      expectedStartTimeAfter: startDate,
+      expectedStartTimeBefore: endDate,
     },
   }
 
@@ -20,15 +21,14 @@ export const mapFlowStatsFilterToFlowRunsFilter: MapFunction<FlowStatsFilter, Fl
 }
 
 export const mapFlowStatsFilterToTaskRunsFilter: MapFunction<FlowStatsFilter, TaskRunsFilter> = function(source) {
-  const range = source.range ? this.map('DateRangeSelectValue', source.range, 'DateRange') : null
-
+  const { startDate, endDate } = this.map('DateRangeSelectValue', source.range, 'DateRange')
   return {
     flows: {
       id: [source.flowId],
     },
     taskRuns: {
-      startTimeAfter: range?.startDate,
-      startTimeBefore: range?.endDate ?? new Date(),
+      startTimeAfter: startDate,
+      startTimeBefore: endDate,
     },
   }
 }

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -1,4 +1,5 @@
 export type DeploymentStatsFilter = {
+  timeSpanInSeconds: number,
   deploymentId: string,
 }
 

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -1,6 +1,7 @@
 import { DateRangeSelectValue } from '@prefecthq/prefect-design'
 
 export type FlowStatsFilter = {
-  range?: NonNullable<DateRangeSelectValue>,
+  range: NonNullable<DateRangeSelectValue>,
   flowId: string,
+
 }


### PR DESCRIPTION
This reverts commit fd9e491b57c795d535a2dfbd4c807c93486f943a, reversing
changes made to 5c30f98005e10a79f0ea693bfd5bc65dee1bd400.

A breaking change was introduced to `FlowStatsFilter` which has negative effects in nebula-ui. Reversing for now. We will want to revisit after the holidays. 

@brandonreid FYI 
Slack thread for context https://prefecthq.slack.com/archives/CJN6L95L7/p1703268199204989
