### PR TITLE
Update vue to 3.4.4 and fix migration issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,14 +40,14 @@
                 "vite": "5.0.10",
                 "vite-svg-loader": "^5.1.0",
                 "vitest": "^1.0.4",
-                "vue-tsc": "1.8.25"
+                "vue-tsc": "1.8.27"
             },
             "peerDependencies": {
                 "@prefecthq/prefect-design": "^2.2.9",
                 "@prefecthq/vue-charts": "^2.0.3",
                 "@prefecthq/vue-compositions": "^1.6.6",
                 "vee-validate": "^4.7.0",
-                "vue": "^3.3.4",
+                "vue": "^3.4.4",
                 "vue-router": "^4.0.12"
             }
         },
@@ -72,9 +72,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.21.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
-            "integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+            "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -2194,51 +2194,51 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-            "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.4.tgz",
+            "integrity": "sha512-U5AdCN+6skzh2bSJrkMj2KZsVkUpgK8/XlxjSRYQZhNPcvt9/kmgIMpFEiTyK+Dz5E1J+8o8//BEIX+bakgVSw==",
             "dependencies": {
-                "@babel/parser": "^7.21.3",
-                "@vue/shared": "3.3.4",
+                "@babel/parser": "^7.23.6",
+                "@vue/shared": "3.4.4",
+                "entities": "^4.5.0",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.0.2"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-            "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.4.tgz",
+            "integrity": "sha512-iSwkdDULCN+Vr8z6uwdlL044GJ/nUmECxP9vu7MzEs4Qma0FwDLYvnvRcyO0ZITuu3Os4FptGUDnhi1kOLSaGw==",
             "dependencies": {
-                "@vue/compiler-core": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@vue/compiler-core": "3.4.4",
+                "@vue/shared": "3.4.4"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-            "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.4.tgz",
+            "integrity": "sha512-OTFcU6vUxUNHBcarzkp4g6d25nvcmDvFDzPRvSrIsByFFPRYN+y3b+j9HxYwt6nlWvGyFCe0roeJdJlfYxbCBg==",
             "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.20.15",
-                "@vue/compiler-core": "3.3.4",
-                "@vue/compiler-dom": "3.3.4",
-                "@vue/compiler-ssr": "3.3.4",
-                "@vue/reactivity-transform": "3.3.4",
-                "@vue/shared": "3.3.4",
+                "@babel/parser": "^7.23.6",
+                "@vue/compiler-core": "3.4.4",
+                "@vue/compiler-dom": "3.4.4",
+                "@vue/compiler-ssr": "3.4.4",
+                "@vue/shared": "3.4.4",
                 "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.0",
-                "postcss": "^8.1.10",
+                "magic-string": "^0.30.5",
+                "postcss": "^8.4.32",
                 "source-map-js": "^1.0.2"
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-            "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.4.tgz",
+            "integrity": "sha512-1DU9DflSSQlx/M61GEBN+NbT/anUki2ooDo9IXfTckCeKA/2IKNhY8KbG3x6zkd3KGrxzteC7de6QL88vEb41Q==",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@vue/compiler-dom": "3.4.4",
+                "@vue/shared": "3.4.4"
             }
         },
         "node_modules/@vue/devtools-api": {
@@ -2272,9 +2272,9 @@
             }
         },
         "node_modules/@vue/language-core": {
-            "version": "1.8.25",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.25.tgz",
-            "integrity": "sha512-NJk/5DnAZlpvXX8BdWmHI45bWGLViUaS3R/RMrmFSvFMSbJKuEODpM4kR0F0Ofv5SFzCWuNiMhxameWpVdQsnA==",
+            "version": "1.8.27",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.27.tgz",
+            "integrity": "sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==",
             "dev": true,
             "dependencies": {
                 "@volar/language-core": "~1.11.1",
@@ -2321,65 +2321,52 @@
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
-            "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.4.tgz",
+            "integrity": "sha512-DFsuJBf6sfhd5SYzJmcBTUG9+EKqjF31Gsk1NJtnpJm9liSZ806XwGJUeNBVQIanax7ODV7Lmk/k17BgxXNuTg==",
             "peer": true,
             "dependencies": {
-                "@vue/shared": "3.3.4"
-            }
-        },
-        "node_modules/@vue/reactivity-transform": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-            "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.20.15",
-                "@vue/compiler-core": "3.3.4",
-                "@vue/shared": "3.3.4",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.0"
+                "@vue/shared": "3.4.4"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
-            "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.4.tgz",
+            "integrity": "sha512-zWWwNQAj5JdxrmOA1xegJm+c4VtyIbDEKgQjSb4va5v7gGTCh0ZjvLI+htGFdVXaO9bs2J3C81p5p+6jrPK8Bw==",
             "peer": true,
             "dependencies": {
-                "@vue/reactivity": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@vue/reactivity": "3.4.4",
+                "@vue/shared": "3.4.4"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
-            "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.4.tgz",
+            "integrity": "sha512-Nlh2ap1J/eJQ6R0g+AIRyGNwpTJQACN0dk8I8FRLH8Ev11DSvfcPOpn4+Kbg5xAMcuq0cHB8zFYxVrOgETrrvg==",
             "peer": true,
             "dependencies": {
-                "@vue/runtime-core": "3.3.4",
-                "@vue/shared": "3.3.4",
-                "csstype": "^3.1.1"
+                "@vue/runtime-core": "3.4.4",
+                "@vue/shared": "3.4.4",
+                "csstype": "^3.1.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
-            "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.4.tgz",
+            "integrity": "sha512-+AjoiKcC41k7SMJBYkDO9xs79/Of8DiThS9mH5l2MK+EY0to3psI0k+sElvVqQvsoZTjHMEuMz0AEgvm2T+CwA==",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-ssr": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@vue/compiler-ssr": "3.4.4",
+                "@vue/shared": "3.4.4"
             },
             "peerDependencies": {
-                "vue": "3.3.4"
+                "vue": "3.4.4"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.4.tgz",
+            "integrity": "sha512-abSgiVRhfjfl3JALR/cSuBl74hGJ3SePgf1mKzodf1eMWLwHZbfEGxT2cNJSsNiw44jEgrO7bNkhchaWA7RwNw=="
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -3046,9 +3033,9 @@
             }
         },
         "node_modules/csstype": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "peer": true
         },
         "node_modules/d3": {
@@ -3686,9 +3673,9 @@
             }
         },
         "node_modules/entities": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "engines": {
                 "node": ">=0.12"
             },
