### PR TITLE
Add a try catch when mapping saved filters in case of malformed data

### DIFF
--- a/src/services/WorkspaceSavedSearchesApi.ts
+++ b/src/services/WorkspaceSavedSearchesApi.ts
@@ -1,3 +1,4 @@
+import { isDefined } from '@prefecthq/prefect-design'
 import { SavedSearchResponse } from '@/models/api/SavedSearchResponse'
 import { SavedSearchesFilter } from '@/models/Filters'
 import { SavedSearch, SavedSearchCreate } from '@/models/SavedSearch'
@@ -11,7 +12,18 @@ export class WorkspaceSavedSearchesApi extends WorkspaceApi {
   public async getSavedSearches(filter: SavedSearchesFilter = {}): Promise<SavedSearch[]> {
     const request = mapper.map('SavedSearchesFilter', filter, 'SavedSearchesFilterRequest')
     const { data } = await this.post<SavedSearchResponse[]>('/filter', request)
-    return mapper.map('SavedSearchResponse', data, 'SavedSearch')
+
+    const mapped = data.map(savedSearch => {
+      try {
+        return mapper.map('SavedSearchResponse', savedSearch, 'SavedSearch')
+      } catch (error) {
+        console.error(error)
+      }
+
+      return undefined
+    }).filter(isDefined)
+
+    return mapped
   }
 
   public async getSavedSearch(id: string): Promise<SavedSearch> {


### PR DESCRIPTION
# Description
Working through some ideas for community reports that I'm unable to reproduce. Since the saved search endpoint is a json blob there's always a chance that the data returned won't match the expected type. Adding a try catch around that to filter out any malformed filters. 