### PR TITLE
Support migrating work pool queue health to work queue status

### DIFF
--- a/src/components/FlowRunWorkQueue.vue
+++ b/src/components/FlowRunWorkQueue.vue
@@ -2,14 +2,20 @@
   <div v-if="!workPool?.isPushPool" class="flow-run-work-queue">
     <span>Work Queue</span>
     <WorkQueueIconText :work-queue-name="workQueueName" :work-pool-name="workPoolName" />
-    <WorkPoolQueueHealthIcon v-if="isNotTerminal && workPoolName" :work-queue-name="workQueueName" :work-pool-name="workPoolName" />
+
+    <template v-if="isNotTerminal && workPoolName">
+      <WorkPoolQueueStatusIcon v-if="can.access.workQueueStatus && workPoolQueue" :work-pool-queue="workPoolQueue" />
+      <WorkPoolQueueHealthIcon v-else-if="!can.access.workQueueStatus" :work-queue-name="workQueueName" :work-pool-name="workPoolName" />
+    </template>
   </div>
 </template>
 
 <script lang="ts" setup>
+  import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
   import { computed, toRefs } from 'vue'
   import { WorkPoolQueueHealthIcon, WorkQueueIconText } from '@/components'
-  import { useWorkPool } from '@/compositions'
+  import WorkPoolQueueStatusIcon from '@/components/WorkPoolQueueStatusIcon.vue'
+  import { useCan, useInterval, useWorkPool, useWorkspaceApi } from '@/compositions'
   import { isTerminalStateType } from '@/models'
 
   const props = defineProps<{
@@ -18,9 +24,23 @@
     flowRunState?: string | null,
   }>()
 
+  const can = useCan()
+
   const isNotTerminal = computed(() => props.flowRunState && !isTerminalStateType(props.flowRunState))
   const { workPoolName } = toRefs(props)
   const { workPool } = useWorkPool(workPoolName)
+
+  const api = useWorkspaceApi()
+  const workPoolQueueArgs = computed<[string, string] | null>(() => {
+    if (!props.workPoolName) {
+      return null
+    }
+    return [props.workPoolName, props.workQueueName]
+  })
+  const options = useInterval()
+
+  const workPoolQueuesSubscription = useSubscriptionWithDependencies(api.workPoolQueues.getWorkPoolQueueByName, workPoolQueueArgs, options)
+  const workPoolQueue = computed(() => workPoolQueuesSubscription.response)
 </script>
 
 <style>

--- a/src/components/WorkPoolQueueStatusArray.vue
+++ b/src/components/WorkPoolQueueStatusArray.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="work-pool-queue-status-array">
     <template v-if="!isPushPool && !showTooMany && workPoolQueues.length > 0">
-      <WorkPoolQueueHealthIcon
-        v-for="workQueue in workPoolQueues"
-        :key="workQueue.id"
-        :work-queue-name="workQueue.name"
-        :work-pool-name="workPool.name"
-        class="work-pool-queue-status-badge__icon"
-      />
+      <template v-for="workQueue in workPoolQueues" :key="workQueue.id">
+        <WorkPoolQueueStatusIcon
+          v-if="can.access.workQueueStatus"
+          :work-pool-queue="workQueue"
+        />
+        <WorkPoolQueueHealthIcon
+          v-else
+          :work-queue-name="workQueue.name"
+          :work-pool-name="workPool.name"
+          class="work-pool-queue-status-badge__icon"
+        />
+      </template>
     </template>
     <span v-if="isPushPool || !showTooMany && workPoolQueues.length < 1" class="work-pool-queue-status-array__none">N/A</span>
     <span v-if="showTooMany" class="work-pool-queue-status-array__too-many">Too many to show here.</span>
@@ -18,12 +23,15 @@
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
   import { WorkPoolQueueHealthIcon } from '@/components'
-  import { useInterval, useWorkspaceApi } from '@/compositions'
+  import WorkPoolQueueStatusIcon from '@/components/WorkPoolQueueStatusIcon.vue'
+  import { useCan, useInterval, useWorkspaceApi } from '@/compositions'
   import { WorkPool } from '@/models'
 
   const props = defineProps<{
     workPool: WorkPool,
   }>()
+
+  const can = useCan()
 
   const maxWorkQueues = 50
   const api = useWorkspaceApi()

--- a/src/components/WorkPoolQueueStatusBadge.vue
+++ b/src/components/WorkPoolQueueStatusBadge.vue
@@ -1,7 +1,8 @@
 <template>
   <template v-if="workQueue && workQueueStatus">
     <p-tag class="work-pool-queue-status-badge" :class="classes">
