### PR TITLE
Schemas: Add ability to omit specific values

### DIFF
--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -32,6 +32,7 @@
 </template>
 
 <script lang="ts" setup>
+  import { isDefined } from '@prefecthq/prefect-design'
   import debounce from 'lodash.debounce'
   import { computed } from 'vue'
   import SchemaFormProperty from '@/schemas/components/SchemaFormProperty.vue'
@@ -40,7 +41,6 @@
   import { SchemaProperty, SchemaProperties, isPropertyWith } from '@/schemas/types/schema'
   import { SchemaValues } from '@/schemas/types/schemaValues'
   import { SchemaValue } from '@/types'
-  import { isNullish } from '@/utilities'
 
   const props = defineProps<{
     parent: SchemaProperty,
@@ -85,7 +85,7 @@
     patches.forEach(({ propertyKey, value }) => {
       updatedValues[propertyKey] = value
 
-      if (isNullish(value)) {
+      if (!isDefined(value)) {
         delete updatedValues[propertyKey]
       }
     })

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -88,7 +88,7 @@
       return null
     },
     set(value) {
-      emit('update:value', value)
+      emit('update:value', value ?? undefined)
     },
   })
 
@@ -101,16 +101,18 @@
 
   function toggleValue(): void {
     if (omitted.value) {
-      value.value = omittedValue.value
       omittedValue.value = null
       omitted.value = false
+
+      emit('update:value', omittedValue.value)
 
       return
     }
 
     omittedValue.value = value.value
-    value.value = null
     omitted.value = true
+
+    emit('update:value', null)
   }
 </script>
 

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -4,10 +4,6 @@
       <div class="schema-form-property__header">
         <span class="schema-form-property__label" :class="classes.label">{{ label }}</span>
 
-        <template v-if="omitted">
-          <span class="text-subdued">(None)</span>
-        </template>
-
         <SchemaFormPropertyMenu v-model:kind="kind" class="ml-auto" :disabled="omitted" flat>
           <template v-if="!required" #default>
             <p-overflow-menu-item :label="omitLabel" @click="toggleValue" />
@@ -101,18 +97,16 @@
 
   function toggleValue(): void {
     if (omitted.value) {
+      value.value = omittedValue.value
       omittedValue.value = null
       omitted.value = false
-
-      emit('update:value', omittedValue.value)
 
       return
     }
 
+    value.value = undefined
     omittedValue.value = value.value
     omitted.value = true
-
-    emit('update:value', null)
   }
 </script>
 

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -8,7 +8,7 @@
           <span class="text-subdued">(None)</span>
         </template>
 
-        <SchemaFormPropertyMenu v-model:kind="kind" class="ml-auto" flat>
+        <SchemaFormPropertyMenu v-model:kind="kind" class="ml-auto" :disabled="omitted" flat>
           <p-overflow-menu-item :label="omitLabel" @click="toggleValue" />
         </SchemaFormPropertyMenu>
       </div>

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -9,7 +9,9 @@
         </template>
 
         <SchemaFormPropertyMenu v-model:kind="kind" class="ml-auto" :disabled="omitted" flat>
-          <p-overflow-menu-item :label="omitLabel" @click="toggleValue" />
+          <template v-if="!required" #default>
+            <p-overflow-menu-item :label="omitLabel" @click="toggleValue" />
+          </template>
         </SchemaFormPropertyMenu>
       </div>
     </template>

--- a/src/schemas/components/SchemaFormPropertyDate.vue
+++ b/src/schemas/components/SchemaFormPropertyDate.vue
@@ -9,11 +9,11 @@
   import { isInvalidDate } from '@/utilities'
 
   const props = defineProps<{
-    value: string | null,
+    value: string | null | undefined,
   }>()
 
   const emit = defineEmits<{
-    'update:value': [string | null],
+    'update:value': [string | null | undefined],
   }>()
 
   const dateFormat = 'yyyy-MM-dd'
@@ -24,7 +24,7 @@
         const parsed = parse(props.value, dateFormat, startOfToday())
 
         if (isInvalidDate(parsed)) {
-          return null
+          return undefined
         }
 
         return parsed

--- a/src/schemas/components/SchemaFormPropertyDateTime.vue
+++ b/src/schemas/components/SchemaFormPropertyDateTime.vue
@@ -10,11 +10,11 @@
   import { isInvalidDate } from '@/utilities'
 
   const props = defineProps<{
-    value: string | null,
+    value: string | null | undefined,
   }>()
 
   const emit = defineEmits<{
-    'update:value': [string | null],
+    'update:value': [string | null | undefined],
   }>()
 
   const value = computed({
@@ -23,7 +23,7 @@
         const parsed = parseISO(props.value)
 
         if (isInvalidDate(parsed)) {
-          return null
+          return undefined
         }
 
         return parsed

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -1,10 +1,12 @@
 <template>
   <p-icon-button-menu small class="schema-form-property-menu">
-    <p-overflow-menu-item v-if="showKind('json')" label="Use JSON input" @click="emit('update:kind', 'json')" />
-    <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="emit('update:kind', 'none')" />
+    <template v-if="!disabled">
+      <p-overflow-menu-item v-if="showKind('json')" label="Use JSON input" @click="emit('update:kind', 'json')" />
+      <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="emit('update:kind', 'none')" />
+    </template>
 
     <template v-if="$slots.default">
-      <p-divider class="schema-form-property-menu__divider" />
+      <p-divider v-if="!disabled" class="schema-form-property-menu__divider" />
       <slot />
     </template>
   </p-icon-button-menu>
@@ -15,6 +17,7 @@
 
   const props = defineProps<{
     kind: PrefectKind,
+    disabled?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/schemas/components/SchemaFormPropertyString.vue
+++ b/src/schemas/components/SchemaFormPropertyString.vue
@@ -13,11 +13,11 @@
 
   const props = defineProps<{
     property: SchemaProperty & { type: 'string' },
-    value: string | null,
+    value: string | null | undefined,
   }>()
 
   const emit = defineEmits<{
-    'update:value': [string | null],
+    'update:value': [string | null | undefined],
   }>()
 
   const { property } = useSchemaProperty(() => props.property)
@@ -53,7 +53,12 @@
     })
   })
 
-  function update(value: string | null): void {
+  function update(value: string | null | undefined): void {
+    if (!value) {
+      emit('update:value', undefined)
+      return
+    }
+
     emit('update:value', value)
   }
 </script>


### PR DESCRIPTION
# Description
Adds a menu item to omit a specific value from a form. Omitting the value disabled the property and removes its value from the from values. Enabling the property adds the original value back to the form values. 

Note: You can only omit an optional value

<img width="787" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/23c50310-3e35-41ed-b347-5714863a6f00">
<img width="785" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/e5b44194-430e-4f87-bf5b-18d206443b83">