@@ -7124,7 +7111,7 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
             "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "dev": true,
+            "devOptional": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7418,16 +7405,24 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
-            "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.4.tgz",
+            "integrity": "sha512-suZXgDVT8lRNhKmxdkwOsR0oyUi8is7mtqI18qW97JLoyorEbE9B2Sb4Ws/mR/+0AgA/JUtsv1ytlRSH3/pDIA==",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.3.4",
-                "@vue/compiler-sfc": "3.3.4",
-                "@vue/runtime-dom": "3.3.4",
-                "@vue/server-renderer": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@vue/compiler-dom": "3.4.4",
+                "@vue/compiler-sfc": "3.4.4",
+                "@vue/runtime-dom": "3.4.4",
+                "@vue/server-renderer": "3.4.4",
+                "@vue/shared": "3.4.4"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/vue-eslint-parser": {
@@ -7495,9 +7490,9 @@
             }
         },
         "node_modules/vue-template-compiler": {
-            "version": "2.7.15",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
-            "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
+            "version": "2.7.16",
+            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
+            "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
             "dev": true,
             "dependencies": {
                 "de-indent": "^1.0.2",
@@ -7505,13 +7500,13 @@
             }
         },
         "node_modules/vue-tsc": {
-            "version": "1.8.25",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.25.tgz",
-            "integrity": "sha512-lHsRhDc/Y7LINvYhZ3pv4elflFADoEOo67vfClAfF2heVHpHmVquLSjojgCSIwzA4F0Pc4vowT/psXCYcfk+iQ==",
+            "version": "1.8.27",
+            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.27.tgz",
+            "integrity": "sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==",
             "dev": true,
             "dependencies": {
                 "@volar/typescript": "~1.11.1",
-                "@vue/language-core": "1.8.25",
+                "@vue/language-core": "1.8.27",
                 "semver": "^7.5.4"
             },
             "bin": {
@@ -7729,9 +7724,9 @@
             "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="
         },
         "@babel/parser": {
-            "version": "7.21.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
-            "integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA=="
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+            "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ=="
         },
         "@babel/runtime": {
             "version": "7.21.5",
@@ -9170,51 +9165,51 @@
             }
         },
         "@vue/compiler-core": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-            "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.4.tgz",
