### PR TITLE
Fix block document input not picking up the schema

### DIFF
--- a/src/components/BlockCreateModal.vue
+++ b/src/components/BlockCreateModal.vue
@@ -80,9 +80,7 @@
   const blockTypes = computed(() => blockTypesSubscription.response ?? [])
   const filteredBlockTypes = computed(() => [...blockTypes.value].filter(blockType => blockType.name !== 'Slack Incoming Webhook'))
 
-
-  const blockSchemaSubscription = computed(() => useBlockSchemaForBlockType(blockType.value?.id))
-  const blockSchema = computed(() => blockSchemaSubscription.value.blockSchema.value)
+  const { blockSchema } = useBlockSchemaForBlockType(() => blockType.value?.id)
 
   const submit = async (request: BlockDocumentCreateNamed): Promise<void> => {
     try {


### PR DESCRIPTION
# Description
When using the block document input component you could end up with an empty modal if no blocks existed because the block schema form would fail to load. Fixed by using the `useBlockTypeSchema` composition correctly

Before
<img width="1315" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/30ab8fa1-6c45-40f9-bd65-d2f7a33b1377">

After
<img width="1345" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/2e003fff-e369-421b-bc66-f0ecc567bc77">
