### PR TITLE
Schemas: List enhancements and support prefect_kind

### DIFF
--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -33,8 +33,8 @@
   import { computed } from 'vue'
   import SchemaFormPropertyMenu from '@/schemas/components/SchemaFormPropertyMenu.vue'
   import { usePrefectKind } from '@/schemas/compositions/usePrefectKind'
-  import { usePropertyInput } from '@/schemas/compositions/usePropertyInput'
   import { useSchemaProperty } from '@/schemas/compositions/useSchemaProperty'
+  import { useSchemaPropertyInput } from '@/schemas/compositions/useSchemaPropertyInput'
   import { SchemaProperty } from '@/schemas/types/schema'
   import { SchemaValue } from '@/schemas/types/schemaValues'
   import { isNullish } from '@/utilities'
@@ -73,7 +73,7 @@
   }
 
   const { kind } = usePrefectKind(value)
-  const { input } = usePropertyInput(property, value)
+  const { input } = useSchemaPropertyInput(property, value)
 </script>
 
 <style>

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -4,7 +4,7 @@
       <div class="schema-form-property__header">
         <span>{{ label }}</span>
 
-        <SchemaFormPropertyMenu v-model:kind="kind" />
+        <SchemaFormPropertyMenu v-model:kind="kind" flat />
       </div>
     </template>
 

--- a/src/schemas/components/SchemaFormPropertyArray.vue
+++ b/src/schemas/components/SchemaFormPropertyArray.vue
@@ -7,22 +7,17 @@
     </template>
     <p-draggable-list v-model="value" allow-create allow-delete :generator="generator">
       <template #item="{ index, handleDown, handleUp, deleteItem, moveToTop, moveToBottom }">
-        <div class="schema-form-property-array__item">
-          <PIcon icon="DragHandle" class="schema-form-property-array__handle" @mousedown="handleDown" @mouseup="handleUp" />
-
-          <SchemaFormPropertyInput v-model:value="value[index]" :property="getPropertyForIndex(index)" />
-
-          <SchemaFormPropertyMenu v-model:kind="kind">
-            <template v-if="!isFirstIndex(index)">
-              <p-overflow-menu-item icon="ArrowSmallUpIcon" label="Move to top" @click="moveToTop" />
-            </template>
-            <template v-if="!isLastIndex(index)">
-              <p-overflow-menu-item icon="ArrowSmallDownIcon" label="Move to bottom" @click="moveToBottom" />
-            </template>
-
-            <p-overflow-menu-item icon="TrashIcon" label="Delete" @click="deleteItem" />
-          </SchemaFormPropertyMenu>
-        </div>
+        <SchemaFormPropertyArrayItem
+          v-model:value="value[index]"
+          :property="getPropertyForIndex(index)"
+          :is-first="isFirstIndex(index)"
+          :is-last="isLastIndex(index)"
+          @delete-item="deleteItem"
+          @handle-down="handleDown"
+          @handle-up="handleUp"
+          @move-to-top="moveToTop"
+          @move-to-bottom="moveToBottom"
+        />
       </template>
     </p-draggable-list>
   </div>
@@ -30,21 +25,18 @@
 
 <script lang="ts" setup>
   import { isArray } from '@prefecthq/prefect-design'
-  import { computed, ref } from 'vue'
-  import SchemaFormPropertyInput from '@/schemas/components/SchemaFormPropertyInput.vue'
-  import SchemaFormPropertyMenu from '@/schemas/components/SchemaFormPropertyMenu.vue'
+  import { computed } from 'vue'
+  import SchemaFormPropertyArrayItem from '@/schemas/components/SchemaFormPropertyArrayItem.vue'
   import { useSchemaProperty } from '@/schemas/compositions/useSchemaProperty'
   import { SchemaProperty } from '@/schemas/types/schema'
-  import { PrefectKind } from '@/schemas/types/schemaValues'
 
   const props = defineProps<{
     property: SchemaProperty & { type: 'array' },
     value: unknown[] | null,
   }>()
 
-  const property = useSchemaProperty(() => props.property)
+  const { property } = useSchemaProperty(() => props.property)
   const empty = computed(() => !props.value?.length)
-  const kind = ref<PrefectKind>('none')
 
   const emit = defineEmits<{
     'update:value': [unknown[] | null],
@@ -102,17 +94,5 @@
   text-sm
   italic;
   margin-left: 30px;
-}
-
-.schema-form-property-array__item { @apply
-  grid
-  gap-2
-  items-start;
-  grid-template-columns: min-content 1fr min-content;
-}
-
-.schema-form-property-array__handle { @apply
-  cursor-grab
-  mt-2
 }
 </style>

