### PR TITLE
Enhancement: use `PCombobox` instead of `PSelect` for enum-backed schema properties

### DIFF
--- a/src/services/schemas/properties/SchemaPropertyArray.ts
+++ b/src/services/schemas/properties/SchemaPropertyArray.ts
@@ -1,4 +1,4 @@
-import { PSelect } from '@prefecthq/prefect-design'
+import { PCombobox } from '@prefecthq/prefect-design'
 import { JsonInput } from '@/components'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
@@ -14,7 +14,7 @@ export class SchemaPropertyArray extends SchemaPropertyService {
     const options = this.getSelectOptions()
 
     if (options.length) {
-      return this.withProps(PSelect, { options })
+      return this.withProps(PCombobox, { options })
     }
 
     return this.withProps(JsonInput)

--- a/src/services/schemas/properties/SchemaPropertyInteger.ts
+++ b/src/services/schemas/properties/SchemaPropertyInteger.ts
@@ -1,4 +1,4 @@
-import { PNumberInput, PSelect } from '@prefecthq/prefect-design'
+import { PNumberInput, PCombobox } from '@prefecthq/prefect-design'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue } from '@/types/schemas'
@@ -11,7 +11,7 @@ export class SchemaPropertyInteger extends SchemaPropertyService {
 
   protected override get component(): SchemaPropertyComponentWithProps {
     if (this.has('enum')) {
-      return this.withProps(PSelect, {
+      return this.withProps(PCombobox, {
         options: this.getSelectOptions(),
       })
     }

--- a/src/services/schemas/properties/SchemaPropertyNumber.ts
+++ b/src/services/schemas/properties/SchemaPropertyNumber.ts
@@ -1,4 +1,4 @@
-import { PNumberInput, PSelect } from '@prefecthq/prefect-design'
+import { PNumberInput, PCombobox } from '@prefecthq/prefect-design'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaPropertyInputAttrs, SchemaValue } from '@/types/schemas'
@@ -11,7 +11,7 @@ export class SchemaPropertyNumber extends SchemaPropertyService {
 
   protected override get component(): SchemaPropertyComponentWithProps {
     if (this.has('enum')) {
-      return this.withProps(PSelect, {
+      return this.withProps(PCombobox, {
         options: this.getSelectOptions(),
       })
     }

--- a/src/services/schemas/properties/SchemaPropertyString.ts
+++ b/src/services/schemas/properties/SchemaPropertyString.ts
@@ -1,4 +1,4 @@
-import { PNumberInput, PSelect, PTextInput, PDateInput } from '@prefecthq/prefect-design'
+import { PNumberInput, PCombobox, PTextInput, PDateInput } from '@prefecthq/prefect-design'
 import { format, isValid, parseISO } from 'date-fns'
 import DateInput from '@/components/DateInput.vue'
 import JsonInput from '@/components/JsonInput.vue'
@@ -15,7 +15,7 @@ export class SchemaPropertyString extends SchemaPropertyService {
 
   protected override get component(): SchemaPropertyComponentWithProps {
     if (this.has('enum')) {
-      return this.withProps(PSelect, {
+      return this.withProps(PCombobox, {
         options: this.getSelectOptions(),
       })
     }
@@ -37,7 +37,7 @@ export class SchemaPropertyString extends SchemaPropertyService {
   }
 
   protected override get default(): SchemaValue {
-    if (this.componentIs(PSelect)) {
+    if (this.componentIs(PCombobox)) {
       return this.property.default ?? null
     }
 

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -2,6 +2,7 @@ import { JsonInput } from '@/components'
 import { isBlockDocumentReferenceValue, isBlockDocumentValue } from '@/models'
 import { schemaPropertyServiceFactory } from '@/services/schemas/properties'
 import { SchemaProperty, SchemaPropertyInputAttrs, Schema, SchemaValues, SchemaValue, schemaHas, SchemaPropertyAnyOf, SchemaPropertyAllOf } from '@/types/schemas'
+import { isArray } from '@/utilities'
 import { withPropsWithoutExcludedFactory } from '@/utilities/components'
 import { stringify } from '@/utilities/json'
 import { isRecord } from '@/utilities/object'
@@ -111,6 +112,10 @@ export function getSchemaPropertyPlaceholder(property: SchemaProperty): string |
 
   if (typeof placeholder === 'string') {
     return placeholder
+  }
+
+  if (isArray(placeholder)) {
+    return placeholder.join(', ')
   }
 
   return stringify(placeholder)


### PR DESCRIPTION
`PCombobox` works as a drop-in replacement for `PSelect` (since it wraps the component under the hood) BUT also provides the ability to search/filter over any of the params in-memory. This PR replaces calls to `PSelect` in the schema property definitions with `PCombobox` to take advantage of this:

Before (multiselect):
![Screenshot 2024-01-16 at 4 57 05 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/5348c8e4-ca33-4584-a015-261298dee9d8)

After (multiselect):
![Screenshot 2024-01-16 at 5 18 14 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/b7060db2-59fc-4646-9479-a5e3c050ffd8)

Before:
![Screenshot 2024-01-16 at 5 20 33 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/d3c77705-c5d3-4c8a-a86a-58204c9c0d36)

After:
![Screenshot 2024-01-16 at 5 20 09 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/beddbc7d-6eaf-4347-b8e2-63f567a4df2c)

