### PR TITLE
Schemas: Set the initial definition index of an `anyOf` property based on the value present

### DIFF
--- a/src/schemas/components/SchemaFormPropertyAnyOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOf.vue
@@ -11,12 +11,13 @@
 <script lang="ts" setup>
   import { ButtonGroupOption } from '@prefecthq/prefect-design'
   import { computed, reactive, ref } from 'vue'
+  import { useWorkspaceApi } from '@/compositions'
   import SchemaFormProperty from '@/schemas/components/SchemaFormProperty.vue'
   import { useSchema } from '@/schemas/compositions/useSchema'
   import { SchemaProperty, isPropertyWith } from '@/schemas/types/schema'
   import { SchemaValue } from '@/schemas/types/schemaValues'
   import { getSchemaDefinition } from '@/schemas/utilities/definitions'
-  import { getSchemaPropertyLabel } from '@/schemas/utilities/properties'
+  import { getInitialIndexForSchemaPropertyAnyOfValue, getSchemaPropertyLabel } from '@/schemas/utilities/properties'
   import { Require } from '@/types/utilities'
 
   const props = defineProps<{
@@ -24,6 +25,9 @@
     value: SchemaValue,
     required: boolean,
   }>()
+
+  const api = useWorkspaceApi()
+  const schema = useSchema()
 
   const emit = defineEmits<{
     'update:value': [SchemaValue],
@@ -39,7 +43,18 @@
     },
   })
 
-  const selectedPropertyIndexValue = ref(0)
+  const initialSelectedPropertyIndex = await getInitialIndexForSchemaPropertyAnyOfValue({
+    schema,
+    property: props.property,
+    value: props.value,
+    api,
+  })
+  
+  if(initialSelectedPropertyIndex === -1) {
+    throw 'not implemented'
+  }
+
+  const selectedPropertyIndexValue = ref(initialSelectedPropertyIndex)
 
   const selectedPropertyIndex = computed({
     get() {
@@ -51,7 +66,6 @@
     },
   })
 