+            "integrity": "sha512-U5AdCN+6skzh2bSJrkMj2KZsVkUpgK8/XlxjSRYQZhNPcvt9/kmgIMpFEiTyK+Dz5E1J+8o8//BEIX+bakgVSw==",
             "requires": {
-                "@babel/parser": "^7.21.3",
-                "@vue/shared": "3.3.4",
+                "@babel/parser": "^7.23.6",
+                "@vue/shared": "3.4.4",
+                "entities": "^4.5.0",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.0.2"
             }
         },
         "@vue/compiler-dom": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-            "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.4.tgz",
+            "integrity": "sha512-iSwkdDULCN+Vr8z6uwdlL044GJ/nUmECxP9vu7MzEs4Qma0FwDLYvnvRcyO0ZITuu3Os4FptGUDnhi1kOLSaGw==",
             "requires": {
-                "@vue/compiler-core": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@vue/compiler-core": "3.4.4",
+                "@vue/shared": "3.4.4"
             }
         },
         "@vue/compiler-sfc": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-            "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.4.tgz",
+            "integrity": "sha512-OTFcU6vUxUNHBcarzkp4g6d25nvcmDvFDzPRvSrIsByFFPRYN+y3b+j9HxYwt6nlWvGyFCe0roeJdJlfYxbCBg==",
             "peer": true,
             "requires": {
-                "@babel/parser": "^7.20.15",
-                "@vue/compiler-core": "3.3.4",
-                "@vue/compiler-dom": "3.3.4",
-                "@vue/compiler-ssr": "3.3.4",
-                "@vue/reactivity-transform": "3.3.4",
-                "@vue/shared": "3.3.4",
+                "@babel/parser": "^7.23.6",
+                "@vue/compiler-core": "3.4.4",
+                "@vue/compiler-dom": "3.4.4",
+                "@vue/compiler-ssr": "3.4.4",
+                "@vue/shared": "3.4.4",
                 "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.0",
-                "postcss": "^8.1.10",
+                "magic-string": "^0.30.5",
+                "postcss": "^8.4.32",
                 "source-map-js": "^1.0.2"
             }
         },
         "@vue/compiler-ssr": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-            "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.4.tgz",
+            "integrity": "sha512-1DU9DflSSQlx/M61GEBN+NbT/anUki2ooDo9IXfTckCeKA/2IKNhY8KbG3x6zkd3KGrxzteC7de6QL88vEb41Q==",
             "peer": true,
             "requires": {
-                "@vue/compiler-dom": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@vue/compiler-dom": "3.4.4",
+                "@vue/shared": "3.4.4"
             }
         },
         "@vue/devtools-api": {
@@ -9235,9 +9230,9 @@
             }
         },
         "@vue/language-core": {
-            "version": "1.8.25",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.25.tgz",
-            "integrity": "sha512-NJk/5DnAZlpvXX8BdWmHI45bWGLViUaS3R/RMrmFSvFMSbJKuEODpM4kR0F0Ofv5SFzCWuNiMhxameWpVdQsnA==",
+            "version": "1.8.27",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.27.tgz",
+            "integrity": "sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==",
             "dev": true,
             "requires": {
                 "@volar/language-core": "~1.11.1",
@@ -9272,62 +9267,49 @@
             }
         },
         "@vue/reactivity": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
