### PR TITLE
Display `description` in resume modal when supplied

### DIFF
--- a/src/components/FlowRunResumeModal.vue
+++ b/src/components/FlowRunResumeModal.vue
@@ -14,6 +14,7 @@
       </p-message>
     </div>
 
+    <p-markdown-renderer v-if="inputDescription" :text="inputDescription" />
     <div v-else>
       Do you want to resume {{ flowRun.name }}?
     </div>
@@ -69,10 +70,12 @@
   const { validate } = useValidationObserver()
 
   let serverValidationError: string
+  let inputDescription: string | null
   let inputSchema: Schema
 
   if (flowRun.value?.state?.stateDetails?.runInputKeyset) {
-    inputSchema = await api.flowRuns.getFlowRunInput(props.flowRunId, flowRun.value.state.stateDetails.runInputKeyset.schema)
+    inputDescription = await api.flowRuns.getFlowRunInputDescription(props.flowRunId, flowRun.value.state.stateDetails.runInputKeyset)
+    inputSchema = await api.flowRuns.getFlowRunInputSchema(props.flowRunId, flowRun.value.state.stateDetails.runInputKeyset)
   }
 
   const resume = async (): Promise<void> => {

--- a/src/maps/mapFlowRunInputKeysetResponseToFlowRunInputKeyset.ts
+++ b/src/maps/mapFlowRunInputKeysetResponseToFlowRunInputKeyset.ts
@@ -4,6 +4,7 @@ import { MapFunction } from '@/services/Mapper'
 
 export const mapFlowRunInputKeysetResponseToFlowRunInputKeyset: MapFunction<FlowRunInputKeysetResponse, FlowRunInputKeyset> = function(source) {
   return {
+    description: source.description,
     response: source.response,
     schema: source.schema,
   }
@@ -11,6 +12,7 @@ export const mapFlowRunInputKeysetResponseToFlowRunInputKeyset: MapFunction<Flow
 
 export const mapFlowRunInputKeysetToFlowRunInputKeysetResponse: MapFunction<FlowRunInputKeyset, FlowRunInputKeysetResponse> = function(source) {
   return {
+    description: source.description,
     response: source.response,
     schema: source.schema,
   }

--- a/src/models/FlowRunInputKeyset.ts
+++ b/src/models/FlowRunInputKeyset.ts
@@ -1,4 +1,5 @@
 export type FlowRunInputKeyset = {
+  description: string,
   schema: string,
   response: string,
 }

--- a/src/models/api/FlowRunInputKeysetResponse.ts
+++ b/src/models/api/FlowRunInputKeysetResponse.ts
@@ -1,4 +1,5 @@
 export type FlowRunInputKeysetResponse = {
+  description: string,
   schema: string,
   response: string,
 }

--- a/src/services/WorkspaceFlowRunsApi.ts
+++ b/src/services/WorkspaceFlowRunsApi.ts
@@ -7,6 +7,7 @@ import { OrchestrationResultResponse } from '@/models/api/OrchestrationResultRes
 import { RunGraphDataResponse } from '@/models/api/RunGraphDataResponse'
 import { FlowRunsFilter, FlowRunsHistoryFilter } from '@/models/Filters'
 import { FlowRun } from '@/models/FlowRun'
+import { FlowRunInputKeyset } from '@/models/FlowRunInputKeyset'
 import { RunHistory } from '@/models/RunHistory'
 import { BatchProcessor } from '@/services/BatchProcessor'
 import { mapper } from '@/services/Mapper'
@@ -73,9 +74,13 @@ export class WorkspaceFlowRunsApi extends WorkspaceApi {
     return mapper.map('RunGraphDataResponse', data, 'RunGraphData')
   }
 
-  public async getFlowRunInput(id: string, key: string): Promise<Schema> {
-    const { data } = await this.get<SchemaResponse>(`/${id}/input/${key}`)
+  public async getFlowRunInputDescription(id: string, keyset: FlowRunInputKeyset): Promise <string | null> {
+    const { data } = await this.get<string | null>(`/${id}/input/${keyset.description}`)
+    return data
+  }
 
+  public async getFlowRunInputSchema(id: string, keyset: FlowRunInputKeyset): Promise<Schema> {
+    const { data } = await this.get<SchemaResponse>(`/${id}/input/${keyset.schema}`)
     return mapper.map('SchemaResponse', data, 'Schema')
   }
 


### PR DESCRIPTION
This updates the flow run resume modal to display a `description` if one has been supplied when the run was paused.

## Example

A flow run can pause and wait for input with a description:

```python
from prefect import flow, pause_flow_run
from prefect.input import RunInput


class TreeInput(RunInput):
    num_trees: int



@flow
async def plant_trees():
    tree_input = await pause_flow_run(
        wait_for_input=TreeInput.with_initial_data(
            description="How many **trees** to plant?"
        )
    )
    for i in range(tree_input.num_trees):
        print(f"Planting tree {i+1} of {tree_input.num_trees}...")


if __name__ == "__main__":
    plant_trees.serve(name="plant-trees")
```

Resuming this flow run in the modal will display the description:

![Screenshot 2024-01-31 at 1 53 46 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/354286/0f9a32a2-a2f1-4c0f-9b03-1ba4bd39407d)