### PR TITLE
Enhancement: Always create blocks in modals from the block document input

### DIFF
--- a/src/components/BlockCreateModal.vue
+++ b/src/components/BlockCreateModal.vue
@@ -58,14 +58,6 @@
     'block-create-modal--schema-creation': blockType.value,
   }))
 
-  const title = computed(() => {
-    if (props.providedBlockType) {
-      return `Add a new ${props.providedBlockType.name} block`
-    }
-
-    return 'Add a new block'
-  })
-
   const handleAdd = (selectedBlockType: BlockType): void => {
     blockType.value = selectedBlockType
   }

--- a/src/components/BlockCreateModal.vue
+++ b/src/components/BlockCreateModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-modal v-model:showModal="internalShowModal" class="block-create-modal" :class="modalClass" title="Add a new block">
+  <p-modal v-model:showModal="internalShowModal" class="block-create-modal" :class="classes" title="Add a new block">
     <BlockTypeList
       v-if="!blockType"
       :capability="capability"
@@ -10,17 +10,25 @@
     />
 
     <template v-if="blockType">
-      <BlockSchemaCreateForm v-if="blockSchema" :key="blockSchema.id" :block-schema="blockSchema" @cancel="cancel" @submit="submit" />
+      <p-heading heading="4">
+        {{ blockType.name }}
+      </p-heading>
+      <BlockSchemaCreateForm v-if="blockSchema" :id="formId" :block-schema="blockSchema" hide-footer @submit="submit" />
+    </template>
+
+    <template #actions>
+      <SubmitButton action="Create" :form-id="formId" />
     </template>
   </p-modal>
 </template>
 
 <script lang="ts" setup>
-  import { showToast } from '@prefecthq/prefect-design'
+  import { randomId, showToast } from '@prefecthq/prefect-design'
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { ref, computed } from 'vue'
   import BlockSchemaCreateForm from '@/components/BlockSchemaCreateForm.vue'
   import BlockTypeList from '@/components/BlockTypeList.vue'
+  import SubmitButton from '@/components/SubmitButton.vue'
   import { useWorkspaceApi, useBlockSchemaForBlockType } from '@/compositions'
   import { useBlockTypesFilter } from '@/compositions/filters'
   import { localization } from '@/localization'
@@ -44,13 +52,18 @@
 
   const blockType = ref(props.providedBlockType)
   const capability = ref(props.capability ?? '')
+  const formId = randomId()
 
+  const classes = computed(() => ({
+    'block-create-modal--schema-creation': blockType.value,
+  }))
 
-  const modalClass = computed(() => {
-    if (blockType.value) {
-      return 'block-create-modal--schema-creation'
+  const title = computed(() => {
+    if (props.providedBlockType) {
+      return `Add a new ${props.providedBlockType.name} block`
     }
-    return ''
+
+    return 'Add a new block'
   })
 
   const handleAdd = (selectedBlockType: BlockType): void => {
@@ -66,10 +79,6 @@
       emit('update:showModal', value)
     },
   })
-
-  const cancel = (): void => {
-    internalShowModal.value = false
-  }
 
   const { filter } = useBlockTypesFilter({
     blockSchemas: {
@@ -95,13 +104,7 @@
 </script>
 
 <style>
-.block-create-modal__block-type-list .block-type-list__types {
-  @apply
+.block-create-modal__block-type-list .block-type-list__types { @apply
   grid-cols-1
-}
-
-.block-create-modal--schema-creation .p-modal__footer {
-  @apply
-  hidden
 }
 </style>

--- a/src/components/BlockDocumentInput.vue
+++ b/src/components/BlockDocumentInput.vue
@@ -5,10 +5,7 @@
     <template v-if="blockDocuments.length">
       <BlockDocumentCombobox v-model:selected="model" v-bind="{ blockDocuments }" class="block-document-input__select" />
     </template>
-    <p-button v-if="blockTypeSlug && useModal" icon-append="PlusIcon" @click="open">
-      Add
-    </p-button>
-    <p-button v-else-if="blockTypeSlug" icon-append="PlusIcon" :to="withRedirect(routes.blockCreate(props.blockTypeSlug))">
+    <p-button v-if="blockTypeSlug" icon-append="PlusIcon" @click="open">
       Add
     </p-button>
     <BlockCreateModal v-if="blockType" v-model:showModal="showModal" :provided-block-type="blockType" @refresh="handleRefresh" />
@@ -21,15 +18,13 @@
   import BlockCreateModal from '@/components/BlockCreateModal.vue'
   import BlockDocumentCombobox from '@/components/BlockDocumentCombobox.vue'
   import LogoImage from '@/components/LogoImage.vue'
-  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import { useWorkspaceApi } from '@/compositions'
   import { useShowModal } from '@/compositions/useShowModal'
   import { BlockDocument } from '@/models'
-  import { withRedirect } from '@/utilities/routes'
 
   const props = defineProps<{
     modelValue: string | null | undefined,
     blockTypeSlug: string,
-    useModal?: boolean,
   }>()
 
   const emit = defineEmits<{
@@ -47,7 +42,6 @@
 
   const { showModal, open, close } = useShowModal()
   const api = useWorkspaceApi()
-  const routes = useWorkspaceRoutes()
   const blockTypeSlug = computed(() => props.blockTypeSlug)
 
   const blockTypeSubscription = useSubscription(api.blockTypes.getBlockTypeBySlug, [blockTypeSlug])

--- a/src/components/BlockSchemaCreateForm.vue
+++ b/src/components/BlockSchemaCreateForm.vue
@@ -8,7 +8,7 @@
       <SchemaFormFields :schema="blockSchema.fields" property="data" />
     </p-content>
 
-    <template #footer>
+    <template v-if="!hideFooter" #footer>
       <p-button @click="cancel">
         Cancel
       </p-button>
@@ -33,6 +33,7 @@
 
   const props = defineProps<{
     blockSchema: BlockSchema,
+    hideFooter?: boolean,
   }>()
 
   const emit = defineEmits<{


### PR DESCRIPTION
# Description
When selecting a block in a schema form there's an "Add" button that allows you to create a new block to use. However this usually takes you away from the current page you're on and often loses the progress you've made on the current form. 

<img width="330" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/16dabc3d-7d0b-49e1-bd09-1d6546d616fd">

The ability to create the new block in a modal was added in https://github.com/PrefectHQ/prefect-ui-library/pull/1821 but it wasn't the default option because at the time we didn't have a way to handle nested blocks (where you cannot create a block without also creating a second block). https://github.com/PrefectHQ/prefect-design/pull/1093 gives us the ability to nicely open multiple modals at once. So now if a modal is used to create a block, and a second block needs to be created, that second block can also be created in a modal without creating an ugly UX.

This PR updates the "Add" button to always open in a modal. That way the user never loses their work and doesn't have to leave the current page. This will make creating work pools and block a much better user experience. 

<img width="596" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/07f2f4b3-0fa8-4878-acc9-8748bd25c3ed">