### PR TITLE
Fix create block modal not submitting the form

### DIFF
--- a/src/components/BlockCreateModal.vue
+++ b/src/components/BlockCreateModal.vue
@@ -16,8 +16,8 @@
       <BlockSchemaCreateForm v-if="blockSchema" :id="formId" :block-schema="blockSchema" hide-footer @submit="submit" />
     </template>
 
-    <template #actions>
-      <SubmitButton action="Create" :form-id="formId" />
+    <template v-if="blockSchema" #actions>
+      <SubmitButton action="Create" :form="formId" />
     </template>
   </p-modal>
 </template>


### PR DESCRIPTION
# Description
The submit button on the create block modal had the wrong attribute for linking the submit button to the form. Fixing that and also not showing the submit button unless the block schema form is being showing. 

closes: https://github.com/PrefectHQ/prefect-ui-library/issues/2029