### PR TITLE
Bugfix: Handle missing status parameter from api.

### DIFF
--- a/src/maps/workPoolQueue.ts
+++ b/src/maps/workPoolQueue.ts
@@ -13,7 +13,7 @@ export const mapWorkPoolQueueResponseToWorkPoolQueue: MapFunction<WorkPoolQueueR
     isPaused: source.is_paused ?? false,
     concurrencyLimit: source.concurrency_limit,
     priority: source.priority,
-    status: source.status.toLowerCase() as Lowercase<WorkPoolQueueResponseStatus>,
+    status: (source.status?.toLowerCase() ?? 'not_ready') as Lowercase<WorkPoolQueueResponseStatus>,
   })
 }
 

--- a/src/models/api/WorkPoolQueueResponse.ts
+++ b/src/models/api/WorkPoolQueueResponse.ts
@@ -13,5 +13,5 @@ export type WorkPoolQueueResponse = {
   is_paused: boolean | null,
   concurrency_limit: number | null,
   priority: number,
-  status: WorkPoolQueueResponseStatus,
+  status?: WorkPoolQueueResponseStatus,
 }

--- a/src/models/api/WorkPoolQueueResponse.ts
+++ b/src/models/api/WorkPoolQueueResponse.ts
@@ -13,5 +13,5 @@ export type WorkPoolQueueResponse = {
   is_paused: boolean | null,
   concurrency_limit: number | null,
   priority: number,
-  status?: WorkPoolQueueResponseStatus,
+  status?: WorkPoolQueueResponseStatus | null,
 }


### PR DESCRIPTION
Fixes runtime error when API isn't returning a work pool queue's status yet. 