### PR TITLE
revert vue update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "@prefecthq/vue-charts": "^2.0.3",
                 "@prefecthq/vue-compositions": "^1.6.6",
                 "vee-validate": "^4.7.0",
-                "vue": "^3.4.4",
+                "vue": "^3.3.4",
                 "vue-router": "^4.0.12"
             }
         },
@@ -2197,6 +2197,7 @@
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.4.tgz",
             "integrity": "sha512-U5AdCN+6skzh2bSJrkMj2KZsVkUpgK8/XlxjSRYQZhNPcvt9/kmgIMpFEiTyK+Dz5E1J+8o8//BEIX+bakgVSw==",
+            "dev": true,
             "dependencies": {
                 "@babel/parser": "^7.23.6",
                 "@vue/shared": "3.4.4",
@@ -2209,37 +2210,95 @@
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.4.tgz",
             "integrity": "sha512-iSwkdDULCN+Vr8z6uwdlL044GJ/nUmECxP9vu7MzEs4Qma0FwDLYvnvRcyO0ZITuu3Os4FptGUDnhi1kOLSaGw==",
+            "dev": true,
             "dependencies": {
                 "@vue/compiler-core": "3.4.4",
                 "@vue/shared": "3.4.4"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.4.tgz",
-            "integrity": "sha512-OTFcU6vUxUNHBcarzkp4g6d25nvcmDvFDzPRvSrIsByFFPRYN+y3b+j9HxYwt6nlWvGyFCe0roeJdJlfYxbCBg==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
+            "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
             "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.23.6",
-                "@vue/compiler-core": "3.4.4",
-                "@vue/compiler-dom": "3.4.4",
-                "@vue/compiler-ssr": "3.4.4",
-                "@vue/shared": "3.4.4",
+                "@babel/parser": "^7.20.15",
+                "@vue/compiler-core": "3.3.4",
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/compiler-ssr": "3.3.4",
+                "@vue/reactivity-transform": "3.3.4",
+                "@vue/shared": "3.3.4",
                 "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.5",
-                "postcss": "^8.4.32",
+                "magic-string": "^0.30.0",
+                "postcss": "^8.1.10",
                 "source-map-js": "^1.0.2"
             }
         },
-        "node_modules/@vue/compiler-ssr": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.4.tgz",
-            "integrity": "sha512-1DU9DflSSQlx/M61GEBN+NbT/anUki2ooDo9IXfTckCeKA/2IKNhY8KbG3x6zkd3KGrxzteC7de6QL88vEb41Q==",
+        "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-core": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+            "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.4.4",
-                "@vue/shared": "3.4.4"
+                "@babel/parser": "^7.21.3",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.0.2"
             }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-dom": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+            "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/@vue/shared": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+            "peer": true
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
+            "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "node_modules/@vue/compiler-ssr/node_modules/@vue/compiler-core": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+            "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.21.3",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "node_modules/@vue/compiler-ssr/node_modules/@vue/compiler-dom": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+            "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "node_modules/@vue/compiler-ssr/node_modules/@vue/shared": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+            "peer": true
         },
         "node_modules/@vue/devtools-api": {
             "version": "6.5.0",
@@ -2321,52 +2380,108 @@
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.4.tgz",
-            "integrity": "sha512-DFsuJBf6sfhd5SYzJmcBTUG9+EKqjF31Gsk1NJtnpJm9liSZ806XwGJUeNBVQIanax7ODV7Lmk/k17BgxXNuTg==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
+            "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
             "peer": true,
             "dependencies": {
-                "@vue/shared": "3.4.4"
+                "@vue/shared": "3.3.4"
             }
+        },
+        "node_modules/@vue/reactivity-transform": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
+            "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.20.15",
+                "@vue/compiler-core": "3.3.4",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.0"
+            }
+        },
+        "node_modules/@vue/reactivity-transform/node_modules/@vue/compiler-core": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+            "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.21.3",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "node_modules/@vue/reactivity-transform/node_modules/@vue/shared": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+            "peer": true
+        },
+        "node_modules/@vue/reactivity/node_modules/@vue/shared": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+            "peer": true
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.4.tgz",
-            "integrity": "sha512-zWWwNQAj5JdxrmOA1xegJm+c4VtyIbDEKgQjSb4va5v7gGTCh0ZjvLI+htGFdVXaO9bs2J3C81p5p+6jrPK8Bw==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
+            "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
             "peer": true,
             "dependencies": {
-                "@vue/reactivity": "3.4.4",
-                "@vue/shared": "3.4.4"
+                "@vue/reactivity": "3.3.4",
+                "@vue/shared": "3.3.4"
             }
