### PR TITLE
Fix bug with converting a saved search into a date range value

### DIFF
--- a/src/components/SavedFiltersMenu.vue
+++ b/src/components/SavedFiltersMenu.vue
@@ -54,7 +54,7 @@
   }>()
 
   const emit = defineEmits<{
-    (event: 'update:selectedSearchOption', value: SavedSearch | null): void,
+    (event: 'update:selectedSearchOption', value: SavedFlowRunsSearch | null): void,
   }>()
 
   const attrs = useAttrs()

--- a/src/maps/savedSearch.ts
+++ b/src/maps/savedSearch.ts
@@ -79,5 +79,6 @@ function getRangeFilter(filters: SavedSearchFilterResponse[]): NonNullable<DateR
   }
 
   const exhaustive: never = range
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   throw new Error(`No handler for date range type: ${(exhaustive as any).type}`)
 }

--- a/src/models/api/SavedSearchResponse.ts
+++ b/src/models/api/SavedSearchResponse.ts
@@ -73,7 +73,7 @@ export function isDateRangeAroundResponse(value: unknown): value is DateRangeAro
 
 export type DateRangeResponse = DateRangeSpanResponse | DateRangeRangeResponse | DateRangePeriodResponse | DateRangeAroundResponse
 
-export function isDateRangeResponse(value: unknown): value is DateRangeRangeResponse {
+export function isDateRangeResponse(value: unknown): value is DateRangeResponse {
   return isDateRangeSpanResponse(value) || isDateRangeRangeResponse(value) || isDateRangePeriodResponse(value) || isDateRangeAroundResponse(value)
 }
 


### PR DESCRIPTION
# Description
Fixes missing conditions when mapping a `SavedSearch` into a `DateRangeSelectValue` that was causing errors to be thrown and filters to not be usable. 

[Community slack thread](https://prefect-community.slack.com/archives/C0192RWGJQH/p1704777648479909)

Error that was thrown
<img width="489" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/2ce9aa0a-4a91-4796-9ef9-9635be8f87ca">