-  const schema = useSchema()
   const propertyValues = reactive<SchemaValue[]>([])
 
   const property = computed(() => {

--- a/src/schemas/components/SchemaFormPropertyBlockDocument.vue
+++ b/src/schemas/components/SchemaFormPropertyBlockDocument.vue
@@ -10,7 +10,7 @@
   import { Require } from '@/types/utilities'
 
   const props = defineProps<{
-    property: Require<SchemaProperty, 'blockTypeSlug'>,
+    property: Require<SchemaProperty, 'block_type_slug'>,
     value: BlockDocumentReferenceValue | null | undefined,
   }>()
 

--- a/src/schemas/components/SchemaFormPropertyBlockDocument.vue
+++ b/src/schemas/components/SchemaFormPropertyBlockDocument.vue
@@ -6,16 +6,16 @@
   import { computed } from 'vue'
   import BlockDocumentInput from '@/components/BlockDocumentInput.vue'
   import { SchemaProperty } from '@/schemas/types/schema'
-  import { PrefectBlockDocumentValue } from '@/schemas/types/schemaValues'
+  import { BlockDocumentReferenceValue } from '@/schemas/types/schemaValues'
   import { Require } from '@/types/utilities'
 
   const props = defineProps<{
-    property: Require<SchemaProperty, 'block_type_slug'>,
-    value: PrefectBlockDocumentValue | null | undefined,
+    property: Require<SchemaProperty, 'blockTypeSlug'>,
+    value: BlockDocumentReferenceValue | null | undefined,
   }>()
 
   const emit = defineEmits<{
-    'update:value': [PrefectBlockDocumentValue | null | undefined],
+    'update:value': [BlockDocumentReferenceValue | null | undefined],
   }>()
 
   const value = computed({

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -16,7 +16,7 @@
   import SchemaFormProperties from '@/schemas/components/SchemaFormProperties.vue'
   import SchemaFormPropertyBlockDocument from '@/schemas/components/SchemaFormPropertyBlockDocument.vue'
   import { SchemaProperty, isPropertyWith, isSchemaPropertyType } from '@/schemas/types/schema'
-  import { SchemaValue, asPrefectBlockDocumentValue, isPrefectKindValue } from '@/schemas/types/schemaValues'
+  import { SchemaValue, asBlockDocumentReferenceValue, isPrefectKindValue } from '@/schemas/types/schemaValues'
   import { withProps } from '@/utilities/components'
   import { asType } from '@/utilities/types'
 
@@ -40,7 +40,7 @@
     if (isPropertyWith(props.property, 'block_type_slug')) {
       return withProps(SchemaFormPropertyBlockDocument, {
         property: props.property,
-        value: asPrefectBlockDocumentValue(value),
+        value: asBlockDocumentReferenceValue(value),
         'onUpdate:value': update,
       })
     }

--- a/src/schemas/types/schemaValues.ts
+++ b/src/schemas/types/schemaValues.ts
@@ -69,16 +69,16 @@ export function isPrefectKindWorkspaceVariable(value: unknown): value is Prefect
   return isPrefectKindValue(value, 'workspace_variable') && isString(value.variable_name)
 }
 
-export type PrefectBlockDocumentValue = {
+export type BlockDocumentReferenceValue = {
   $ref: string,
 }
 
-export function isPrefectBlockDocumentValue(value: unknown): value is PrefectBlockDocumentValue {
+export function isBlockDocumentReferenceValue(value: unknown): value is BlockDocumentReferenceValue {
   return isRecord(value) && isString(value.$ref)
 }
 
-export function asPrefectBlockDocumentValue(value: unknown): PrefectBlockDocumentValue | null {
-  if (isPrefectBlockDocumentValue(value)) {
+export function asBlockDocumentReferenceValue(value: unknown): BlockDocumentReferenceValue | null {
+  if (isBlockDocumentReferenceValue(value)) {
     return value
   }
 

--- a/src/schemas/utilities/properties.ts
+++ b/src/schemas/utilities/properties.ts
@@ -1,4 +1,10 @@
-import { SchemaProperty, SchemaPropertyType } from '@/schemas/types/schema'
+import { isNotNullish } from '@prefecthq/prefect-design'
+import { Schema, SchemaProperty, SchemaPropertyType, isPropertyWith } from '@/schemas/types/schema'
+import { BlockDocumentReferenceValue, SchemaValue, isBlockDocumentReferenceValue } from '@/schemas/types/schemaValues'
+import { getSchemaDefinition } from '@/schemas/utilities/definitions'
+import { Require } from '@/types/utilities'
+import { isArray, isEmptyObject, isRecord } from '@/utilities'
+import { CreateApi } from '@/utilities/api'
 
 const schemaPropertyTypeLabelMap: Record<SchemaPropertyType, string> = {
   'null': 'None',
@@ -22,4 +28,103 @@ export function getSchemaPropertyLabel(property: SchemaProperty): string {
   const type = getSchemaPropertyTypeLabel(property.type)
 
   return property.title ?? property.format ?? type
+}
+
+export function getSchemaPropertyAllOfDefinitions(property: Require<SchemaProperty, 'anyOf'>, schema: Schema): SchemaProperty[] {
+  return property.anyOf.map(definition => {
+    if (isPropertyWith(definition, '$ref')) {
+      return getSchemaDefinition(schema, definition.$ref)
+    }
+
+    return definition
+  })
+}
+
+type InitialIndexContext = {
+  property: Require<SchemaProperty, 'anyOf'>,
+  value: SchemaValue,
+  schema: Schema,
+  api: CreateApi,
+}
+
+export async function getInitialIndexForSchemaPropertyAnyOfValue({ value, property, schema, api }: InitialIndexContext): Promise<number> {
+  // if there's no value default to showing the first definition
+  if (!isNotNullish(value)) {
+    return 0
+  }
+
+  const definitions = getSchemaPropertyAllOfDefinitions(property, schema)
+
+  // block documents are the only reason this utility is async.
+  // if the value is a block document reference we need to fetch the block document from the api
+  // to determine the block type
+  if (isBlockDocumentReferenceValue(value)) {
+    return await getBlockDocumentReferenceDefinitionIndex(value, definitions, api)
+  }
+
+  switch (typeof value) {
+    case 'string':
+      return definitions.findIndex(definition => definition.type == 'string')
+    case 'number':
+      return definitions.findIndex(definition => definition.type == 'number' || definition.type === 'integer')
+    case 'boolean':
+      return definitions.findIndex(definition => definition.type == 'boolean')
+    case 'object':
+      return getObjectDefinitionIndex(value, definitions)
+    default:
+      return -1
+  }
+}
+
+async function getBlockDocumentReferenceDefinitionIndex(value: BlockDocumentReferenceValue, definitions: SchemaProperty[], api: CreateApi): Promise<number> {
+  const blockDocument = await api.blockDocuments.getBlockDocument(value.$ref)
+
+  const definition = definitions.find(definition => definition.block_type_slug === blockDocument.blockType.slug)
+
+  if (definition) {
+    return definitions.indexOf(definition)
+  }
+
+  return -1
+}
+
+function getObjectDefinitionIndex(value: object | null, definitions: SchemaProperty[]): number {
+  if (isRecord(value)) {
+    return getRecordDefinitionIndex(value, definitions)
+  }
+
+  if (isArray(value)) {
+    return definitions.findIndex(definition => definition.type === 'array')
+  }
+
+  if (value === null) {
+    return definitions.findIndex(definition => definition.type === 'null')
+  }
+
+  return -1
+}
+
+function getRecordDefinitionIndex(value: Record<string, unknown>, definitions: SchemaProperty[]): number {
+  if (isEmptyObject(value)) {
+    return definitions.findIndex(definition => definition.type === 'object')
+  }
+
+  const valueKeys = Object.keys(value)
+
+  const [index, keysInCommon] = definitions.reduce<[number, number]>(([resultIndex, resultKeysInCommon], definition, definitionIndex) => {
+    const definitionKeys = Object.keys(definition.properties ?? {})
+    const definitionKeysInCommon = valueKeys.filter(value => definitionKeys.includes(value)).length
+
+    if (definitionKeysInCommon > resultKeysInCommon) {
+      return [definitionIndex, definitionKeysInCommon]
+    }
+
+    return [resultIndex, resultKeysInCommon]
+  }, [0, 0])
+
+  if (keysInCommon === 0) {
+    return -1
+  }
+
+  return index
 }


### PR DESCRIPTION
# Description
In order to maintain backwards compatibility we need to able to match a value for an `anyOf` property with the correct definition. So adding that logic to the new schemas codebase. Mostly copied/inspired by the existing [getSchemaValueAllOfDefinition](https://github.com/PrefectHQ/prefect-ui-library/blob/main/src/services/schemas/utilities.ts#L200) in the current codebase. This should ensure we have at least as good of support as we do today for this. 