+        },
+        "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+            "peer": true
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.4.tgz",
-            "integrity": "sha512-Nlh2ap1J/eJQ6R0g+AIRyGNwpTJQACN0dk8I8FRLH8Ev11DSvfcPOpn4+Kbg5xAMcuq0cHB8zFYxVrOgETrrvg==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
+            "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
             "peer": true,
             "dependencies": {
-                "@vue/runtime-core": "3.4.4",
-                "@vue/shared": "3.4.4",
-                "csstype": "^3.1.3"
+                "@vue/runtime-core": "3.3.4",
+                "@vue/shared": "3.3.4",
+                "csstype": "^3.1.1"
             }
         },
+        "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+            "peer": true
+        },
         "node_modules/@vue/server-renderer": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.4.tgz",
-            "integrity": "sha512-+AjoiKcC41k7SMJBYkDO9xs79/Of8DiThS9mH5l2MK+EY0to3psI0k+sElvVqQvsoZTjHMEuMz0AEgvm2T+CwA==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
+            "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-ssr": "3.4.4",
-                "@vue/shared": "3.4.4"
+                "@vue/compiler-ssr": "3.3.4",
+                "@vue/shared": "3.3.4"
             },
             "peerDependencies": {
-                "vue": "3.4.4"
+                "vue": "3.3.4"
             }
+        },
+        "node_modules/@vue/server-renderer/node_modules/@vue/shared": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+            "peer": true
         },
         "node_modules/@vue/shared": {
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.4.tgz",
-            "integrity": "sha512-abSgiVRhfjfl3JALR/cSuBl74hGJ3SePgf1mKzodf1eMWLwHZbfEGxT2cNJSsNiw44jEgrO7bNkhchaWA7RwNw=="
+            "integrity": "sha512-abSgiVRhfjfl3JALR/cSuBl74hGJ3SePgf1mKzodf1eMWLwHZbfEGxT2cNJSsNiw44jEgrO7bNkhchaWA7RwNw==",
+            "dev": true
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -7111,7 +7226,7 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
             "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "devOptional": true,
+            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7405,24 +7520,16 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.4.tgz",
-            "integrity": "sha512-suZXgDVT8lRNhKmxdkwOsR0oyUi8is7mtqI18qW97JLoyorEbE9B2Sb4Ws/mR/+0AgA/JUtsv1ytlRSH3/pDIA==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
+            "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.4.4",
-                "@vue/compiler-sfc": "3.4.4",
-                "@vue/runtime-dom": "3.4.4",
-                "@vue/server-renderer": "3.4.4",
-                "@vue/shared": "3.4.4"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/compiler-sfc": "3.3.4",
+                "@vue/runtime-dom": "3.3.4",
+                "@vue/server-renderer": "3.3.4",
+                "@vue/shared": "3.3.4"
             }
         },
         "node_modules/vue-eslint-parser": {
@@ -7515,6 +7622,34 @@
             "peerDependencies": {
                 "typescript": "*"
             }
+        },
+        "node_modules/vue/node_modules/@vue/compiler-core": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+            "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.21.3",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "node_modules/vue/node_modules/@vue/compiler-dom": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+            "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "node_modules/vue/node_modules/@vue/shared": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+            "peer": true
         },
         "node_modules/w3c-xmlserializer": {
             "version": "4.0.0",
@@ -9168,6 +9303,7 @@
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.4.tgz",
             "integrity": "sha512-U5AdCN+6skzh2bSJrkMj2KZsVkUpgK8/XlxjSRYQZhNPcvt9/kmgIMpFEiTyK+Dz5E1J+8o8//BEIX+bakgVSw==",
+            "dev": true,
             "requires": {
                 "@babel/parser": "^7.23.6",
                 "@vue/shared": "3.4.4",
@@ -9180,36 +9316,98 @@
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.4.tgz",
             "integrity": "sha512-iSwkdDULCN+Vr8z6uwdlL044GJ/nUmECxP9vu7MzEs4Qma0FwDLYvnvRcyO0ZITuu3Os4FptGUDnhi1kOLSaGw==",
+            "dev": true,
             "requires": {
                 "@vue/compiler-core": "3.4.4",
                 "@vue/shared": "3.4.4"
             }
         },
         "@vue/compiler-sfc": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.4.tgz",
-            "integrity": "sha512-OTFcU6vUxUNHBcarzkp4g6d25nvcmDvFDzPRvSrIsByFFPRYN+y3b+j9HxYwt6nlWvGyFCe0roeJdJlfYxbCBg==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
+            "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
             "peer": true,
             "requires": {
-                "@babel/parser": "^7.23.6",
-                "@vue/compiler-core": "3.4.4",
-                "@vue/compiler-dom": "3.4.4",
-                "@vue/compiler-ssr": "3.4.4",
-                "@vue/shared": "3.4.4",
+                "@babel/parser": "^7.20.15",
+                "@vue/compiler-core": "3.3.4",
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/compiler-ssr": "3.3.4",
+                "@vue/reactivity-transform": "3.3.4",
+                "@vue/shared": "3.3.4",
                 "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.5",
-                "postcss": "^8.4.32",
+                "magic-string": "^0.30.0",
+                "postcss": "^8.1.10",
                 "source-map-js": "^1.0.2"
+            },
+            "dependencies": {
+                "@vue/compiler-core": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+                    "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+                    "peer": true,
+                    "requires": {
+                        "@babel/parser": "^7.21.3",
+                        "@vue/shared": "3.3.4",
+                        "estree-walker": "^2.0.2",
+                        "source-map-js": "^1.0.2"
+                    }
+                },
+                "@vue/compiler-dom": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+                    "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+                    "peer": true,
+                    "requires": {
+                        "@vue/compiler-core": "3.3.4",
+                        "@vue/shared": "3.3.4"
+                    }
+                },
+                "@vue/shared": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+                    "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+                    "peer": true
+                }
             }
         },
         "@vue/compiler-ssr": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.4.tgz",
