### PR TITLE
Fix converting saved search filters to a LocationQuery

### DIFF
--- a/src/components/FlowRunsPageWithDefaultFilter.vue
+++ b/src/components/FlowRunsPageWithDefaultFilter.vue
@@ -5,15 +5,16 @@
 <script lang="ts">
   import { defineComponent, shallowRef, watch } from 'vue'
   import { NavigationGuard, RouteComponent } from 'vue-router'
-  import { isEmptyObject, mapper, getQueryForFlowRunsFilter, isFunction } from '..'
+  import { isEmptyObject, mapper, isFunction } from '..'
   import { useDefaultSavedSearchFilter } from '@/compositions/useDefaultSavedSearchFilter'
 
   const setDefaultFlowRunsFilterQueryIfEmpty: NavigationGuard = (to) => {
     const { value: defaultFlowRunsSavedSearchFilter, isCustom } = useDefaultSavedSearchFilter()
+
     if (isEmptyObject(to.query) && isCustom.value) {
-      const asFlowRunsFilter = mapper.map('SavedSearchFilter', defaultFlowRunsSavedSearchFilter.value, 'FlowRunsFilter')
-      const asQueryParams = getQueryForFlowRunsFilter(asFlowRunsFilter)
-      return { ...to, query: asQueryParams }
+      const query = mapper.map('SavedSearchFilter', defaultFlowRunsSavedSearchFilter.value, 'LocationQuery')
+
+      return { ...to, query }
     }
     return true
   }

--- a/src/maps/index.ts
+++ b/src/maps/index.ts
@@ -39,7 +39,7 @@ import { mapNotificationUpdateToNotificationUpdateRequest } from '@/maps/notific
 import { mapNumberToString, mapStringToNumber } from '@/maps/number'
 import { mapOrchestrationResultResponseToOrchestrationResult } from '@/maps/orchestrationResult'
 import { mapRunGraphDataResponse, mapRunGraphNodeResponse } from '@/maps/runGraphData'
-import { mapSavedSearchResponseToSavedSearch } from '@/maps/savedSearch'
+import { mapSavedSearchResponseToSavedSearch, mapSavedSearchToLocationQuery } from '@/maps/savedSearch'
 import { mapSavedSearchCreateToSavedSearchCreateRequest } from '@/maps/savedSearchCreate'
 import { mapSavedSearchFilterToFlowRunsFilter } from '@/maps/savedSearchFilter'
 import { mapUiFlowRunHistoryToScatterPlotItem } from '@/maps/scatterPlotItem'
@@ -137,7 +137,10 @@ export const maps = {
   RunHistory: { FlowRunHistoryResponse: mapRunHistoryToFlowRunHistoryResponse, DivergingBarChartItem: mapRunHistoryToDivergingBarChartItem },
   SavedSearchCreate: { SavedSearchCreateRequest: mapSavedSearchCreateToSavedSearchCreateRequest },
   SavedSearchesFilter: { SavedSearchesFilterRequest: mapSavedSearchesFilter },
-  SavedSearchFilter: { FlowRunsFilter: mapSavedSearchFilterToFlowRunsFilter },
+  SavedSearchFilter: {
+    FlowRunsFilter: mapSavedSearchFilterToFlowRunsFilter,
+    LocationQuery: mapSavedSearchToLocationQuery,
+  },
   SavedSearchResponse: { SavedSearch: mapSavedSearchResponseToSavedSearch },
   Schedule: { ScheduleResponse: mapScheduleToScheduleResponse, ScheduleRequest: mapScheduleToScheduleRequest },
   ScheduleResponse: { Schedule: mapScheduleResponseToSchedule },

--- a/src/maps/savedSearch.ts
+++ b/src/maps/savedSearch.ts
@@ -1,4 +1,5 @@
 import { DateRangeSelectAroundValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue, DateRangeSelectPeriodValue } from '@prefecthq/prefect-design'
+import { LocationQuery } from 'vue-router'
 import { SavedSearchFilterResponse, SavedSearchResponse, isDateRangeResponse, isDateRangeRangeResponse, isDateRangeAroundResponse, isDateRangeSpanResponse, isDateRangePeriodResponse } from '@/models/api/SavedSearchResponse'
 import { SavedSearch, SavedSearchFilter } from '@/models/SavedSearch'
 import { MapFunction, mapper } from '@/services/Mapper'
@@ -10,6 +11,64 @@ export const mapSavedSearchResponseToSavedSearch: MapFunction<SavedSearchRespons
     name: source.name,
     filters: mapSavedSearchFilters(source.filters),
   })
+}
+
+export const mapSavedSearchToLocationQuery: MapFunction<SavedSearchFilter, LocationQuery> = function(filter) {
+  const query: LocationQuery = {}
+
+  if (filter.deployment.length) {
+    query.deployment = filter.deployment
+  }
+
+  if (filter.flow.length) {
+    query.flow = filter.flow
+  }
+
+  if (filter.workPool.length) {
+    query.workPool = filter.workPool
+  }
+
+  if (filter.workQueue.length) {
+    query.workQueue = filter.workQueue
+  }
+
+  if (filter.tag.length) {
+    query.tag = filter.tag
+  }
+
+  if (filter.state.length) {
+    query.state = filter.state
+  }
+
+  const { range } = filter
+
+  switch (range.type) {
+    case 'around':
+      query.type = 'around'
+      query.date = this.map('Date', range.date, 'string')
+      query.unit = range.unit
+      query.quantity = range.quantity.toString()
+      break
+    case 'period':
+      query.type = 'period'
+      query.period = range.period
+      break
+    case 'range':
+      query.type = 'range'
+      query.startDate = this.map('Date', range.startDate, 'string')
+      query.endDate = this.map('Date', range.endDate, 'string')
+      break
+    case 'span':
+      query.type = 'span'
+      query.seconds = range.seconds.toString()
+      break
+    default:
+      const exhaustive: never = range
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      throw new Error(`Mapping saved search filters.range missing case for: ${(exhaustive as any).type}`)
+  }
+
+  return query
 }
 
 function mapSavedSearchFilters(filters: SavedSearchFilterResponse[] = []): SavedSearchFilter {


### PR DESCRIPTION
# Description
With the recent update to the flow runs page filters the actual query params used changed. The existing logic converted the saved filters into a `FlowRunsFilter` which no longer matches the expected query the page wants. So essentially going to the flow runs page when you had a custom default filter did nothing. This fixes that by updating the logic for loading the default into the url. 

This is a little forced, but there isn't an existing utility that really works here. So wrote a custom mapper to handle this. 