### PR TITLE
Schemas: Specify supported `kind` values per implementation

### DIFF
--- a/src/schemas/components/SchemaForm.vue
+++ b/src/schemas/components/SchemaForm.vue
@@ -10,15 +10,18 @@
   import { provide, computed } from 'vue'
   import SchemaFormProperties from '@/schemas/components/SchemaFormProperties.vue'
   import { schemaInjectionKey } from '@/schemas/compositions/useSchema'
+  import { schemaFormKindsInjectionKey } from '@/schemas/compositions/useSchemaFormKinds'
   import { Schema } from '@/schemas/types/schema'
-  import { SchemaValues } from '@/schemas/types/schemaValues'
+  import { PrefectKind, SchemaValues } from '@/schemas/types/schemaValues'
 
   const props = defineProps<{
     schema: Schema,
     values: SchemaValues,
+    kinds: PrefectKind[],
   }>()
 
   provide(schemaInjectionKey, props.schema)
+  provide(schemaFormKindsInjectionKey, props.kinds)
 
   const emit = defineEmits<{
     'update:values': [SchemaValues],

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-icon-button-menu small class="schema-form-property-menu">
+  <p-icon-button-menu v-if="showMenu" small class="schema-form-property-menu">
     <template v-if="!disabled">
       <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="emit('update:kind', 'none')" />
       <p-overflow-menu-item v-if="showKind('json')" label="Use JSON input" @click="emit('update:kind', 'json')" />
@@ -8,13 +8,15 @@
     </template>
 
     <template v-if="$slots.default">
-      <p-divider v-if="!disabled" class="schema-form-property-menu__divider" />
+      <p-divider v-if="showDivider" class="schema-form-property-menu__divider" />
       <slot />
     </template>
   </p-icon-button-menu>
 </template>
 
 <script lang="ts" setup>
+  import { computed, useSlots } from 'vue'
+  import { useSchemaFormKinds } from '@/schemas/compositions/useSchemaFormKinds'
   import { PrefectKind } from '@/schemas/types/schemaValues'
 
   const props = defineProps<{
@@ -26,8 +28,14 @@
     'update:kind': [PrefectKind],
   }>()
 
+  const slots = useSlots()
+  const kinds = useSchemaFormKinds()
+
+  const showMenu = computed(() => kinds.length || slots.default)
+  const showDivider = computed(() => !props.disabled && kinds.length)
+
   function showKind(kind: PrefectKind): boolean {
-    return props.kind !== kind
+    return props.kind !== kind && kinds.includes(kind)
   }
 </script>
 

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -7,7 +7,7 @@
       <p-overflow-menu-item v-if="showKind('jinja')" label="Create a template" @click="emit('update:kind', 'jinja')" />
     </template>
 
-    <template v-if="$slots.default">
+    <template v-if="slots.default">
       <p-divider v-if="showDivider" class="schema-form-property-menu__divider" />
       <slot />
     </template>

--- a/src/schemas/compositions/useSchemaFormKinds.ts
+++ b/src/schemas/compositions/useSchemaFormKinds.ts
@@ -1,0 +1,8 @@
+import { InjectionKey, inject } from 'vue'
+import { PrefectKind, prefectKinds } from '@/schemas/types/schemaValues'
+
+export const schemaFormKindsInjectionKey: InjectionKey<Readonly<PrefectKind[]>> = Symbol()
+
+export function useSchemaFormKinds(): Readonly<PrefectKind[]> {
+  return inject(schemaFormKindsInjectionKey, prefectKinds)
+}


### PR DESCRIPTION
# Description
Adds a prop for specifying which prefect kind features are supported. This will allow each implementation to pick and choose features. For example `jinja` is currently only supported for automations. 