--- a/src/schemas/components/SchemaFormPropertyArray.vue
+++ b/src/schemas/components/SchemaFormPropertyArray.vue
@@ -13,8 +13,10 @@
           <SchemaFormPropertyInput v-model:value="value[index]" :property="getPropertyForIndex(index)" />
 
           <SchemaFormPropertyMenu v-model:kind="kind">
-            <template v-if="multipleValues">
+            <template v-if="!isFirstIndex(index)">
               <p-overflow-menu-item icon="ArrowSmallUpIcon" label="Move to top" @click="moveToTop" />
+            </template>
+            <template v-if="!isLastIndex(index)">
               <p-overflow-menu-item icon="ArrowSmallDownIcon" label="Move to bottom" @click="moveToBottom" />
             </template>
 
@@ -42,7 +44,6 @@
 
   const property = useSchemaProperty(() => props.property)
   const empty = computed(() => !props.value?.length)
-  const multipleValues = computed(() => (props.value?.length ?? 0) > 1)
   const kind = ref<PrefectKind>('none')
 
   const emit = defineEmits<{
@@ -77,6 +78,14 @@
 
     return property.default ?? null
   }
+
+  function isFirstIndex(index: number): boolean {
+    return index === 0
+  }
+
+  function isLastIndex(index: number): boolean {
+    return index === (props.value?.length ?? 0) - 1
+  }
 </script>
 
 <style>
@@ -84,10 +93,15 @@
   block
 }
 
+.schema-form-property-array .p-draggable-list > .p-button {
+  margin-left: 30px;
+}
+
 .schema-form-property-array__empty { @apply
   text-subdued
   text-sm
-  italic
+  italic;
+  margin-left: 30px;
 }
 
 .schema-form-property-array__item { @apply

--- a/src/schemas/components/SchemaFormPropertyArrayItem.vue
+++ b/src/schemas/components/SchemaFormPropertyArrayItem.vue
@@ -23,7 +23,7 @@
   import { computed } from 'vue'
   import SchemaFormPropertyMenu from '@/schemas/components/SchemaFormPropertyMenu.vue'
   import { usePrefectKind } from '@/schemas/compositions/usePrefectKind'
-  import { usePropertyInput } from '@/schemas/compositions/usePropertyInput'
+  import { useSchemaPropertyInput } from '@/schemas/compositions/useSchemaPropertyInput'
   import { SchemaProperty } from '@/schemas/types/schema'
   import { SchemaValue } from '@/schemas/types/schemaValues'
 
@@ -52,7 +52,7 @@
     },
   })
 
-  const { input } = usePropertyInput(() => props.property, value)
+  const { input } = useSchemaPropertyInput(() => props.property, value)
   const { kind } = usePrefectKind(value)
 </script>
 

--- a/src/schemas/components/SchemaFormPropertyArrayItem.vue
+++ b/src/schemas/components/SchemaFormPropertyArrayItem.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="schema-form-property-array-item">
+    <PIcon icon="DragHandle" class="schema-form-property-array-item__handle" @mousedown="emit('handleDown')" @mouseup="emit('handleUp')" />
+
+    <keep-alive>
+      <component :is="input.component" v-bind="input.props" />
+    </keep-alive>
+
+    <SchemaFormPropertyMenu v-model:kind="kind">
+      <template v-if="!isFirst">
+        <p-overflow-menu-item icon="ArrowSmallUpIcon" label="Move to top" @click="emit('moveToTop')" />
+      </template>
+      <template v-if="!isLast">
+        <p-overflow-menu-item icon="ArrowSmallDownIcon" label="Move to bottom" @click="emit('moveToBottom')" />
+      </template>
+
+      <p-overflow-menu-item icon="TrashIcon" label="Delete" @click="emit('deleteItem')" />
+    </SchemaFormPropertyMenu>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import SchemaFormPropertyMenu from '@/schemas/components/SchemaFormPropertyMenu.vue'
+  import { usePrefectKind } from '@/schemas/compositions/usePrefectKind'
+  import { usePropertyInput } from '@/schemas/compositions/usePropertyInput'
+  import { SchemaProperty } from '@/schemas/types/schema'
+  import { SchemaValue } from '@/schemas/types/schemaValues'
+
+  const props = defineProps<{
+    property: SchemaProperty,
+    value: SchemaValue,
+    isLast: boolean,
+    isFirst: boolean,
+  }>()
+
+  const emit = defineEmits<{
+    'update:value': [SchemaValue],
+    'moveToTop': [],
+    'moveToBottom': [],
+    'deleteItem': [],
+    'handleDown': [],
+    'handleUp': [],
+  }>()
+
+  const value = computed({
+    get() {
+      return props.value
+    },
+    set(value) {
+      emit('update:value', value)
+    },
+  })
+
+  const { input } = usePropertyInput(() => props.property, value)
+  const { kind } = usePrefectKind(value)
+</script>
+
+<style>
+.schema-form-property-array-item { @apply
+  grid
+  gap-2
+  items-start;
+  grid-template-columns: min-content 1fr min-content;
+}
+
+.schema-form-property-array-item__handle { @apply
+  cursor-grab
+  mt-2
+}
+</style>

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -36,7 +36,7 @@
     emit('update:value', value)
   }
 
