### PR TITLE
Fix:  Use the same icon in the extra info modal and tooltip components for consistency

### DIFF
--- a/src/components/ExtraInfoModal.vue
+++ b/src/components/ExtraInfoModal.vue
@@ -1,6 +1,6 @@
 <template>
   <button class="extra-info-modal" v-bind="attrs" type="button" @click.stop.prevent="open">
-    <p-icon icon="InformationCircleIcon" solid class="extra-info-modal__icon" />
+    <p-icon icon="InformationCircleIcon" class="extra-info-modal__icon" />
   </button>
   <p-modal v-model:show-modal="showModal" :title="title">
     <slot />

--- a/src/components/ExtraInfoModal.vue
+++ b/src/components/ExtraInfoModal.vue
@@ -1,6 +1,6 @@
 <template>
   <button class="extra-info-modal" v-bind="attrs" type="button" @click.stop.prevent="open">
-    <p-icon icon="QuestionMarkCircleIcon" solid />
+    <p-icon icon="InformationCircleIcon" solid class="extra-info-modal__icon" />
   </button>
   <p-modal v-model:show-modal="showModal" :title="title">
     <slot />
@@ -40,5 +40,9 @@
   pl-1
   align-middle
   -translate-y-[10%]
+}
+
+.extra-info-modal__icon { @apply
+  cursor-help
 }
 </style>


### PR DESCRIPTION
Updates the extra info modal to use the same icon as extra info tooltip. 

Closes https://github.com/PrefectHQ/nebula-ui/issues/4076

<img width="1048" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/db0bbce3-6e0f-4efe-8390-b11e9d4d31e8">
