### PR TITLE
Bugfix: Prevent leading slot from blowing out the page heading grid

### DIFF
--- a/src/components/PageHeading.vue
+++ b/src/components/PageHeading.vue
@@ -46,6 +46,7 @@
   flex
   flex-col
   gap-2
+  min-w-0
 }
 
 .page-heading__crumbs { @apply


### PR DESCRIPTION
The trailing slot is already working as intended

Before:
![Screenshot 2024-01-17 at 2 55 17 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/b0ca3211-9fb7-456e-8a38-f850c39fb12a)

After:
![Screenshot 2024-01-17 at 2 56 52 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/b74519b6-878f-4782-82fc-29a461c0ca75)


Resolves: https://github.com/PrefectHQ/prefect/issues/11659