### PR TITLE
Chore: Check the component type before returning a joined placeholder

### DIFF
--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -114,7 +114,7 @@ export function getSchemaPropertyPlaceholder(property: SchemaProperty): string |
     return placeholder
   }
 
-  if (isArray(placeholder)) {
+  if (isArray(placeholder) && property.meta?.component !== JsonInput) {
     return placeholder.join(', ')
   }
 


### PR DESCRIPTION
#2004 slightly changed the way placeholders for list properties were displayed by joining list defaults. This didn't account for the fact that certain unstructured lists use only `JsonInput` components and so should in fact display the placeholder as JSON. This update checks the component type before returning the joined placeholder list and falls back to the stringified default as previous in cases where the JsonInput is in use.