### PR TITLE
Fix: Use anchor rather than start terminology for anchor date

### DIFF
--- a/src/components/IntervalScheduleForm.vue
+++ b/src/components/IntervalScheduleForm.vue
@@ -17,7 +17,7 @@
       </div>
 
       <div>
-        <p-label label="Start date">
+        <p-label label="Anchor date">
           <DateInput v-model="anchorDate" show-time />
         </p-label>
       </div>

--- a/src/models/IntervalSchedule.ts
+++ b/src/models/IntervalSchedule.ts
@@ -101,7 +101,7 @@ export class IntervalSchedule implements IIntervalSchedule {
     }
 
     if (this.anchorDate && verbose) {
-      str += ` from ${formatDate(this.anchorDate)} at ${formatTimeNumeric(this.anchorDate)} (${this.timezone ?? 'UTC'})`
+      str += ` using ${formatDate(this.anchorDate)} at ${formatTimeNumeric(this.anchorDate)} (${this.timezone ?? 'UTC'}) as the anchor date`
     }
 
     if (str == '') {


### PR DESCRIPTION
Interval schedules have an anchor date, which is the interval that schedules can be calculated from.  As we set out [in the docs, ](https://docs.prefect.io/latest/concepts/schedules/?h=schedu#interval): 

> _the anchor_date does not indicate a "start time" for the schedule, but rather a fixed point in time from which to compute intervals. If the anchor date is in the future, then schedule dates are computed by subtracting the interval from it_

This PR changes some of the language in the UI to make it more clear. 

Closes https://github.com/PrefectHQ/prefect/issues/11551