### PR TITLE
Fix the font size for schema input descriptions

### DIFF
--- a/src/components/SchemaFormInput.vue
+++ b/src/components/SchemaFormInput.vue
@@ -3,7 +3,7 @@
     <template #description>
       <div class="schema-form-input__description">
         <template v-if="property.description">
-          <p-markdown-renderer :text="property.description" />
+          <p-markdown-renderer :text="property.description" class="schema-form-input__markdown" />
         </template>
 
         <template v-if="isNullType">
@@ -63,5 +63,10 @@
 
 .schema-form-input__description {
   overflow-wrap: anywhere;
+}
+
+.schema-form-input__markdown { @apply
+  text-subdued
+  text-sm
 }
 </style>


### PR DESCRIPTION
# Description
The markdown component used to render property descriptions defaults to font-md but label descriptions are supposed to be font-sm. Updating the input component to specific the font size fixes the descriptions so they're the correct size. 

Before
<img width="576" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/b77b890a-6698-498c-909e-8a04913be54c">

After
<img width="575" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/cacd7b3a-55e8-4628-8849-088fe0375d01">