-            "integrity": "sha512-1DU9DflSSQlx/M61GEBN+NbT/anUki2ooDo9IXfTckCeKA/2IKNhY8KbG3x6zkd3KGrxzteC7de6QL88vEb41Q==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
+            "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
             "peer": true,
             "requires": {
-                "@vue/compiler-dom": "3.4.4",
-                "@vue/shared": "3.4.4"
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/shared": "3.3.4"
+            },
+            "dependencies": {
+                "@vue/compiler-core": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+                    "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+                    "peer": true,
+                    "requires": {
+                        "@babel/parser": "^7.21.3",
+                        "@vue/shared": "3.3.4",
+                        "estree-walker": "^2.0.2",
+                        "source-map-js": "^1.0.2"
+                    }
+                },
+                "@vue/compiler-dom": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+                    "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+                    "peer": true,
+                    "requires": {
+                        "@vue/compiler-core": "3.3.4",
+                        "@vue/shared": "3.3.4"
+                    }
+                },
+                "@vue/shared": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+                    "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+                    "peer": true
+                }
             }
         },
         "@vue/devtools-api": {
@@ -9267,49 +9465,115 @@
             }
         },
         "@vue/reactivity": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.4.tgz",
-            "integrity": "sha512-DFsuJBf6sfhd5SYzJmcBTUG9+EKqjF31Gsk1NJtnpJm9liSZ806XwGJUeNBVQIanax7ODV7Lmk/k17BgxXNuTg==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
+            "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
             "peer": true,
             "requires": {
-                "@vue/shared": "3.4.4"
+                "@vue/shared": "3.3.4"
+            },
+            "dependencies": {
+                "@vue/shared": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+                    "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+                    "peer": true
+                }
+            }
+        },
+        "@vue/reactivity-transform": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
+            "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
+            "peer": true,
+            "requires": {
+                "@babel/parser": "^7.20.15",
+                "@vue/compiler-core": "3.3.4",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.0"
+            },
+            "dependencies": {
+                "@vue/compiler-core": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+                    "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+                    "peer": true,
+                    "requires": {
+                        "@babel/parser": "^7.21.3",
+                        "@vue/shared": "3.3.4",
+                        "estree-walker": "^2.0.2",
+                        "source-map-js": "^1.0.2"
+                    }
+                },
+                "@vue/shared": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+                    "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+                    "peer": true
+                }
             }
         },
         "@vue/runtime-core": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.4.tgz",
-            "integrity": "sha512-zWWwNQAj5JdxrmOA1xegJm+c4VtyIbDEKgQjSb4va5v7gGTCh0ZjvLI+htGFdVXaO9bs2J3C81p5p+6jrPK8Bw==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
+            "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
             "peer": true,
             "requires": {
-                "@vue/reactivity": "3.4.4",
-                "@vue/shared": "3.4.4"
+                "@vue/reactivity": "3.3.4",
+                "@vue/shared": "3.3.4"
+            },
+            "dependencies": {
+                "@vue/shared": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+                    "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+                    "peer": true
+                }
             }
         },
         "@vue/runtime-dom": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.4.tgz",
