### PR TITLE
Schemas: Add support for block documents in schemas

### DIFF
--- a/src/schemas/components/SchemaFormPropertyBlockDocument.vue
+++ b/src/schemas/components/SchemaFormPropertyBlockDocument.vue
@@ -1,0 +1,36 @@
+<template>
+  <BlockDocumentInput v-model="value" :block-type-slug="property.block_type_slug" class="schema-form-property-block-document" />
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import BlockDocumentInput from '@/components/BlockDocumentInput.vue'
+  import { SchemaProperty } from '@/schemas/types/schema'
+  import { PrefectBlockDocumentValue } from '@/schemas/types/schemaValues'
+  import { Require } from '@/types/utilities'
+
+  const props = defineProps<{
+    property: Require<SchemaProperty, 'block_type_slug'>,
+    value: PrefectBlockDocumentValue | null | undefined,
+  }>()
+
+  const emit = defineEmits<{
+    'update:value': [PrefectBlockDocumentValue | null | undefined],
+  }>()
+
+  const value = computed({
+    get() {
+      return props.value?.$ref ?? null
+    },
+    set(value) {
+      if (value === null) {
+        emit('update:value', value)
+        return
+      }
+
+      emit('update:value', {
+        $ref: value,
+      })
+    },
+  })
+</script>

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -14,8 +14,9 @@
   import { computed } from 'vue'
   import SchemaFormKindInput from '@/schemas/components/SchemaFormKindInput.vue'
   import SchemaFormProperties from '@/schemas/components/SchemaFormProperties.vue'
-  import { SchemaProperty, isSchemaPropertyType } from '@/schemas/types/schema'
-  import { SchemaValue, isPrefectKindValue } from '@/schemas/types/schemaValues'
+  import SchemaFormPropertyBlockDocument from '@/schemas/components/SchemaFormPropertyBlockDocument.vue'
+  import { SchemaProperty, isPropertyWith, isSchemaPropertyType } from '@/schemas/types/schema'
+  import { SchemaValue, asPrefectBlockDocumentValue, isPrefectKindValue } from '@/schemas/types/schemaValues'
   import { withProps } from '@/utilities/components'
   import { asType } from '@/utilities/types'
 
@@ -35,6 +36,14 @@
   const input = computed(() => {
     const { type } = props.property
     const { value } = props
+
+    if (isPropertyWith(props.property, 'block_type_slug')) {
+      return withProps(SchemaFormPropertyBlockDocument, {
+        property: props.property,
+        value: asPrefectBlockDocumentValue(value),
+        'onUpdate:value': update,
+      })
+    }
 
     if (isSchemaPropertyType(type, 'boolean')) {
       return withProps(PToggle, {

--- a/src/schemas/types/schema.ts
+++ b/src/schemas/types/schema.ts
@@ -39,6 +39,7 @@ export type SchemaDefinition = `#/definitions/${string}`
 export type SchemaPropertyResponse = {
   // prefect specific properties
   position?: number,
+  block_type_slug?: string,
 
   // open api properties
   $ref?: SchemaDefinition,

--- a/src/schemas/types/schemaValues.ts
+++ b/src/schemas/types/schemaValues.ts
@@ -68,3 +68,19 @@ export type PrefectKindWorkspaceVariable = BasePrefectKindValue<'workspace_varia
 export function isPrefectKindWorkspaceVariable(value: unknown): value is PrefectKindWorkspaceVariable {
   return isPrefectKindValue(value, 'workspace_variable') && isString(value.variable_name)
 }
+
+export type PrefectBlockDocumentValue = {
+  $ref: string,
+}
+
+export function isPrefectBlockDocumentValue(value: unknown): value is PrefectBlockDocumentValue {
+  return isRecord(value) && isString(value.$ref)
+}
+
+export function asPrefectBlockDocumentValue(value: unknown): PrefectBlockDocumentValue | null {
+  if (isPrefectBlockDocumentValue(value)) {
+    return value
+  }
+
+  return null
+}


### PR DESCRIPTION
# Description
Adds support for schema properties that have `block_type_slug` on them. When present renders a BlockDocumentInput component to allow the user to select a block document or create a new one. 