-  const property = useSchemaProperty(() => props.property)
+  const { property } = useSchemaProperty(() => props.property)
 
   const input = computed(() => {
     const { type } = property.value

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -4,7 +4,7 @@
     <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="emit('update:kind', 'none')" />
 
     <template v-if="$slots.default">
-      <p-divider />
+      <p-divider class="schema-form-property-menu__divider" />
       <slot />
     </template>
   </p-icon-button-menu>
@@ -25,3 +25,9 @@
     return props.kind !== kind
   }
 </script>
+
+<style>
+.schema-form-property-menu__divider .p-divider { @apply
+  m-0
+}
+</style>

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -2,6 +2,11 @@
   <p-icon-button-menu small flat class="schema-form-property-menu">
     <p-overflow-menu-item v-if="showKind('json')" label="Use JSON input" @click="emit('update:kind', 'json')" />
     <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="emit('update:kind', 'none')" />
+
+    <template v-if="$slots.default">
+      <p-divider />
+      <slot />
+    </template>
   </p-icon-button-menu>
 </template>
 

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-icon-button-menu small flat class="schema-form-property-menu">
+  <p-icon-button-menu small class="schema-form-property-menu">
     <p-overflow-menu-item v-if="showKind('json')" label="Use JSON input" @click="emit('update:kind', 'json')" />
     <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="emit('update:kind', 'none')" />
 

--- a/src/schemas/components/SchemaFormPropertyString.vue
+++ b/src/schemas/components/SchemaFormPropertyString.vue
@@ -20,7 +20,7 @@
     'update:value': [string | null],
   }>()
 
