### PR TITLE
Schemas: Support for arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "vue-tsc": "1.8.27"
             },
             "peerDependencies": {
-                "@prefecthq/prefect-design": "^2.2.11",
+                "@prefecthq/prefect-design": "^2.3.0",
                 "@prefecthq/vue-charts": "^2.0.3",
                 "@prefecthq/vue-compositions": "^1.7.1",
                 "vee-validate": "^4.7.0",
@@ -1252,9 +1252,9 @@
             }
         },
         "node_modules/@prefecthq/prefect-design": {
-            "version": "2.2.11",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.2.11.tgz",
-            "integrity": "sha512-NsNKnwMCH06H3Ok2BY0PzpL4RFZeWXDgK+N0pEzZEXcJvbX3YP1FAFlKbfvKIPR2qKiFiICtrd6wzcayVM9Qbg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.3.0.tgz",
+            "integrity": "sha512-N1kOP/71L2wIb91tJHdYJwuEoTPpqocw7u9COt2KUym8BbxhYItb92gM7bAygT78ztznRKIFsNSegkiT1kq0rw==",
             "peer": true,
             "dependencies": {
                 "@heroicons/vue": "2.0.17",
@@ -8477,9 +8477,9 @@
             }
         },
         "@prefecthq/prefect-design": {
-            "version": "2.2.11",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.2.11.tgz",
-            "integrity": "sha512-NsNKnwMCH06H3Ok2BY0PzpL4RFZeWXDgK+N0pEzZEXcJvbX3YP1FAFlKbfvKIPR2qKiFiICtrd6wzcayVM9Qbg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.3.0.tgz",
+            "integrity": "sha512-N1kOP/71L2wIb91tJHdYJwuEoTPpqocw7u9COt2KUym8BbxhYItb92gM7bAygT78ztznRKIFsNSegkiT1kq0rw==",
             "peer": true,
             "requires": {
                 "@heroicons/vue": "2.0.17",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "vue-tsc": "1.8.27"
     },
     "peerDependencies": {
-        "@prefecthq/prefect-design": "^2.2.11",
+        "@prefecthq/prefect-design": "^2.3.0",
         "@prefecthq/vue-charts": "^2.0.3",
         "@prefecthq/vue-compositions": "^1.7.1",
         "vee-validate": "^4.7.0",

--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -42,11 +42,11 @@
   const props = defineProps<{
     parent: SchemaProperty,
     properties: SchemaProperties,
-    values: SchemaValues | null,
+    values: SchemaValues | undefined,
   }>()
 
   const emit = defineEmits<{
-    'update:values': [SchemaValues | null],
+    'update:values': [SchemaValues | undefined],
   }>()
 
   const properties = computed(() => {
@@ -61,7 +61,7 @@
   })
 
   function getValue(propertyKey: string): unknown {
-    return props.values?.[propertyKey] ?? null
+    return props.values?.[propertyKey] ?? undefined
   }
 
   function setValue(propertyKey: string, value: unknown): void {

--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -1,16 +1,7 @@
 <template>
   <p-content class="schema-form-properties">
     <template v-for="[key, property] in properties" :key="key">
-      <template v-if="isPropertyWith(property, '$ref')">
-        <SchemaFormProperty
-          :value="getValue(key)"
-          :property="getSchemaDefinition(schema, property.$ref)"
-          :required="getRequired(key)"
-          @update:value="setValue(key, $event)"
-        />
-      </template>
-
-      <template v-else-if="isPropertyWith(property, 'allOf')">
+      <template v-if="isPropertyWith(property, 'allOf')">
         <SchemaFormPropertyAllOf
           :value="getValue(key)"
           :property="property"
@@ -48,16 +39,15 @@
   import { useSchema } from '@/schemas/compositions/useSchema'
   import { SchemaProperty, SchemaProperties, isPropertyWith } from '@/schemas/types/schema'
   import { SchemaValues } from '@/schemas/types/schemaValues'
-  import { getSchemaDefinition } from '@/schemas/utilities/definitions'
 
   const props = defineProps<{
     parent: SchemaProperty,
     properties: SchemaProperties,
-    values: SchemaValues,
+    values: SchemaValues | null,
   }>()
 
   const emit = defineEmits<{
-    'update:values': [SchemaValues],
+    'update:values': [SchemaValues | null],
   }>()
 
   const schema = useSchema()
@@ -74,7 +64,7 @@
   })
 
   function getValue(propertyKey: string): unknown {
-    return props.values[propertyKey] ?? null
+    return props.values?.[propertyKey] ?? null
   }
 
   function setValue(propertyKey: string, value: unknown): void {

--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -36,7 +36,6 @@
   import SchemaFormProperty from '@/schemas/components/SchemaFormProperty.vue'
   import SchemaFormPropertyAllOf from '@/schemas/components/SchemaFormPropertyAllOf.vue'
   import SchemaFormPropertyAnyOf from '@/schemas/components/SchemaFormPropertyAnyOf.vue'
-  import { useSchema } from '@/schemas/compositions/useSchema'
   import { SchemaProperty, SchemaProperties, isPropertyWith } from '@/schemas/types/schema'
   import { SchemaValues } from '@/schemas/types/schemaValues'
 
@@ -49,8 +48,6 @@
   const emit = defineEmits<{
     'update:values': [SchemaValues | null],
   }>()
-
-  const schema = useSchema()
 
   const properties = computed(() => {
     return Object.entries(props.properties).sort((entryA, entryB) => {

--- a/src/schemas/components/SchemaFormPropertyAllOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAllOf.vue
@@ -33,11 +33,15 @@
 
   const schema = useSchema()
 
-  const property = computed(() => props.property.allOf.reduce<SchemaProperty>((property, definition) => {
-    if (isPropertyWith(definition, '$ref')) {
-      return merge(property, getSchemaDefinition(schema, definition.$ref))
-    }
+  const property = computed(() => {
+    const definitions = props.property.allOf.reduce<SchemaProperty>((property, definition) => {
+      if (isPropertyWith(definition, '$ref')) {
+        return merge(getSchemaDefinition(schema, definition.$ref), property)
+      }
 
-    return merge(property, definition)
-  }, {}))
+      return merge(property, definition)
+    }, {})
+
+    return merge(definitions, props.property)
+  })
 </script>

--- a/src/schemas/components/SchemaFormPropertyArray.vue
+++ b/src/schemas/components/SchemaFormPropertyArray.vue
@@ -1,0 +1,60 @@
+<template>
+  <p-draggable-list v-model="value" allow-create allow-delete class="schema-form-property-array" :generator="() => null">
+    <template #item="{ index, handleDown, handleUp, deleteItem }">
+      <div class="schema-form-property-array__item">
+        <PIcon icon="DragHandle" class="schema-form-property-array__handle" @mousedown="handleDown" @mouseup="handleUp" />
+
+        <SchemaFormPropertyInput v-model:value="value[index]" :property="property.items ?? {}" />
+
+        <p-button icon="TrashIcon" @click="deleteItem" />
+      </div>
+    </template>
+  </p-draggable-list>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import SchemaFormPropertyInput from '@/schemas/components/SchemaFormPropertyInput.vue'
+  import { SchemaProperty } from '@/schemas/types/schema'
+
+  const props = defineProps<{
+    property: SchemaProperty & { type: 'array' },
+    value: unknown[] | null,
+  }>()
+
+  const emit = defineEmits<{
+    'update:value': [unknown[] | null],
+  }>()
+
+  const value = computed({
+    get() {
+      return props.value ?? []
+    },
+    set(value) {
+      if (value.length === 0) {
+        emit('update:value', null)
+        return
+      }
+
+      emit('update:value', value)
+    },
+  })
+</script>
+
+<style>
+.schema-form-property-array .p-draggable-list__item { @apply
+  block
+}
+
+.schema-form-property-array__item { @apply
+  grid
+  gap-2
+  items-start;
+  grid-template-columns: min-content 1fr min-content;
+}
+
+.schema-form-property-array__handle { @apply
+  cursor-grab
+  mt-2
+}
+</style>

--- a/src/schemas/components/SchemaFormPropertyObject.vue
+++ b/src/schemas/components/SchemaFormPropertyObject.vue
@@ -12,11 +12,11 @@
 
   const props = defineProps<{
     property: SchemaProperty & { type: 'object' },
-    values: SchemaValues | null,
+    values: SchemaValues | undefined,
   }>()
 
   const emit = defineEmits<{
-    'update:values': [SchemaValues | null],
+    'update:values': [SchemaValues | undefined],
   }>()
 
   const values = computed({

--- a/src/schemas/components/SchemaFormPropertyObject.vue
+++ b/src/schemas/components/SchemaFormPropertyObject.vue
@@ -1,0 +1,30 @@
+<template>
+  <p-card class="schema-form-property-object">
+    <SchemaFormProperties v-model:values="values" :parent="property" :properties="property.properties ?? {}" />
+  </p-card>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import SchemaFormProperties from '@/schemas/components/SchemaFormProperties.vue'
+  import { SchemaProperty } from '@/schemas/types/schema'
+  import { SchemaValues } from '@/schemas/types/schemaValues'
+
+  const props = defineProps<{
+    property: SchemaProperty & { type: 'object' },
+    values: SchemaValues | null,
+  }>()
+
+  const emit = defineEmits<{
+    'update:values': [SchemaValues | null],
+  }>()
+
+  const values = computed({
+    get() {
+      return props.values
+    },
+    set(values) {
+      emit('update:values', values)
+    },
+  })
+</script>


### PR DESCRIPTION
# Description
Adds ux for properties of `type: 'array'`. Uses the new `PDraggableList` component from prefect-design. Can add, re-order, and delete items from an array. Supports all features of schema properties. 

Using this example flow
```python
class User(BaseModel):
    name: str
    age: int
    birthday: date

@flow
def schema_testing(list: List[User], names: List[str]):
```

Produces this UI
<img width="702" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/4ce34440-65f2-42da-85ff-5e7f1e7459df">
<img width="692" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/b1ed9934-40da-4615-bd4b-cde467347ff1">

Currently the user is only given a json input (same flow)
<img width="696" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/e0f06115-4163-483c-a3d5-238e7a20b358">

