### PR TITLE
Use python types as labels for OpenApi data types

### DIFF
--- a/src/schemas/components/SchemaFormPropertyAnyOfInput.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOfInput.vue
@@ -16,6 +16,7 @@
   import { SchemaProperty, isPropertyWith } from '@/schemas/types/schema'
   import { SchemaValue } from '@/schemas/types/schemaValues'
   import { getSchemaDefinition } from '@/schemas/utilities/definitions'
+  import { getSchemaPropertyLabel } from '@/schemas/utilities/properties'
   import { Require } from '@/types/utilities'
 
   const props = defineProps<{
@@ -64,17 +65,17 @@
   })
 
   const options = computed<ButtonGroupOption[]>(() => props.property.anyOf.map((property, index) => ({
-    label: getLabelForProperty(property),
+    label: getOptionLabelForProperty(property),
     value: index,
   })))
 
-  function getLabelForProperty(property: SchemaProperty): string {
+  function getOptionLabelForProperty(property: SchemaProperty): string {
     if (property.$ref) {
       const definition = getSchemaDefinition(schema, property.$ref)
 
-      return getLabelForProperty(definition)
+      return getSchemaPropertyLabel(definition)
     }
 
-    return property.title ?? property.format ?? property.type ?? ''
+    return getSchemaPropertyLabel(property)
   }
 </script>

--- a/src/schemas/utilities/properties.ts
+++ b/src/schemas/utilities/properties.ts
@@ -1,0 +1,25 @@
+import { SchemaProperty, SchemaPropertyType } from '@/schemas/types/schema'
+
+const schemaPropertyTypeLabelMap: Record<SchemaPropertyType, string> = {
+  'null': 'None',
+  'string': 'str',
+  'boolean': 'bool',
+  'integer': 'int',
+  'number': 'float',
+  'array': 'list',
+  'object': 'dict',
+}
+
+export function getSchemaPropertyTypeLabel(type: SchemaPropertyType | undefined): string {
+  if (type) {
+    return schemaPropertyTypeLabelMap[type]
+  }
+
+  return ''
+}
+
+export function getSchemaPropertyLabel(property: SchemaProperty): string {
+  const type = getSchemaPropertyTypeLabel(property.type)
+
+  return property.title ?? property.format ?? type
+}


### PR DESCRIPTION
# Description
Abstracts getting a label for a schema property into a utility and adds a utility for converting an OpenApi data type into its python equivalent. 