-  const property = useSchemaProperty(() => props.property)
+  const { property } = useSchemaProperty(() => props.property)
 
   const input = computed(() => {
     const { format } = property.value

--- a/src/schemas/compositions/usePrefectKind.ts
+++ b/src/schemas/compositions/usePrefectKind.ts
@@ -1,0 +1,34 @@
+import { Ref, computed } from 'vue'
+import { PrefectKind, isPrefectKindValue } from '@/schemas/types/schemaValues'
+
+export type UsePrefectKind = {
+  kind: Ref<PrefectKind>,
+}
+
+export function usePrefectKind(propertyValue: Ref<unknown>): UsePrefectKind {
+  const kindValuesMap: Partial<Record<PrefectKind, unknown>> = {}
+
+  const kind = computed<PrefectKind>({
+    get() {
+      if (isPrefectKindValue(propertyValue.value)) {
+        return propertyValue.value.__prefect_kind
+      }
+
+      return 'none'
+    },
+    set(__prefect_kind) {
+      kindValuesMap[kind.value] = propertyValue.value
+
+      if (__prefect_kind in kindValuesMap) {
+        propertyValue.value = kindValuesMap[__prefect_kind]
+        return
+      }
+
+      propertyValue.value = { __prefect_kind }
+    },
+  })
+
+  return {
+    kind,
+  }
+}

--- a/src/schemas/compositions/usePropertyInput.ts
+++ b/src/schemas/compositions/usePropertyInput.ts
@@ -1,0 +1,49 @@
+import { MaybeRefOrGetter, Ref, computed, toValue } from 'vue'
+import SchemaFormPropertyInput from '@/schemas/components/SchemaFormPropertyInput.vue'
+import SchemaFormPropertyKindJson from '@/schemas/components/SchemaFormPropertyKindJson.vue'
+import { SchemaProperty } from '@/schemas/types/schema'
+import { isPrefectKindValue } from '@/schemas/types/schemaValues'
+import { SchemaValue } from '@/types'
+import { withProps } from '@/utilities/components'
+
+// this is a lot easier to just let typescript infer the return type
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function usePropertyInput(schemaProperty: MaybeRefOrGetter<SchemaProperty>, propertyValue: Ref<SchemaValue>) {
+  const input = computed(() => {
+    const property = toValue(schemaProperty)
+
+    if (!isPrefectKindValue(propertyValue.value)) {
+      return withProps(SchemaFormPropertyInput, {
+        property: property,
+        value: propertyValue.value,
+        'onUpdate:value': (value) => propertyValue.value = value,
+      })
+    }
+
+    if (isPrefectKindValue(propertyValue.value, 'json')) {
+      return withProps(SchemaFormPropertyKindJson, {
+        value: propertyValue.value,
+        'onUpdate:value': (value) => propertyValue.value = value,
+      })
+    }
+
+    if (isPrefectKindValue(propertyValue.value, 'jinja')) {
+      throw 'not implemented'
+    }
+
+    if (isPrefectKindValue(propertyValue.value, 'workspace_variable')) {
+      throw 'not implemented'
+    }
+
+    if (isPrefectKindValue(propertyValue.value, 'none')) {
+      throw 'not implemented'
+    }
+
+    const exhaustive: never = propertyValue.value
+    console.error(new Error(`SchemaFormProperty input is not exhaustive: ${JSON.stringify(exhaustive)}`))
+
+    return { component: null, props: {} }
+  })
+
+  return { input }
+}

--- a/src/schemas/compositions/useSchemaProperty.ts
+++ b/src/schemas/compositions/useSchemaProperty.ts
@@ -4,7 +4,14 @@ import { useSchema } from '@/schemas/compositions/useSchema'
 import { SchemaProperty, isPropertyWith } from '@/schemas/types/schema'
 import { getSchemaDefinition } from '@/schemas/utilities/definitions'
 
-export function useSchemaProperty(source: MaybeRefOrGetter<SchemaProperty>): ComputedRef<SchemaProperty> {
+type UseSchemaProperty = {
+  property: ComputedRef<SchemaProperty>,
+  label: ComputedRef<string>,
+  description: ComputedRef<string>,
+  disabled: ComputedRef<boolean>,
+}
+
+export function useSchemaProperty(source: MaybeRefOrGetter<SchemaProperty>, required?: MaybeRefOrGetter<boolean>): UseSchemaProperty {
   const schema = useSchema()
 
   const property = computed(() => {
@@ -17,5 +24,30 @@ export function useSchemaProperty(source: MaybeRefOrGetter<SchemaProperty>): Com
     return value
   })
 
-  return property
+
+  const label = computed(() => {
+    const title = property.value.title ?? ''
+
+    if (!toValue(required)) {
+      return `${title} (Optional)`.trim()
+    }
+
+    return title
+  })
+
+  const description = computed(() => {
+    const { description = '' } = property.value
+    const descriptionWithNewlinesRemoved = description.replace(/\n(?!\n)/g, ' ')
+
+    return descriptionWithNewlinesRemoved
+  })
+
+  const disabled = computed(() => Boolean(property.value.const))
+
+  return {
+    property,
+    label,
+    description,
+    disabled,
+  }
 }

--- a/src/schemas/compositions/useSchemaPropertyInput.ts
+++ b/src/schemas/compositions/useSchemaPropertyInput.ts
@@ -8,7 +8,7 @@ import { withProps } from '@/utilities/components'
 
 // this is a lot easier to just let typescript infer the return type
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function usePropertyInput(schemaProperty: MaybeRefOrGetter<SchemaProperty>, propertyValue: Ref<SchemaValue>) {
+export function useSchemaPropertyInput(schemaProperty: MaybeRefOrGetter<SchemaProperty>, propertyValue: Ref<SchemaValue>) {
   const input = computed(() => {
     const property = toValue(schemaProperty)
 


### PR DESCRIPTION
# Description
Adds the ability to switch between prefect kinds for individual list items. Adds menu items for "Move to bottom" and "Move to top". Abstracts the logic for prefect kind as well as schema property input into compositions for reuse. 

<img width="763" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/d148c7e7-2d2b-476b-9ac0-9af6819c4a29">
