### PR TITLE
Schemas: Add support for jinja templates

### DIFF
--- a/src/schemas/components/SchemaFormPropertyKindJinja.vue
+++ b/src/schemas/components/SchemaFormPropertyKindJinja.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-code-input v-model="value" lang="jinja" class="schema-form-property-kind-jinja" />
+  <p-code-input v-model="value" lang="jinja" class="schema-form-property-kind-jinja" show-line-numbers />
 </template>
 
 <script lang="ts" setup>

--- a/src/schemas/components/SchemaFormPropertyKindJinja.vue
+++ b/src/schemas/components/SchemaFormPropertyKindJinja.vue
@@ -1,0 +1,28 @@
+<template>
+  <p-code-input v-model="value" lang="jinja" class="schema-form-property-kind-jinja" />
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { PrefectKindJinja } from '@/schemas/types/schemaValues'
+
+  const props = defineProps<{
+    value: PrefectKindJinja,
+  }>()
+
+  const emit = defineEmits<{
+    'update:value': [PrefectKindJinja],
+  }>()
+
+  const value = computed({
+    get() {
+      return props.value.template
+    },
+    set(template) {
+      emit('update:value', {
+        __prefect_kind: 'jinja',
+        template,
+      })
+    },
+  })
+</script>

--- a/src/schemas/components/SchemaFormPropertyKindJson.vue
+++ b/src/schemas/components/SchemaFormPropertyKindJson.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-code-input v-model="value" lang="json" class="schema-form-property-kind-json" />
+  <p-code-input v-model="value" lang="json" class="schema-form-property-kind-json" show-line-numbers />
 </template>
 
 <script lang="ts" setup>

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -4,6 +4,7 @@
       <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="emit('update:kind', 'none')" />
       <p-overflow-menu-item v-if="showKind('json')" label="Use JSON input" @click="emit('update:kind', 'json')" />
       <p-overflow-menu-item v-if="showKind('workspace_variable')" label="Select variable" @click="emit('update:kind', 'workspace_variable')" />
+      <p-overflow-menu-item v-if="showKind('jinja')" label="Create a template" @click="emit('update:kind', 'jinja')" />
     </template>
 
     <template v-if="$slots.default">

--- a/src/schemas/compositions/useSchemaPropertyInput.ts
+++ b/src/schemas/compositions/useSchemaPropertyInput.ts
@@ -1,5 +1,6 @@
 import { MaybeRefOrGetter, Ref, computed, toValue } from 'vue'
 import SchemaFormPropertyInput from '@/schemas/components/SchemaFormPropertyInput.vue'
+import SchemaFormPropertyKindJinja from '@/schemas/components/SchemaFormPropertyKindJinja.vue'
 import SchemaFormPropertyKindJson from '@/schemas/components/SchemaFormPropertyKindJson.vue'
 import SchemaFormPropertyKindWorkspaceVariable from '@/schemas/components/SchemaFormPropertyKindWorkspaceVariable.vue'
 import { SchemaProperty } from '@/schemas/types/schema'
@@ -29,7 +30,10 @@ export function useSchemaPropertyInput(schemaProperty: MaybeRefOrGetter<SchemaPr
     }
 
     if (isPrefectKindValue(propertyValue.value, 'jinja')) {
-      throw 'not implemented'
+      return withProps(SchemaFormPropertyKindJinja, {
+        value: propertyValue.value,
+        'onUpdate:value': (value) => propertyValue.value = value,
+      })
     }
 
     if (isPrefectKindValue(propertyValue.value, 'workspace_variable')) {


### PR DESCRIPTION
# Description
Adds support for using jinja templates for schema properties

<img width="799" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/3f47e4d7-7e2c-4a17-9934-6b8a80cf0fca">
<img width="793" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/7d9f5f4b-84ee-4b7b-b7e2-258e48e2e1c0">
