### PR TITLE
Add a try catch around converting the default filter to a location query

### DIFF
--- a/src/components/FlowRunsPageWithDefaultFilter.vue
+++ b/src/components/FlowRunsPageWithDefaultFilter.vue
@@ -12,10 +12,15 @@
     const { value: defaultFlowRunsSavedSearchFilter, isCustom } = useDefaultSavedSearchFilter()
 
     if (isEmptyObject(to.query) && isCustom.value) {
-      const query = mapper.map('SavedSearchFilter', defaultFlowRunsSavedSearchFilter.value, 'LocationQuery')
+      try {
+        const query = mapper.map('SavedSearchFilter', defaultFlowRunsSavedSearchFilter.value, 'LocationQuery')
 
-      return { ...to, query }
+        return { ...to, query }
+      } catch (error) {
+        console.error(error)
+      }
     }
+
     return true
   }
 


### PR DESCRIPTION
# Description
Attempting to fix where the flow runs page doesn't load when there is an issue with a default filter. 