-      <WorkPoolQueueHealthIcon :work-queue-name="workQueueName" :work-pool-name="workPoolName" class="work-pool-queue-status-badge__icon" />
+      <WorkPoolQueueStatusIcon v-if="can.access.workQueueStatus" :work-pool-queue="workQueue" />
+      <WorkPoolQueueHealthIcon v-else :work-queue-name="workQueueName" :work-pool-name="workPoolName" class="work-pool-queue-status-badge__icon" />
       {{ label }}
     </p-tag>
   </template>
@@ -10,13 +11,16 @@
 <script lang="ts" setup>
   import { computed } from 'vue'
   import { WorkPoolQueueHealthIcon } from '@/components'
-  import { useWorkQueueStatus } from '@/compositions'
+  import WorkPoolQueueStatusIcon from '@/components/WorkPoolQueueStatusIcon.vue'
+  import { useCan, useWorkQueueStatus } from '@/compositions'
   import { WorkPool, WorkPoolQueue } from '@/models'
 
   const props = defineProps<{
     workQueue: WorkPoolQueue,
     workPool: WorkPool,
   }>()
+
+  const can = useCan()
 
   const workQueueName = computed(() => props.workQueue.name)
   const workPoolName = computed(() => props.workPool.name)
@@ -25,6 +29,10 @@
   const healthy = computed(() => workQueueStatus.value?.healthy)
 
   const label = computed(() => {
+    if (can.access.workQueueStatus) {
+      return { 'ready': 'Ready', 'not_ready': 'Not Ready', 'paused': 'Paused' }[props.workQueue.status]
+    }
+
     if (props.workQueue.isPaused) {
       return 'Paused'
     }

--- a/src/components/WorkPoolQueueStatusIcon.vue
+++ b/src/components/WorkPoolQueueStatusIcon.vue
@@ -30,11 +30,11 @@
   }>(() => {
     switch (props.workPoolQueue.status) {
       case 'paused':
-        return { state: 'paused', icon: 'PauseCircleIcon', tooltip: 'Work pool queue is paused. No work will be executed.' }
+        return { state: 'paused', icon: 'PauseCircleIcon', tooltip: 'Work queue is paused. No work will be executed.' }
       case 'ready':
-        return { state: 'ready', icon: 'CheckCircleIcon', tooltip: 'Work pool queue has at least one actively polling worker ready to execute work.' }
+        return { state: 'ready', icon: 'CheckCircleIcon', tooltip: 'Work queue has at least one actively polling worker ready to execute work.' }
       case 'not_ready':
-        return { state: 'not_ready', icon: 'ExclamationCircleIcon', tooltip: 'Work pool queue does not have any actively polling workers ready to execute work.' }
+        return { state: 'not_ready', icon: 'ExclamationCircleIcon', tooltip: 'Work queue does not have any actively polling workers ready to execute work.' }
       default:
         const exhaustiveCheck: never = props.workPoolQueue.status
         throw new Error(`Unhandled work pool queue status: ${exhaustiveCheck}`)

--- a/src/components/WorkPoolQueueStatusIcon.vue
+++ b/src/components/WorkPoolQueueStatusIcon.vue
@@ -23,20 +23,18 @@
     workPoolQueue: WorkPoolQueue,
   }>()
 
-
   const status = computed<{
     state: 'paused' | 'ready' | 'not_ready',
-    name: string,
     icon: Icon,
     tooltip: string,
   }>(() => {
     switch (props.workPoolQueue.status) {
       case 'paused':
-        return { state: 'paused', name: 'Paused', icon: 'PauseCircleIcon', tooltip: 'Work pool queue is paused. No work will be executed.' }
+        return { state: 'paused', icon: 'PauseCircleIcon', tooltip: 'Work pool queue is paused. No work will be executed.' }
       case 'ready':
-        return { state: 'ready', name: 'Ready', icon: 'CheckCircleIcon', tooltip: 'Work pool queue has at least one actively polling worker ready to execute work.' }
+        return { state: 'ready', icon: 'CheckCircleIcon', tooltip: 'Work pool queue has at least one actively polling worker ready to execute work.' }
       case 'not_ready':
-        return { state: 'not_ready', name: 'Not Ready', icon: 'ExclamationCircleIcon', tooltip: 'Work pool queue does not have any actively polling workers ready to execute work.' }
+        return { state: 'not_ready', icon: 'ExclamationCircleIcon', tooltip: 'Work pool queue does not have any actively polling workers ready to execute work.' }
       default:
         const exhaustiveCheck: never = props.workPoolQueue.status
         throw new Error(`Unhandled work pool queue status: ${exhaustiveCheck}`)
@@ -49,6 +47,10 @@
 <style>
 .work-pool-queue-status-icon { @apply
   cursor-help
+}
+
+.work-pool-queue-status-icon--not_ready { @apply
+  text-sentiment-negative
 }
 
 .work-pool-queue-status-icon--paused { @apply

--- a/src/components/WorkPoolQueueStatusIcon.vue
+++ b/src/components/WorkPoolQueueStatusIcon.vue
@@ -1,0 +1,59 @@
+<template>
+  <p-tooltip
+    class="work-pool-queue-status-icon"
+    :text="status.tooltip"
+  >
+    <StatusIcon v-if="status.state === 'ready'" status="ready" />
+    <p-icon
+      v-if="status.state !== 'ready'"
+      :icon="status.icon"
+      size="small"
+      :class="classes"
+    />
+  </p-tooltip>
+</template>
+
+<script lang="ts" setup>
+  import { Icon } from '@prefecthq/prefect-design'
+  import { computed } from 'vue'
+  import StatusIcon from '@/components/StatusIcon.vue'
+  import { WorkPoolQueue } from '@/models'
+
+  const props = defineProps<{
+    workPoolQueue: WorkPoolQueue,
+  }>()
+
+
+  const status = computed<{
+    state: 'paused' | 'ready' | 'not_ready',
+    name: string,
+    icon: Icon,
+    tooltip: string,
+  }>(() => {
+    switch (props.workPoolQueue.status) {
+      case 'paused':
+        return { state: 'paused', name: 'Paused', icon: 'PauseCircleIcon', tooltip: 'Work pool queue is paused. No work will be executed.' }
+      case 'ready':
+        return { state: 'ready', name: 'Ready', icon: 'CheckCircleIcon', tooltip: 'Work pool queue has at least one actively polling worker ready to execute work.' }
+      case 'not_ready':
+        return { state: 'not_ready', name: 'Not Ready', icon: 'ExclamationCircleIcon', tooltip: 'Work pool queue does not have any actively polling workers ready to execute work.' }
+      default:
+        const exhaustiveCheck: never = props.workPoolQueue.status
+        throw new Error(`Unhandled work pool queue status: ${exhaustiveCheck}`)
+    }
+  })
+
+  const classes = computed(() => `work-pool-queue-status-icon--${status.value.state}`)
+</script>
+
+<style>
+.work-pool-queue-status-icon { @apply
+  cursor-help
+}
+
+.work-pool-queue-status-icon--paused { @apply
+  flex
+  items-center
+  text-subdued
+}
+</style>

--- a/src/maps/workPoolQueue.ts
+++ b/src/maps/workPoolQueue.ts
@@ -1,4 +1,4 @@
-import { WorkPoolQueue, WorkPoolQueueCreate, WorkPoolQueueCreateRequest, WorkPoolQueueEdit, WorkPoolQueueEditRequest, WorkPoolQueueResponse } from '@/models'
+import { WorkPoolQueue, WorkPoolQueueCreate, WorkPoolQueueCreateRequest, WorkPoolQueueEdit, WorkPoolQueueEditRequest, WorkPoolQueueResponse, WorkPoolQueueResponseStatus, WorkPoolQueueStatus } from '@/models'
 import { MapFunction } from '@/services/Mapper'
 
 export const mapWorkPoolQueueResponseToWorkPoolQueue: MapFunction<WorkPoolQueueResponse, WorkPoolQueue> = function(source) {
@@ -13,6 +13,7 @@ export const mapWorkPoolQueueResponseToWorkPoolQueue: MapFunction<WorkPoolQueueR
     isPaused: source.is_paused ?? false,
     concurrencyLimit: source.concurrency_limit,
     priority: source.priority,
+    status: source.status.toLowerCase() as Lowercase<WorkPoolQueueResponseStatus>,
   })
 }
 
@@ -28,6 +29,7 @@ export const mapWorkPoolQueueToWorkPoolQueueResponse: MapFunction<WorkPoolQueue,
     is_paused: source.isPaused,
     concurrency_limit: source.concurrencyLimit,
     priority: source.priority,
+    status: source.status.toUpperCase() as Uppercase<WorkPoolQueueStatus>,
   }
 }
 

--- a/src/mocks/workPoolQueue.ts
+++ b/src/mocks/workPoolQueue.ts
@@ -13,6 +13,7 @@ export const randomWorkPoolQueue: MockFunction<WorkPoolQueue, [Partial<WorkPoolQ
     isPaused: this.create('boolean'),
     concurrencyLimit: this.create('number'),
     priority: this.create('number'),
+    status: 'ready',
     ...overrides,
   })
 }

--- a/src/models/WorkPoolQueue.ts
+++ b/src/models/WorkPoolQueue.ts
@@ -1,3 +1,5 @@
+export type WorkPoolQueueStatus = 'ready' | 'paused' | 'not_ready'
+
 export interface IWorkPoolQueue {
   readonly id: string,
   created: Date,
@@ -9,6 +11,7 @@ export interface IWorkPoolQueue {
   isPaused: boolean,
   concurrencyLimit: number | null,
   priority: number,
+  status: WorkPoolQueueStatus,
 }
 
 export class WorkPoolQueue implements IWorkPoolQueue {
@@ -22,6 +25,7 @@ export class WorkPoolQueue implements IWorkPoolQueue {
   public isPaused: boolean
   public concurrencyLimit: number | null
   public priority: number
+  public status: WorkPoolQueueStatus
 
   public constructor(workPoolQueue: IWorkPoolQueue) {
     this.id = workPoolQueue.id
@@ -34,5 +38,6 @@ export class WorkPoolQueue implements IWorkPoolQueue {
     this.isPaused = workPoolQueue.isPaused
     this.concurrencyLimit = workPoolQueue.concurrencyLimit
     this.priority = workPoolQueue.priority
+    this.status = workPoolQueue.status
   }
 }

--- a/src/models/api/WorkPoolQueueResponse.ts
+++ b/src/models/api/WorkPoolQueueResponse.ts
@@ -1,5 +1,7 @@
 import { DateString } from '@/types/dates'
 
+export type WorkPoolQueueResponseStatus = 'READY' | 'PAUSED' | 'NOT_READY'
+
 export type WorkPoolQueueResponse = {
   id: string,
   created: DateString,
@@ -11,4 +13,5 @@ export type WorkPoolQueueResponse = {
   is_paused: boolean | null,
   concurrency_limit: number | null,
   priority: number,
+  status: WorkPoolQueueResponseStatus,
 }

--- a/src/services/can.ts
+++ b/src/services/can.ts
@@ -1,7 +1,7 @@
 import { InjectionKey, ref } from 'vue'
 import { MaybeRef } from '@/types/reactivity'
 
-export const workspaceFeatureFlags = ['access:deploymentStatus'] as const satisfies Readonly<`access:${string}`[]>
+export const workspaceFeatureFlags = ['access:deploymentStatus', 'access:workQueueStatus'] as const satisfies Readonly<`access:${string}`[]>
 
 export type WorkspaceFeatureFlag = typeof workspaceFeatureFlags[number]
 


### PR DESCRIPTION
This PR sets up supporting work to migrate work pool queue health statuses over to a new, more streamlined work queue status diagnostic. In this PR, a new feature flag (expected as `access:workQueueStatus`) can be used to switch the work queue health indicator over to use the new status field. 

Additional differences:
- work queue health has been on a deprecation path and so the icon comes with a related tooltip. Upon switching over to status, this deprecation tooltip is now replaced with more status-specific information.

| **flag disabled** | **flag enabled** |
| ---- | ---- |
| <img width="1496" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/56c5a7a6-6c40-411d-855c-74c599ce4cb0"> | <img width="1496" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/45edf0fe-2e3c-4ed8-bf0a-9605da05264e"> |
| <img width="1494" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/c06ff31d-cf98-4acb-8a84-4c8008ead1c1"> | <img width="1502" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/269e47ca-1601-4a7a-997a-eb27e1ff6bf6"> | 
| <img width="1498" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/a71ce7f5-36a3-4b9d-8ff3-8f86b3a67333"> | <img width="1498" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/59622ed9-fc02-4c0a-91ec-2fb93bca6bf7"> |
| <img width="377" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/788e4b98-3d40-4c60-9c1b-d9885e874804"> | <img width="356" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/29aecc63-ebfb-4318-adc5-4ab0d67f1982"> <img width="344" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/5f242be9-54b2-4379-a739-f72e277783c2"> <img width="339" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/93faf802-4b79-458b-a48c-ada003ce9da0"> Edited to "Work ~~pool~~ queue" |


