### PR TITLE
Fix property.required sometimes being null 

### DIFF
--- a/src/services/schemas/resolvers/meta.ts
+++ b/src/services/schemas/resolvers/meta.ts
@@ -10,9 +10,9 @@ export const schemaMetaResolver: SchemaResolver = (schema: Schema): Schema => {
 
 type PropertiesSource = Pick<SchemaProperty, 'properties' | 'required'>
 
-function resolveSchemaPropertiesMeta({ required = [], properties = {} }: PropertiesSource, level: number): SchemaProperties {
-  return mapValues(properties, (key, property) => {
-    const propertyIsRequired = required.includes(key)
+function resolveSchemaPropertiesMeta({ required, properties }: PropertiesSource, level: number): SchemaProperties {
+  return mapValues(properties ?? {}, (key, property) => {
+    const propertyIsRequired = required?.includes(key) ?? false
 
     return resolveSchemaPropertyMeta(property!, propertyIsRequired, level)
   })


### PR DESCRIPTION
# Description
When building meta for a schema property we're also checking if the property is required. `required` is an optional field on the parent property and its being defaulted to an empty array.

We had a report of a user's deployments not loading and the error traced down to `required` being `null` rather than `undefined`. I'm not sure why it would be `null` but we generally treat `null` and `undefined` the same. So updating to use a safer check in case either `required` or `properties` are null. 