### PR TITLE
Core components for Schemas V2

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,7 @@
     }
   },
   "rules": {
-    "import/no-default-export": "error"
+    "import/no-default-export": "error",
+    "camelcase": ["error", { "allow": ["__prefect_kind"] }]
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from './router'
 export * from './services'
 export * from './types'
 export * from './utilities'
+export * from './schemas'
 
 import '@/styles/style.css'
 

--- a/src/schemas/components/SchemaForm.vue
+++ b/src/schemas/components/SchemaForm.vue
@@ -1,0 +1,35 @@
+<template>
+  <p-form class="schema-form">
+    <template v-if="schema.properties">
+      <SchemaFormProperties v-model:values="values" :parent="schema" :properties="schema.properties" />
+    </template>
+  </p-form>
+</template>
+
+<script lang="ts" setup>
+  import { provide, computed } from 'vue'
+  import SchemaFormProperties from '@/schemas/components/SchemaFormProperties.vue'
+  import { schemaInjectionKey } from '@/schemas/compositions/useSchema'
+  import { Schema } from '@/schemas/types/schema'
+  import { SchemaValues } from '@/schemas/types/schemaValues'
+
+  const props = defineProps<{
+    schema: Schema,
+    values: SchemaValues,
+  }>()
+
+  provide(schemaInjectionKey, props.schema)
+
+  const emit = defineEmits<{
+    'update:values': [SchemaValues],
+  }>()
+
+  const values = computed({
+    get() {
+      return props.values
+    },
+    set(values) {
+      emit('update:values', values)
+    },
+  })
+</script>

--- a/src/schemas/components/SchemaFormKindInput.vue
+++ b/src/schemas/components/SchemaFormKindInput.vue
@@ -1,0 +1,63 @@
+<template>
+  <component :is="input.component" v-bind="input.props" />
+</template>
+
+<script lang="ts" setup>
+  import { PCodeInput } from '@prefecthq/prefect-design'
+  import { computed } from 'vue'
+  import SchemaFormPropertyInput from '@/schemas/components/SchemaFormPropertyInput.vue'
+  import { SchemaProperty } from '@/schemas/types/schema'
+  import { PrefectKindValue, isPrefectKindJinja, isPrefectKindJson, isPrefectKindNull, isPrefectKindWorkspaceVariable } from '@/schemas/types/schemaValues'
+  import { withProps } from '@/utilities/components'
+
+  const props = defineProps<{
+    property: SchemaProperty,
+    value: PrefectKindValue,
+  }>()
+
+  const emit = defineEmits<{
+    'update:value': [PrefectKindValue],
+  }>()
+
+  const input = computed(() => {
+    if (isPrefectKindJinja(props.value)) {
+      return withProps(PCodeInput, {
+        lang: 'jinja',
+        modelValue: props.value.template,
+        'onUpdate:modelValue': template => emit('update:value', {
+          __prefect_kind: 'jinja',
+          template,
+        }),
+      })
+    }
+
+    if (isPrefectKindJson(props.value)) {
+      return withProps(PCodeInput, {
+        lang: 'json',
+        modelValue: props.value.value,
+        'onUpdate:modelValue': value => emit('update:value', {
+          __prefect_kind: 'json',
+          value,
+        }),
+      })
+    }
+
+    if (isPrefectKindWorkspaceVariable(props.value)) {
+      throw 'not implemented'
+    }
+
+    if (isPrefectKindNull(props.value)) {
+      return withProps(SchemaFormPropertyInput, {
+        property: props.property,
+        value: props.value.value,
+        'onUpdate:value': value => emit('update:value', {
+          __prefect_kind: null,
+          value,
+        }),
+      })
+    }
+
+    const exhaustive: never = props.value
+    throw new Error(`getPrefectKindInputComponent missing case for ${exhaustive}`)
+  })
+</script>

--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="schema-form-properties">
+    <template v-for="[key, property] in properties" :key="key">
+      <SchemaFormProperty
+        :value="getValue(key)"
+        :property="property"
+        :required="getRequired(key)"
+        @update:value="setValue(key, $event)"
+      />
+    </template>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import SchemaFormProperty from '@/schemas/components/SchemaFormProperty.vue'
+  import { SchemaProperty, SchemaProperties } from '@/schemas/types/schema'
+  import { SchemaValues } from '@/schemas/types/schemaValues'
+
+  const props = defineProps<{
+    parent: SchemaProperty,
+    properties: SchemaProperties,
+    values: SchemaValues,
+  }>()
+
+  const emit = defineEmits<{
+    'update:values': [SchemaValues],
+  }>()
+
+  const properties = computed(() => {
+    return Object.entries(props.properties).sort((entryA, entryB) => {
+      const [, propertyA] = entryA
+      const [, propertyB] = entryB
+      const { position: positionA = 0 } = propertyA
+      const { position: positionB = 0 } = propertyB
+
+      return positionA - positionB
+    })
+  })
+
+  function getValue(propertyKey: string): unknown {
+    return props.values[propertyKey] ?? null
+  }
+
+  function setValue(propertyKey: string, value: unknown): void {
+    emit('update:values', {
+      ...props.values,
+      [propertyKey]: value,
+    })
+  }
+
+  function getRequired(propertyKey: string): boolean {
+    return props.parent.required?.includes(propertyKey) ?? false
+  }
+</script>

--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -1,12 +1,41 @@
 <template>
   <div class="schema-form-properties">
     <template v-for="[key, property] in properties" :key="key">
-      <SchemaFormProperty
-        :value="getValue(key)"
-        :property="property"
-        :required="getRequired(key)"
-        @update:value="setValue(key, $event)"
-      />
+      <template v-if="isPropertyWith(property, '$ref')">
+        <SchemaFormProperty
+          :value="getValue(key)"
+          :property="getSchemaDefinition(schema, property.$ref)"
+          :required="getRequired(key)"
+          @update:value="setValue(key, $event)"
+        />
+      </template>
+
+      <template v-else-if="isPropertyWith(property, 'allOf')">
+        <SchemaFormPropertyAllOfInput
+          :value="getValue(key)"
+          :property="property"
+          :required="getRequired(key)"
+          @update:value="setValue(key, $event)"
+        />
+      </template>
+
+      <template v-else-if="isPropertyWith(property, 'anyOf')">
+        <SchemaFormPropertyAnyOfInput
+          :value="getValue(key)"
+          :property="property"
+          :required="getRequired(key)"
+          @update:value="setValue(key, $event)"
+        />
+      </template>
+
+      <template v-else>
+        <SchemaFormProperty
+          :value="getValue(key)"
+          :property="property"
+          :required="getRequired(key)"
+          @update:value="setValue(key, $event)"
+        />
+      </template>
     </template>
   </div>
 </template>
@@ -14,8 +43,12 @@
 <script lang="ts" setup>
   import { computed } from 'vue'
   import SchemaFormProperty from '@/schemas/components/SchemaFormProperty.vue'
-  import { SchemaProperty, SchemaProperties } from '@/schemas/types/schema'
+  import SchemaFormPropertyAllOfInput from '@/schemas/components/SchemaFormPropertyAllOfInput.vue'
+  import SchemaFormPropertyAnyOfInput from '@/schemas/components/SchemaFormPropertyAnyOfInput.vue'
+  import { useSchema } from '@/schemas/compositions/useSchema'
+  import { SchemaProperty, SchemaProperties, isPropertyWith } from '@/schemas/types/schema'
   import { SchemaValues } from '@/schemas/types/schemaValues'
+  import { getSchemaDefinition } from '@/schemas/utilities/definitions'
 
   const props = defineProps<{
     parent: SchemaProperty,
@@ -26,6 +59,8 @@
   const emit = defineEmits<{
     'update:values': [SchemaValues],
   }>()
+
+  const schema = useSchema()
 
   const properties = computed(() => {
     return Object.entries(props.properties).sort((entryA, entryB) => {

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -1,0 +1,54 @@
+<template>
+  <p-label class="schema-form-property" :label="label">
+    <template v-if="description" #description>
+      <div class="schema-form-property__description">
+        <p-markdown-renderer :text="description" class="schema-form-input__markdown" />
+      </div>
+    </template>
+
+    <SchemaFormPropertyInput v-model:value="value" :property="property" />
+  </p-label>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import SchemaFormPropertyInput from '@/schemas/components/SchemaFormPropertyInput.vue'
+  import { SchemaProperty } from '@/schemas/types/schema'
+  import { SchemaValue } from '@/schemas/types/schemaValues'
+
+  const props = defineProps<{
+    property: SchemaProperty,
+    value: SchemaValue,
+    required: boolean,
+  }>()
+
+  const emit = defineEmits<{
+    'update:value': [SchemaValue],
+  }>()
+
+  const value = computed({
+    get() {
+      return props.value
+    },
+    set(value) {
+      emit('update:value', value)
+    },
+  })
+
+  const label = computed(() => {
+    const title = props.property.title ?? ''
+
+    if (!props.required) {
+      return `${title} (Optional)`.trim()
+    }
+
+    return title
+  })
+
+  const description = computed(() => {
+    const { description = '' } = props.property
+    const descriptionWithNewlinesRemoved = description.replace(/\n/g, ' ')
+
+    return descriptionWithNewlinesRemoved
+  })
+</script>

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -47,7 +47,7 @@
 
   const description = computed(() => {
     const { description = '' } = props.property
-    const descriptionWithNewlinesRemoved = description.replace(/\n/g, ' ')
+    const descriptionWithNewlinesRemoved = description.replace(/\n(?!\n)/g, ' ')
 
     return descriptionWithNewlinesRemoved
   })

--- a/src/schemas/components/SchemaFormPropertyAllOfInput.vue
+++ b/src/schemas/components/SchemaFormPropertyAllOfInput.vue
@@ -1,0 +1,12 @@
+<template>
+  <span>TODO</span>
+</template>
+
+<script lang="ts" setup>
+  import { SchemaProperty } from '@/schemas/types/schema'
+  import { Require } from '@/types/utilities'
+
+  defineProps<{
+    property: Require<SchemaProperty, 'allOf'>,
+  }>()
+</script>

--- a/src/schemas/components/SchemaFormPropertyAnyOfInput.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOfInput.vue
@@ -1,0 +1,12 @@
+<template>
+  <span>TODO</span>
+</template>
+
+<script lang="ts" setup>
+  import { SchemaProperty } from '@/schemas/types/schema'
+  import { Require } from '@/types/utilities'
+
+  defineProps<{
+    property: Require<SchemaProperty, 'anyOf'>,
+  }>()
+</script>

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="schema-form-property-input">
+    <template v-if="isPrefectKindValue(value)">
+      <SchemaFormKindInput :value="value" :property="property" @update:value="emit('update:value', $event)" />
+    </template>
+    <template v-else>
+      <component :is="input.component" v-bind="input.props" />
+    </template>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { PNumberInput, PTextInput, PToggle } from '@prefecthq/prefect-design'
+  import { computed } from 'vue'
+  import SchemaFormKindInput from '@/schemas/components/SchemaFormKindInput.vue'
+  import SchemaFormProperties from '@/schemas/components/SchemaFormProperties.vue'
+  import { SchemaProperty, isSchemaPropertyType } from '@/schemas/types/schema'
+  import { SchemaValue, isPrefectKindValue } from '@/schemas/types/schemaValues'
+  import { withProps } from '@/utilities/components'
+  import { asType } from '@/utilities/types'
+
+  const props = defineProps<{
+    property: SchemaProperty,
+    value: SchemaValue,
+  }>()
+
+  const emit = defineEmits<{
+    'update:value': [SchemaValue],
+  }>()
+
+  function update(value: unknown): void {
+    emit('update:value', value)
+  }
+
+  const input = computed(() => {
+    const { type } = props.property
+    const value = props
+
+    if (isSchemaPropertyType(type, 'boolean')) {
+      return withProps(PToggle, {
+        modelValue: asType(value, Boolean),
+        'onUpdate:modelValue': update,
+      })
+    }
+
+    if (isSchemaPropertyType(type, 'string')) {
+      return withProps(PTextInput, {
+        modelValue: asType(value, String),
+        'onUpdate:modelValue': update,
+      })
+    }
+
+    if (isSchemaPropertyType(type, 'integer') || isSchemaPropertyType(type, 'number')) {
+      return withProps(PNumberInput, {
+        modelValue: asType(value, Number),
+        'onUpdate:modelValue': update,
+      })
+    }
+
+    if (isSchemaPropertyType(type, 'array')) {
+      // new list input from prefect-design
+      throw 'not implemented'
+    }
+
+    if (isSchemaPropertyType(type, 'object')) {
+      return withProps(SchemaFormProperties, {
+        parent: props.property,
+        properties: props.property.properties ?? {},
+        values: asType(value, Object),
+        'onUpdate:values': update,
+      })
+    }
+
+    if (isSchemaPropertyType(type, 'null')) {
+      return { component: null, props: {} }
+    }
+
+    if (isSchemaPropertyType(type, undefined)) {
+      throw 'not implemented'
+    }
+
+    const exhaustive: never = type
+    throw new Error(`SchemaFormPropertyInput missing case for ${exhaustive}`)
+  })
+</script>

--- a/src/schemas/compositions/useSchema.ts
+++ b/src/schemas/compositions/useSchema.ts
@@ -1,0 +1,14 @@
+import { InjectionKey, inject } from 'vue'
+import { Schema } from '@/schemas/types/schema'
+
+export const schemaInjectionKey: InjectionKey<Schema> = Symbol()
+
+export function useSchema(): Schema {
+  const schema = inject(schemaInjectionKey)
+
+  if (!schema) {
+    throw new Error('No schema was provided')
+  }
+
+  return schema
+}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,0 +1,3 @@
+import SchemaForm from '@/schemas/components/SchemaForm.vue'
+
+export { SchemaForm as SchemaFormV2 }

--- a/src/schemas/types/schema.ts
+++ b/src/schemas/types/schema.ts
@@ -1,3 +1,5 @@
+import { isDefined } from '@prefecthq/prefect-design'
+import { Simplify } from '@/types/utilities'
 import { createTuple } from '@/utilities'
 
 export const { values: schemaTypes, isValue: isSchemaType } = createTuple([
@@ -65,6 +67,12 @@ export type SchemaPropertyResponse = {
   title?: string,
   type?: SchemaPropertyType,
   // uniqueItems?: boolean,
+}
+
+export function isPropertyWith<
+  TKey extends keyof SchemaProperty
+>(value: SchemaProperty, property: TKey): value is Simplify<SchemaProperty & Required<Pick<SchemaProperty, TKey>>> {
+  return isDefined(value[property])
 }
 
 export type SchemaResponse = SchemaPropertyResponse & {

--- a/src/schemas/types/schema.ts
+++ b/src/schemas/types/schema.ts
@@ -1,6 +1,7 @@
 import { createTuple } from '@/utilities'
 
 export const { values: schemaTypes, isValue: isSchemaType } = createTuple([
+  'null',
   'string',
   'boolean',
   'integer',
@@ -9,7 +10,11 @@ export const { values: schemaTypes, isValue: isSchemaType } = createTuple([
   'object',
 ])
 
-export type SchemaType = typeof schemaTypes[number]
+export type SchemaPropertyType = typeof schemaTypes[number]
+
+export function isSchemaPropertyType<T extends SchemaPropertyType | undefined>(value: unknown, type: T): value is T {
+  return value === type
+}
 
 export const { values: schemaStringFormat, isValue: isSchemaStringFormat } = createTuple([
   'date',
@@ -58,7 +63,7 @@ export type SchemaPropertyResponse = {
   properties?: SchemaPropertiesResponse,
   required?: string[],
   title?: string,
-  type?: SchemaType,
+  type?: SchemaPropertyType,
   // uniqueItems?: boolean,
 }
 

--- a/src/schemas/types/schema.ts
+++ b/src/schemas/types/schema.ts
@@ -23,12 +23,18 @@ export const { values: schemaStringFormat, isValue: isSchemaStringFormat } = cre
 
 export type SchemaStringFormat = typeof schemaStringFormat[number]
 
-export type SchemaPropertiesResponse = Record<string, SchemaPropertyResponse | undefined>
-export type SchemaDefinitionsResponse = Record<string, SchemaPropertyResponse | undefined>
+export type SchemaPropertiesResponse = Record<string, SchemaPropertyResponse>
+export type SchemaDefinitionsResponse = Record<string, SchemaPropertyResponse>
+
+export type SchemaDefinition = `#/definitions/${string}`
 
 // Commented out properties are unused. Left here for future reference
 export type SchemaPropertyResponse = {
-  $ref?: `#/definitions/${string}`,
+  // prefect specific properties
+  position?: number,
+
+  // open api properties
+  $ref?: SchemaDefinition,
   anyOf?: SchemaPropertyResponse[],
   allOf?: SchemaPropertyResponse[],
   // oneOf?: SchemaPropertyResponse[],
@@ -61,4 +67,6 @@ export type SchemaResponse = SchemaPropertyResponse & {
 }
 
 // For now these are the same. Once we get to block references and secrets there will be some snake to camel case conversions
+export type SchemaProperties = SchemaPropertiesResponse
+export type SchemaProperty = SchemaPropertyResponse
 export type Schema = SchemaResponse

--- a/src/schemas/types/schemaValues.ts
+++ b/src/schemas/types/schemaValues.ts
@@ -1,3 +1,4 @@
+import { Simplify } from '@/types/utilities'
 import { isRecord, isString } from '@/utilities'
 import { createTuple } from '@/utilities/tuples'
 
@@ -13,14 +14,16 @@ export const { values: prefectKinds, isValue: isPrefectKind } = createTuple([
 
 export type PrefectKind = typeof prefectKinds[number]
 
-export type PrefectKindValue<
-  TKind extends PrefectKind,
+type BasePrefectKindValue<
+  TKind extends PrefectKind = PrefectKind,
   TRest extends Record<string, unknown> = Record<string, unknown>
 > = {
   __prefect_kind: TKind,
 } & TRest
 
-export function isPrefectKindValue<T extends PrefectKind = PrefectKind>(value: unknown, kind?: T): value is PrefectKindValue<T> {
+export type PrefectKindValue = PrefectKindNull | PrefectKindJinja | PrefectKindJson | PrefectKindWorkspaceVariable
+
+export function isPrefectKindValue<T extends PrefectKind = PrefectKind>(value: unknown, kind?: T): value is Simplify<PrefectKindValue & { __prefect_kind: T }> {
   const isKindObject = isRecord(value) && isPrefectKind(value.__prefect_kind)
 
   if (!isKindObject) {
@@ -34,7 +37,7 @@ export function isPrefectKindValue<T extends PrefectKind = PrefectKind>(value: u
   return true
 }
 
-export type PrefectKindNull = PrefectKindValue<null, {
+export type PrefectKindNull = BasePrefectKindValue<null, {
   value: unknown,
 }>
 
@@ -42,7 +45,7 @@ export function isPrefectKindNull(value: unknown): value is PrefectKindNull {
   return isPrefectKindValue(value, null) && 'value' in value
 }
 
-export type PrefectKindJson = PrefectKindValue<'json', {
+export type PrefectKindJson = BasePrefectKindValue<'json', {
   value: string,
 }>
 
@@ -50,7 +53,7 @@ export function isPrefectKindJson(value: unknown): value is PrefectKindJson {
   return isPrefectKindValue(value, 'json') && isString(value.value)
 }
 
-export type PrefectKindJinja = PrefectKindValue<'jinja', {
+export type PrefectKindJinja = BasePrefectKindValue<'jinja', {
   template: string,
 }>
 
@@ -58,7 +61,7 @@ export function isPrefectKindJinja(value: unknown): value is PrefectKindJinja {
   return isPrefectKindValue(value, 'jinja') && isString(value.template)
 }
 
-export type PrefectKindWorkspaceVariable = PrefectKindValue<'workspace_variable', {
+export type PrefectKindWorkspaceVariable = BasePrefectKindValue<'workspace_variable', {
   variable_name: string,
 }>
 

--- a/src/schemas/types/schemaValues.ts
+++ b/src/schemas/types/schemaValues.ts
@@ -1,7 +1,8 @@
 import { isRecord, isString } from '@/utilities'
 import { createTuple } from '@/utilities/tuples'
 
-export type SchemaValues = Record<string, unknown>
+export type SchemaValue = unknown
+export type SchemaValues = Record<string, SchemaValue>
 
 export const { values: prefectKinds, isValue: isPrefectKind } = createTuple([
   null,

--- a/src/schemas/utilities/definitions.ts
+++ b/src/schemas/utilities/definitions.ts
@@ -1,0 +1,8 @@
+import { Schema, SchemaDefinition, SchemaProperty } from '@/schemas/types/schema'
+
+export function getSchemaDefinition(schema: Schema, definition: SchemaDefinition): SchemaProperty {
+  const definitionKey = definition.replace('#/definitions/', '')
+  const definitionSchema = schema.definitions?.[definitionKey]
+
+  return definitionSchema ?? {}
+}

--- a/src/schemas/utilities/definitions.ts
+++ b/src/schemas/utilities/definitions.ts
@@ -4,5 +4,9 @@ export function getSchemaDefinition(schema: Schema, definition: SchemaDefinition
   const definitionKey = definition.replace('#/definitions/', '')
   const definitionSchema = schema.definitions?.[definitionKey]
 
-  return definitionSchema ?? {}
+  if (!definitionSchema) {
+    throw new Error(`Definition not found for ${definition}`)
+  }
+
+  return definitionSchema
 }

--- a/src/schemas/utilities/properties.ts
+++ b/src/schemas/utilities/properties.ts
@@ -1,7 +1,0 @@
-import { SchemaProperty } from '@/schemas/types/schema'
-
-export function getPropertyPosition(property: SchemaProperty): number {
-  const { position = 0 } = property
-
-  return position
-}

--- a/src/schemas/utilities/properties.ts
+++ b/src/schemas/utilities/properties.ts
@@ -1,0 +1,7 @@
+import { SchemaProperty } from '@/schemas/types/schema'
+
+export function getPropertyPosition(property: SchemaProperty): number {
+  const { position = 0 } = property
+
+  return position
+}

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -28,3 +28,8 @@ export type NumberRange<
   )
 
 export type MaybeArray<T> = T | T[]
+
+// Converts types like { A: boolean } & { B: number } & { C: string } into a { A: boolean, B: number, C: string}
+export type Simplify<T> = {
+  [KeyType in keyof T]: T[KeyType]
+} & {}

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -30,6 +30,6 @@ export type NumberRange<
 export type MaybeArray<T> = T | T[]
 
 // Converts types like { A: boolean } & { B: number } & { C: string } into a { A: boolean, B: number, C: string}
-export type Simplify<T> = {
-  [KeyType in keyof T]: T[KeyType]
-} & {}
+// this type is somewhat magical and don't wanna mess with the {}
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type Simplify<T> = { [K in keyof T]: T[K] } & {}

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -1,0 +1,7 @@
+export function asType<T extends() => unknown>(value: unknown, type: T): ReturnType<T> | null {
+  if (typeof value === typeof type()) {
+    return value as ReturnType<T>
+  }
+
+  return null
+}


### PR DESCRIPTION
# Description
Adds the component structure for rendering dynamic forms based on a prefect schema. I stopped when I got to things like `anyOf` and `allOf` because this PR was already getting pretty large. But a lot of this is boilerplate props and v-models. 

Important distinction between this PR and the existing schema components is
- No client side validation (no vee-validate OR useValidation)
- v-models 🐐 
- Intentionally not supporting every possibility OpenApi allows for but optimizing for schemas that are actually possible to generate from Pydantic
- Not mapping schemas or schema values
- Not pre resolving definitions (they are resolved as needed)