### PR TITLE
Add basic support for `anyOf` for schema properties

### DIFF
--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="schema-form-properties">
+  <p-content class="schema-form-properties">
     <template v-for="[key, property] in properties" :key="key">
       <template v-if="isPropertyWith(property, '$ref')">
         <SchemaFormProperty
@@ -37,7 +37,7 @@
         />
       </template>
     </template>
-  </div>
+  </p-content>
 </template>
 
 <script lang="ts" setup>

--- a/src/schemas/components/SchemaFormPropertyAnyOfInput.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOfInput.vue
@@ -1,12 +1,67 @@
 <template>
-  <span>TODO</span>
+  <div class="schema-form-property-any-of-input">
+    <p-button-group v-model="selected" :options="options" small />
+  </div>
+
+  <p-card>
+    <SchemaFormProperty v-model:value="value" :property="property" :required="required" />
+  </p-card>
 </template>
 
 <script lang="ts" setup>
-  import { SchemaProperty } from '@/schemas/types/schema'
+  import { ButtonGroupOption } from '@prefecthq/prefect-design'
+  import { computed, ref } from 'vue'
+  import SchemaFormProperty from '@/schemas/components/SchemaFormProperty.vue'
+  import { useSchema } from '@/schemas/compositions/useSchema'
+  import { SchemaProperty, isPropertyWith } from '@/schemas/types/schema'
+  import { SchemaValue } from '@/schemas/types/schemaValues'
+  import { getSchemaDefinition } from '@/schemas/utilities/definitions'
   import { Require } from '@/types/utilities'
 
-  defineProps<{
+  const props = defineProps<{
     property: Require<SchemaProperty, 'anyOf'>,
+    value: SchemaValue,
+    required: boolean,
   }>()
+
+  const emit = defineEmits<{
+    'update:value': [SchemaValue],
+  }>()
+
+  const value = computed({
+    get() {
+      return props.value
+    },
+    set(value) {
+      emit('update:value', value)
+    },
+  })
+
+  const schema = useSchema()
+  const selected = ref(0)
+
+  const property = computed(() => {
+    const selectedProperty = props.property.anyOf[selected.value]
+
+    if (isPropertyWith(selectedProperty, '$ref')) {
+      return getSchemaDefinition(schema, selectedProperty.$ref)
+    }
+
+    return selectedProperty
+  })
+
+  const options = computed<ButtonGroupOption[]>(() => props.property.anyOf.map((property, index) => ({
+    label: getLabelForProperty(property),
+    value: index,
+  })))
+
+  function getLabelForProperty(property: SchemaProperty): string {
+    if (property.$ref) {
+      const definition = getSchemaDefinition(schema, property.$ref)
+
+      return getLabelForProperty(definition)
+    }
+
+    return property.title ?? property.format ?? property.type ?? ''
+  }
 </script>

--- a/src/schemas/components/SchemaFormPropertyAnyOfInput.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOfInput.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="schema-form-property-any-of-input">
-    <p-button-group v-model="selected" :options="options" small />
+    <p-button-group v-model="selectedPropertyIndex" :options="options" small />
   </div>
 
   <p-card>
-    <SchemaFormProperty v-model:value="value" :property="property" :required="required" />
+    <SchemaFormProperty :key="selectedPropertyIndexValue" v-model:value="value" :property="property" :required="required" />
   </p-card>
 </template>
 
 <script lang="ts" setup>
   import { ButtonGroupOption } from '@prefecthq/prefect-design'
-  import { computed, ref } from 'vue'
+  import { computed, reactive, ref } from 'vue'
   import SchemaFormProperty from '@/schemas/components/SchemaFormProperty.vue'
   import { useSchema } from '@/schemas/compositions/useSchema'
   import { SchemaProperty, isPropertyWith } from '@/schemas/types/schema'
@@ -30,18 +30,31 @@
 
   const value = computed({
     get() {
-      return props.value
+      return propertyValues[selectedPropertyIndex.value]
     },
     set(value) {
+      propertyValues[selectedPropertyIndex.value] = value
       emit('update:value', value)
     },
   })
 
+  const selectedPropertyIndexValue = ref(0)
+
+  const selectedPropertyIndex = computed({
+    get() {
+      return selectedPropertyIndexValue.value
+    },
+    set(index) {
+      selectedPropertyIndexValue.value = index
+      emit('update:value', propertyValues[index])
+    },
+  })
+
   const schema = useSchema()
-  const selected = ref(0)
+  const propertyValues = reactive<SchemaValue[]>([])
 
   const property = computed(() => {
-    const selectedProperty = props.property.anyOf[selected.value]
+    const selectedProperty = props.property.anyOf[selectedPropertyIndex.value]
 
     if (isPropertyWith(selectedProperty, '$ref')) {
       return getSchemaDefinition(schema, selectedProperty.$ref)

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -34,7 +34,7 @@
 
   const input = computed(() => {
     const { type } = props.property
-    const value = props
+    const { value } = props
 
     if (isSchemaPropertyType(type, 'boolean')) {
       return withProps(PToggle, {


### PR DESCRIPTION
# Description
Adds support for schema properties that are an `anyOf` definition. Supports switching between schemas while preserving user input for each schema. Switching between schemas restores any previously entered values. 

Note: This does not address matching existing values to their proper schema. That will be addressed in a future PR. 