-            "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.4.tgz",
+            "integrity": "sha512-DFsuJBf6sfhd5SYzJmcBTUG9+EKqjF31Gsk1NJtnpJm9liSZ806XwGJUeNBVQIanax7ODV7Lmk/k17BgxXNuTg==",
             "peer": true,
             "requires": {
-                "@vue/shared": "3.3.4"
-            }
-        },
-        "@vue/reactivity-transform": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-            "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-            "peer": true,
-            "requires": {
-                "@babel/parser": "^7.20.15",
-                "@vue/compiler-core": "3.3.4",
-                "@vue/shared": "3.3.4",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.0"
+                "@vue/shared": "3.4.4"
             }
         },
         "@vue/runtime-core": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
-            "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.4.tgz",
+            "integrity": "sha512-zWWwNQAj5JdxrmOA1xegJm+c4VtyIbDEKgQjSb4va5v7gGTCh0ZjvLI+htGFdVXaO9bs2J3C81p5p+6jrPK8Bw==",
             "peer": true,
             "requires": {
-                "@vue/reactivity": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@vue/reactivity": "3.4.4",
+                "@vue/shared": "3.4.4"
             }
         },
         "@vue/runtime-dom": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
-            "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.4.tgz",
+            "integrity": "sha512-Nlh2ap1J/eJQ6R0g+AIRyGNwpTJQACN0dk8I8FRLH8Ev11DSvfcPOpn4+Kbg5xAMcuq0cHB8zFYxVrOgETrrvg==",
             "peer": true,
             "requires": {
-                "@vue/runtime-core": "3.3.4",
-                "@vue/shared": "3.3.4",
-                "csstype": "^3.1.1"
+                "@vue/runtime-core": "3.4.4",
+                "@vue/shared": "3.4.4",
+                "csstype": "^3.1.3"
             }
         },
         "@vue/server-renderer": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
-            "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.4.tgz",
+            "integrity": "sha512-+AjoiKcC41k7SMJBYkDO9xs79/Of8DiThS9mH5l2MK+EY0to3psI0k+sElvVqQvsoZTjHMEuMz0AEgvm2T+CwA==",
             "peer": true,
             "requires": {
-                "@vue/compiler-ssr": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@vue/compiler-ssr": "3.4.4",
+                "@vue/shared": "3.4.4"
             }
         },
         "@vue/shared": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.4.tgz",
+            "integrity": "sha512-abSgiVRhfjfl3JALR/cSuBl74hGJ3SePgf1mKzodf1eMWLwHZbfEGxT2cNJSsNiw44jEgrO7bNkhchaWA7RwNw=="
         },
         "abab": {
             "version": "2.0.6",
@@ -9784,9 +9766,9 @@
             }
         },
         "csstype": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "peer": true
         },
         "d3": {
@@ -10249,9 +10231,9 @@
             }
         },
         "entities": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
         },
         "es-abstract": {
             "version": "1.21.2",
@@ -12733,7 +12715,7 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
             "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "dev": true
+            "devOptional": true
         },
         "ufo": {
             "version": "1.3.2",
@@ -12895,16 +12877,16 @@
             }
         },
         "vue": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
