### PR TITLE
Bugfix: Make sure tags column can respect width

### DIFF
--- a/src/components/DeploymentsList.vue
+++ b/src/components/DeploymentsList.vue
@@ -46,7 +46,9 @@
 
       <template #tags="{ row }">
         <template v-if="row.tags">
-          <p-tag-wrapper :tags="row.tags" justify="left" />
+          <div class="deployment-list__tags">
+            <p-tag-wrapper :tags="row.tags" justify="left" />
+          </div>
         </template>
       </template>
 
@@ -172,7 +174,6 @@
     },
     {
       label: 'Tags',
-      width: '100px',
       visible: media.md,
     },
     {
@@ -248,5 +249,10 @@
 
 .deployment-list__menu { @apply
   ml-2
+}
+
+.deployment-list__tags { @apply
+  max-w-80
+  min-w-0
 }
 </style>


### PR DESCRIPTION
There's an issue in prefect-design where column styles aren't being applied outside of the header. I'm not sure if that's intentional or where we might be implicitly relying on that behavior so for now this will resolve the immediate issue of tags overflowing on the deployments table.

Before:
![Screenshot 2024-01-23 at 10 33 30 AM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/4a99b268-dbdf-4bd6-9278-faa87afbd4ef)

After:
![Screenshot 2024-01-23 at 10 32 15 AM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/606cd21b-9f79-4d3e-a305-c05403fcf071)


Resolves: https://github.com/PrefectHQ/prefect/issues/11710