-            "integrity": "sha512-Nlh2ap1J/eJQ6R0g+AIRyGNwpTJQACN0dk8I8FRLH8Ev11DSvfcPOpn4+Kbg5xAMcuq0cHB8zFYxVrOgETrrvg==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
+            "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
             "peer": true,
             "requires": {
-                "@vue/runtime-core": "3.4.4",
-                "@vue/shared": "3.4.4",
-                "csstype": "^3.1.3"
+                "@vue/runtime-core": "3.3.4",
+                "@vue/shared": "3.3.4",
+                "csstype": "^3.1.1"
+            },
+            "dependencies": {
+                "@vue/shared": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+                    "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+                    "peer": true
+                }
             }
         },
         "@vue/server-renderer": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.4.tgz",
-            "integrity": "sha512-+AjoiKcC41k7SMJBYkDO9xs79/Of8DiThS9mH5l2MK+EY0to3psI0k+sElvVqQvsoZTjHMEuMz0AEgvm2T+CwA==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
+            "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
             "peer": true,
             "requires": {
-                "@vue/compiler-ssr": "3.4.4",
-                "@vue/shared": "3.4.4"
+                "@vue/compiler-ssr": "3.3.4",
+                "@vue/shared": "3.3.4"
+            },
+            "dependencies": {
+                "@vue/shared": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+                    "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+                    "peer": true
+                }
             }
         },
         "@vue/shared": {
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.4.tgz",
-            "integrity": "sha512-abSgiVRhfjfl3JALR/cSuBl74hGJ3SePgf1mKzodf1eMWLwHZbfEGxT2cNJSsNiw44jEgrO7bNkhchaWA7RwNw=="
+            "integrity": "sha512-abSgiVRhfjfl3JALR/cSuBl74hGJ3SePgf1mKzodf1eMWLwHZbfEGxT2cNJSsNiw44jEgrO7bNkhchaWA7RwNw==",
+            "dev": true
         },
         "abab": {
             "version": "2.0.6",
@@ -12715,7 +12979,7 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
             "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "devOptional": true
+            "dev": true
         },
         "ufo": {
             "version": "1.3.2",
@@ -12877,16 +13141,46 @@
             }
         },
         "vue": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.4.tgz",
-            "integrity": "sha512-suZXgDVT8lRNhKmxdkwOsR0oyUi8is7mtqI18qW97JLoyorEbE9B2Sb4Ws/mR/+0AgA/JUtsv1ytlRSH3/pDIA==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
+            "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
             "peer": true,
             "requires": {
-                "@vue/compiler-dom": "3.4.4",
-                "@vue/compiler-sfc": "3.4.4",
-                "@vue/runtime-dom": "3.4.4",
-                "@vue/server-renderer": "3.4.4",
-                "@vue/shared": "3.4.4"
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/compiler-sfc": "3.3.4",
+                "@vue/runtime-dom": "3.3.4",
+                "@vue/server-renderer": "3.3.4",
+                "@vue/shared": "3.3.4"
+            },
+            "dependencies": {
+                "@vue/compiler-core": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+                    "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+                    "peer": true,
+                    "requires": {
+                        "@babel/parser": "^7.21.3",
+                        "@vue/shared": "3.3.4",
+                        "estree-walker": "^2.0.2",
+                        "source-map-js": "^1.0.2"
+                    }
+                },
+                "@vue/compiler-dom": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+                    "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+                    "peer": true,
+                    "requires": {
+                        "@vue/compiler-core": "3.3.4",
+                        "@vue/shared": "3.3.4"
+                    }
+                },
+                "@vue/shared": {
+                    "version": "3.3.4",
+                    "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+                    "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+                    "peer": true
+                }
             }
         },
         "vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@prefecthq/vue-charts": "^2.0.3",
         "@prefecthq/vue-compositions": "^1.6.6",
         "vee-validate": "^4.7.0",
-        "vue": "^3.4.4",
+        "vue": "^3.3.4",
         "vue-router": "^4.0.12"
     },
     "dependencies": {


### PR DESCRIPTION
Reverting the vue update from https://github.com/PrefectHQ/prefect-ui-library/pull/1985

~~Not working as expected. Works fine when package is linked locally but does not when installed from npm. The changes in that PR that are not the vue update are still valid.~~

This was premature. nebula-ui wasn't on the version of ui-library that included the fixes in this PR. Updated ui-library to latest and the issue went away. I reverted this revert. 