-            "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.4.tgz",
+            "integrity": "sha512-suZXgDVT8lRNhKmxdkwOsR0oyUi8is7mtqI18qW97JLoyorEbE9B2Sb4Ws/mR/+0AgA/JUtsv1ytlRSH3/pDIA==",
             "peer": true,
             "requires": {
-                "@vue/compiler-dom": "3.3.4",
-                "@vue/compiler-sfc": "3.3.4",
-                "@vue/runtime-dom": "3.3.4",
-                "@vue/server-renderer": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@vue/compiler-dom": "3.4.4",
+                "@vue/compiler-sfc": "3.4.4",
+                "@vue/runtime-dom": "3.4.4",
+                "@vue/server-renderer": "3.4.4",
+                "@vue/shared": "3.4.4"
             }
         },
         "vue-eslint-parser": {
@@ -12950,9 +12932,9 @@
             }
         },
         "vue-template-compiler": {
-            "version": "2.7.15",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
-            "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
+            "version": "2.7.16",
+            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
+            "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
             "dev": true,
             "requires": {
                 "de-indent": "^1.0.2",
@@ -12960,13 +12942,13 @@
             }
         },
         "vue-tsc": {
-            "version": "1.8.25",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.25.tgz",
-            "integrity": "sha512-lHsRhDc/Y7LINvYhZ3pv4elflFADoEOo67vfClAfF2heVHpHmVquLSjojgCSIwzA4F0Pc4vowT/psXCYcfk+iQ==",
+            "version": "1.8.27",
+            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.27.tgz",
+            "integrity": "sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==",
             "dev": true,
             "requires": {
                 "@volar/typescript": "~1.11.1",
-                "@vue/language-core": "1.8.25",
+                "@vue/language-core": "1.8.27",
                 "semver": "^7.5.4"
             }
         },

--- a/package.json
+++ b/package.json
@@ -58,14 +58,14 @@
         "vite": "5.0.10",
         "vite-svg-loader": "^5.1.0",
         "vitest": "^1.0.4",
-        "vue-tsc": "1.8.25"
+        "vue-tsc": "1.8.27"
     },
     "peerDependencies": {
         "@prefecthq/prefect-design": "^2.2.9",
         "@prefecthq/vue-charts": "^2.0.3",
         "@prefecthq/vue-compositions": "^1.6.6",
         "vee-validate": "^4.7.0",
-        "vue": "^3.3.4",
+        "vue": "^3.4.4",
         "vue-router": "^4.0.12"
     },
     "dependencies": {

--- a/src/components/FlowRouterLink.vue
+++ b/src/components/FlowRouterLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <span v-if="showLink" class="flow-router-link">
+  <span v-if="flowId" class="flow-router-link">
     <slot name="before">
       <span v-if="before">
         {{ before }}

--- a/src/compositions/usePagination.ts
+++ b/src/compositions/usePagination.ts
@@ -84,11 +84,10 @@ export function usePagination<
   const countSubscription = useSubscriptionWithDependencies(countMethod, countSubscriptionParameters, options)
   const total = computed(() => countSubscription.response ?? 0)
 
-  const fetchParametersRef = toRef(fetchParametersGetter)
   const fetchSubscriptions: UseSubscription<TFetch>[] = reactive([])
   const results = computed(() => fetchSubscriptions.flatMap(subscription => subscription.response ?? []) as unknown as Awaited<ReturnType<TFetch>>)
 
-  watch([total, page, fetchParametersRef], ([total, page, parameters]) => {
+  watch([total, page, fetchParametersGetter], ([total, page, parameters]) => {
     if (total === 0 || page === 0 || parameters === null) {
       fetchSubscriptions.forEach(subscription => subscription.unsubscribe())
       fetchSubscriptions.splice(0)
@@ -103,7 +102,7 @@ export function usePagination<
 
     fetchSubscriptions.forEach(subscription => subscription.unsubscribe())
     fetchSubscriptions.splice(0, Infinity, ...newSubscriptions)
-  }, { immediate: true })
+  }, { immediate: true, deep: true })
 
   const { subscriptions } = useSubscriptions(() => [
     countSubscription,


### PR DESCRIPTION
# Description
Updating vue to 3.4.x in nebula-ui led to some unexpected issues with filters. I believe this was due to vue's reactivity updates for more efficient triggering of effects. Adding `deep: true` to the watcher in `usePagination` fixes the issue. And considering the parameters are likely to be nested objects anyways I'm actually surprised it worked on vue 3.3.x. 

Also fixes a type error revealed by updating vue-tsc which was required to update vue. 