### PR TITLE
Schema: Validation errors

### DIFF
--- a/src/schemas/components/SchemaForm.vue
+++ b/src/schemas/components/SchemaForm.vue
@@ -1,7 +1,7 @@
 <template>
   <p-form class="schema-form" @submit="submit">
     <template v-if="schema.properties">
-      <SchemaFormProperties v-model:values="values" :parent="schema" :properties="schema.properties" />
+      <SchemaFormProperties v-model:values="values" :parent="schema" :properties="schema.properties" :errors="errors" />
     </template>
   </p-form>
 </template>
@@ -14,7 +14,7 @@
   import { schemaFormKindsInjectionKey } from '@/schemas/compositions/useSchemaFormKinds'
   import { Schema } from '@/schemas/types/schema'
   import { PrefectKind, SchemaValues } from '@/schemas/types/schemaValues'
-  import { SchemaValuesValidationError } from '@/schemas/types/schemaValuesValidationResponse'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
 
   const props = withDefaults(defineProps<{
     schema: Schema,
@@ -35,7 +35,7 @@
   }>()
 
   const api = useWorkspaceApi()
-  const errors = ref<SchemaValuesValidationError[]>()
+  const errors = ref<SchemaValueError[]>([])
 
   const values = computed({
     get() {

--- a/src/schemas/components/SchemaForm.vue
+++ b/src/schemas/components/SchemaForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-form class="schema-form">
+  <p-form class="schema-form" @submit="submit">
     <template v-if="schema.properties">
       <SchemaFormProperties v-model:values="values" :parent="schema" :properties="schema.properties" />
     </template>
@@ -7,25 +7,35 @@
 </template>
 
 <script lang="ts" setup>
-  import { provide, computed } from 'vue'
+  import { provide, computed, ref } from 'vue'
+  import { useWorkspaceApi } from '@/compositions'
   import SchemaFormProperties from '@/schemas/components/SchemaFormProperties.vue'
   import { schemaInjectionKey } from '@/schemas/compositions/useSchema'
   import { schemaFormKindsInjectionKey } from '@/schemas/compositions/useSchemaFormKinds'
   import { Schema } from '@/schemas/types/schema'
   import { PrefectKind, SchemaValues } from '@/schemas/types/schemaValues'
+  import { SchemaValuesValidationError } from '@/schemas/types/schemaValuesValidationResponse'
 
-  const props = defineProps<{
+  const props = withDefaults(defineProps<{
     schema: Schema,
     values: SchemaValues,
     kinds: PrefectKind[],
-  }>()
+    loading?: boolean | null,
+  }>(), {
+    loading: null,
+  })
 
   provide(schemaInjectionKey, props.schema)
   provide(schemaFormKindsInjectionKey, props.kinds)
 
   const emit = defineEmits<{
     'update:values': [SchemaValues],
+    'update:loading': [boolean],
+    'submit': [SchemaValues],
   }>()
+
+  const api = useWorkspaceApi()
+  const errors = ref<SchemaValuesValidationError[]>()
 
   const values = computed({
     get() {
@@ -35,4 +45,36 @@
       emit('update:values', values)
     },
   })
+
+  const loadingFallback = ref(false)
+  const loading = computed({
+    get() {
+      return props.loading ?? loadingFallback.value
+    },
+    set(value) {
+      loadingFallback.value = value
+      emit('update:loading', value)
+    },
+  })
+
+  async function submit(): Promise<void> {
+    loading.value = true
+
+    try {
+      const { valid, errors: errorsResponse } = await api.schemas.validate(props.schema, values.value)
+      console.log(errorsResponse)
+
+      errors.value = errorsResponse
+
+      if (!valid) {
+        return
+      }
+    } catch (error) {
+      console.error(error)
+    } finally {
+      loading.value = false
+    }
+
+    emit('submit', values.value)
+  }
 </script>

--- a/src/schemas/components/SchemaForm.vue
+++ b/src/schemas/components/SchemaForm.vue
@@ -62,7 +62,6 @@
 
     try {
       const { valid, errors: errorsResponse } = await api.schemas.validate(props.schema, values.value)
-      console.log(errorsResponse)
 
       errors.value = errorsResponse
 

--- a/src/schemas/components/SchemaFormKindInput.vue
+++ b/src/schemas/components/SchemaFormKindInput.vue
@@ -3,16 +3,19 @@
 </template>
 
 <script lang="ts" setup>
-  import { PCodeInput } from '@prefecthq/prefect-design'
+  import { PCodeInput, State } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import SchemaFormPropertyInput from '@/schemas/components/SchemaFormPropertyInput.vue'
   import { SchemaProperty } from '@/schemas/types/schema'
   import { PrefectKindValue, isPrefectKindJinja, isPrefectKindJson, isPrefectKindNull, isPrefectKindWorkspaceVariable } from '@/schemas/types/schemaValues'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
   import { withProps } from '@/utilities/components'
 
   const props = defineProps<{
     property: SchemaProperty,
     value: PrefectKindValue,
+    errors: SchemaValueError[],
+    state: State,
   }>()
 
   const emit = defineEmits<{
@@ -50,6 +53,8 @@
       return withProps(SchemaFormPropertyInput, {
         property: props.property,
         value: props.value.value,
+        errors: props.errors,
+        state: props.state,
         'onUpdate:value': value => emit('update:value', {
           __prefect_kind: 'none',
           value,

--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -6,6 +6,7 @@
           :value="getValue(key)"
           :property="property"
           :required="getRequired(key)"
+          :errors="getSchemaPropertyErrors(key, errors)"
           @update:value="setValue(key, $event)"
         />
       </template>
@@ -15,6 +16,7 @@
           :value="getValue(key)"
           :property="property"
           :required="getRequired(key)"
+          :errors="getSchemaPropertyErrors(key, errors)"
           @update:value="setValue(key, $event)"
         />
       </template>
@@ -24,6 +26,7 @@
           :value="getValue(key)"
           :property="property"
           :required="getRequired(key)"
+          :errors="getSchemaPropertyErrors(key, errors)"
           @update:value="setValue(key, $event)"
         />
       </template>
@@ -40,12 +43,15 @@
   import SchemaFormPropertyAnyOf from '@/schemas/components/SchemaFormPropertyAnyOf.vue'
   import { SchemaProperty, SchemaProperties, isPropertyWith } from '@/schemas/types/schema'
   import { SchemaValues } from '@/schemas/types/schemaValues'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
+  import { getSchemaPropertyErrors } from '@/schemas/utilities/errors'
   import { SchemaValue } from '@/types'
 
   const props = defineProps<{
     parent: SchemaProperty,
     properties: SchemaProperties,
     values: SchemaValues | undefined,
+    errors: SchemaValueError[],
   }>()
 
   const emit = defineEmits<{

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-label class="schema-form-property">
+  <p-label class="schema-form-property" :state="error.state" :message="error.message">
     <template #label>
       <div class="schema-form-property__header">
         <span class="schema-form-property__label" :class="classes.label">{{ label }}</span>
@@ -26,7 +26,7 @@
       </template>
 
       <keep-alive>
-        <component :is="input.component" v-bind="input.props" />
+        <component :is="input.component" v-bind="input.props" :errors="errors" />
       </keep-alive>
     </fieldset>
   </p-label>
@@ -41,18 +41,22 @@
   import { useSchemaPropertyInput } from '@/schemas/compositions/useSchemaPropertyInput'
   import { SchemaProperty } from '@/schemas/types/schema'
   import { SchemaValue } from '@/schemas/types/schemaValues'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
+  import { getSchemaPropertyError } from '@/schemas/utilities/errors'
   import { isNullish } from '@/utilities'
 
   const props = defineProps<{
     property: SchemaProperty,
     value: SchemaValue,
     required: boolean,
+    errors: SchemaValueError[],
   }>()
 
   const emit = defineEmits<{
     'update:value': [SchemaValue],
   }>()
 
+  const error = computed(() => getSchemaPropertyError(props.errors))
   const { property, label, description, disabled } = useSchemaProperty(() => props.property, () => props.required)
   const omitted = ref(false)
   const omittedValue = ref<SchemaValue>(null)
@@ -93,7 +97,7 @@
   }
 
   const { kind } = usePrefectKind(value)
-  const { input } = useSchemaPropertyInput(property, value)
+  const { input } = useSchemaPropertyInput(property, value, () => props.errors)
 
   function toggleValue(): void {
     if (omitted.value) {

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -26,7 +26,7 @@
       </template>
 
       <keep-alive>
-        <component :is="input.component" v-bind="input.props" :errors="errors" />
+        <component :is="input.component" v-bind="input.props" />
       </keep-alive>
     </fieldset>
   </p-label>

--- a/src/schemas/components/SchemaFormPropertyAllOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAllOf.vue
@@ -1,5 +1,5 @@
 <template>
-  <SchemaFormProperty v-model:value="value" :property="property" :required="required" />
+  <SchemaFormProperty v-model:value="value" :property="property" :required="required" :errors="errors" />
 </template>
 
 <script lang="ts" setup>
@@ -9,6 +9,7 @@
   import { useSchema } from '@/schemas/compositions/useSchema'
   import { SchemaProperty, isPropertyWith } from '@/schemas/types/schema'
   import { SchemaValue } from '@/schemas/types/schemaValues'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
   import { getSchemaDefinition } from '@/schemas/utilities/definitions'
   import { Require } from '@/types/utilities'
 
@@ -16,6 +17,7 @@
     property: Require<SchemaProperty, 'allOf'>,
     value: SchemaValue,
     required: boolean,
+    errors: SchemaValueError[],
   }>()
 
   const emit = defineEmits<{

--- a/src/schemas/components/SchemaFormPropertyAnyOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOf.vue
@@ -4,7 +4,7 @@
   </div>
 
   <p-card>
-    <SchemaFormProperty :key="selectedPropertyIndexValue" v-model:value="value" :property="property" :required="required" />
+    <SchemaFormProperty :key="selectedPropertyIndexValue" v-model:value="value" :property="property" :required="required" :errors="errors" />
   </p-card>
 </template>
 
@@ -16,6 +16,7 @@
   import { useSchema } from '@/schemas/compositions/useSchema'
   import { SchemaProperty, isPropertyWith } from '@/schemas/types/schema'
   import { SchemaValue } from '@/schemas/types/schemaValues'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
   import { getSchemaDefinition } from '@/schemas/utilities/definitions'
   import { getInitialIndexForSchemaPropertyAnyOfValue, getSchemaPropertyLabel } from '@/schemas/utilities/properties'
   import { Require } from '@/types/utilities'
@@ -24,6 +25,7 @@
     property: Require<SchemaProperty, 'anyOf'>,
     value: SchemaValue,
     required: boolean,
+    errors: SchemaValueError[],
   }>()
 
   const api = useWorkspaceApi()

--- a/src/schemas/components/SchemaFormPropertyArray.vue
+++ b/src/schemas/components/SchemaFormPropertyArray.vue
@@ -5,7 +5,7 @@
         No items in this list
       </p>
     </template>
-    <p-draggable-list v-model="value" allow-create allow-delete :generator="generator">
+    <p-draggable-list v-model="value" allow-create allow-delete :generator="generator" :state="state">
       <template #item="{ index, handleDown, handleUp, deleteItem, moveToTop, moveToBottom }">
         <SchemaFormPropertyArrayItem
           v-model:value="value[index]"
@@ -24,7 +24,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { isArray } from '@prefecthq/prefect-design'
+  import { State, isArray } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import SchemaFormPropertyArrayItem from '@/schemas/components/SchemaFormPropertyArrayItem.vue'
   import { useSchemaProperty } from '@/schemas/compositions/useSchemaProperty'
@@ -33,6 +33,7 @@
   const props = defineProps<{
     property: SchemaProperty & { type: 'array' },
     value: unknown[] | null,
+    state: State,
   }>()
 
   const { property } = useSchemaProperty(() => props.property)

--- a/src/schemas/components/SchemaFormPropertyArray.vue
+++ b/src/schemas/components/SchemaFormPropertyArray.vue
@@ -10,6 +10,7 @@
         <SchemaFormPropertyArrayItem
           v-model:value="value[index]"
           :property="getPropertyForIndex(index)"
+          :errors="getSchemaPropertyErrors(index, errors)"
           :is-first="isFirstIndex(index)"
           :is-last="isLastIndex(index)"
           @delete-item="deleteItem"
@@ -29,10 +30,13 @@
   import SchemaFormPropertyArrayItem from '@/schemas/components/SchemaFormPropertyArrayItem.vue'
   import { useSchemaProperty } from '@/schemas/compositions/useSchemaProperty'
   import { SchemaProperty } from '@/schemas/types/schema'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
+  import { getSchemaPropertyErrors } from '@/schemas/utilities/errors'
 
   const props = defineProps<{
     property: SchemaProperty & { type: 'array' },
     value: unknown[] | null,
+    errors: SchemaValueError[],
     state: State,
   }>()
 
@@ -68,6 +72,8 @@
   function generator(): unknown {
     const index = value.value.length
     const property = getPropertyForIndex(index)
+
+    console.log(property)
 
     return property.default ?? null
   }

--- a/src/schemas/components/SchemaFormPropertyArray.vue
+++ b/src/schemas/components/SchemaFormPropertyArray.vue
@@ -73,8 +73,6 @@
     const index = value.value.length
     const property = getPropertyForIndex(index)
 
-    console.log(property)
-
     return property.default ?? null
   }
 

--- a/src/schemas/components/SchemaFormPropertyArrayItem.vue
+++ b/src/schemas/components/SchemaFormPropertyArrayItem.vue
@@ -26,12 +26,14 @@
   import { useSchemaPropertyInput } from '@/schemas/compositions/useSchemaPropertyInput'
   import { SchemaProperty } from '@/schemas/types/schema'
   import { SchemaValue } from '@/schemas/types/schemaValues'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
 
   const props = defineProps<{
     property: SchemaProperty,
     value: SchemaValue,
     isLast: boolean,
     isFirst: boolean,
+    errors: SchemaValueError[],
   }>()
 
   const emit = defineEmits<{
@@ -52,7 +54,7 @@
     },
   })
 
-  const { input } = useSchemaPropertyInput(() => props.property, value)
+  const { input } = useSchemaPropertyInput(() => props.property, value, () => props.errors)
   const { kind } = usePrefectKind(value)
 </script>
 

--- a/src/schemas/components/SchemaFormPropertyBlockDocument.vue
+++ b/src/schemas/components/SchemaFormPropertyBlockDocument.vue
@@ -1,8 +1,9 @@
 <template>
-  <BlockDocumentInput v-model="value" :block-type-slug="property.blockTypeSlug" class="schema-form-property-block-document" />
+  <BlockDocumentInput v-model="value" :block-type-slug="property.blockTypeSlug" :state="state" class="schema-form-property-block-document" />
 </template>
 
 <script lang="ts" setup>
+  import { State } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import BlockDocumentInput from '@/components/BlockDocumentInput.vue'
   import { SchemaProperty } from '@/schemas/types/schema'
@@ -12,6 +13,7 @@
   const props = defineProps<{
     property: Require<SchemaProperty, 'blockTypeSlug'>,
     value: BlockDocumentReferenceValue | null | undefined,
+    state: State,
   }>()
 
   const emit = defineEmits<{

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -83,6 +83,7 @@
       return withProps(SchemaFormPropertyArray, {
         property: { ...property.value, type },
         value: asType(value, Array),
+        errors: props.errors,
         state: props.state,
         'onUpdate:value': update,
       })

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { PNumberInput, PToggle } from '@prefecthq/prefect-design'
+  import { PNumberInput, PToggle, State } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import SchemaFormKindInput from '@/schemas/components/SchemaFormKindInput.vue'
   import SchemaFormPropertyArray from '@/schemas/components/SchemaFormPropertyArray.vue'
@@ -20,12 +20,15 @@
   import { useSchemaProperty } from '@/schemas/compositions/useSchemaProperty'
   import { SchemaProperty, isPropertyWith, isSchemaPropertyType } from '@/schemas/types/schema'
   import { SchemaValue, asBlockDocumentReferenceValue, isPrefectKindValue } from '@/schemas/types/schemaValues'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
   import { withProps } from '@/utilities/components'
   import { asType } from '@/utilities/types'
 
   const props = defineProps<{
     property: SchemaProperty,
     value: SchemaValue,
+    errors: SchemaValueError[],
+    state: State,
   }>()
 
   const emit = defineEmits<{
@@ -45,6 +48,7 @@
     if (isPropertyWith(property.value, 'blockTypeSlug')) {
       return withProps(SchemaFormPropertyBlockDocument, {
         property: property.value,
+        state: props.state,
         value: asBlockDocumentReferenceValue(value),
         'onUpdate:value': update,
       })
@@ -53,6 +57,7 @@
     if (isSchemaPropertyType(type, 'boolean')) {
       return withProps(PToggle, {
         modelValue: asType(value, Boolean),
+        state: props.state,
         'onUpdate:modelValue': update,
       })
     }
@@ -61,6 +66,7 @@
       return withProps(SchemaFormPropertyString, {
         property: { ...property.value, type },
         value: asType(value, String),
+        state: props.state,
         'onUpdate:value': update,
       })
     }
@@ -68,6 +74,7 @@
     if (isSchemaPropertyType(type, 'integer') || isSchemaPropertyType(type, 'number')) {
       return withProps(PNumberInput, {
         modelValue: asType(value, Number),
+        state: props.state,
         'onUpdate:modelValue': update,
       })
     }
@@ -76,6 +83,7 @@
       return withProps(SchemaFormPropertyArray, {
         property: { ...property.value, type },
         value: asType(value, Array),
+        state: props.state,
         'onUpdate:value': update,
       })
     }
@@ -84,6 +92,7 @@
       return withProps(SchemaFormPropertyObject, {
         property: { ...property.value, type },
         values: asType(value, Object),
+        errors: props.errors,
         'onUpdate:values': update,
       })
     }

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="schema-form-property-input">
     <template v-if="isPrefectKindValue(value)">
-      <SchemaFormKindInput :value="value" :property="property" @update:value="emit('update:value', $event)" />
+      <SchemaFormKindInput v-bind="{ value, property, errors, state }" @update:value="emit('update:value', $event)" />
     </template>
     <template v-else>
       <component :is="input.component" v-bind="input.props" />

--- a/src/schemas/components/SchemaFormPropertyKindJson.vue
+++ b/src/schemas/components/SchemaFormPropertyKindJson.vue
@@ -1,13 +1,17 @@
 <template>
-  <p-code-input v-model="value" lang="json" class="schema-form-property-kind-json" show-line-numbers />
+  <p-code-input v-model="value" lang="json" :state="state" class="schema-form-property-kind-json" show-line-numbers />
 </template>
 
 <script lang="ts" setup>
+  import { State } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import { PrefectKindJson } from '@/schemas/types/schemaValues'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
 
   const props = defineProps<{
     value: PrefectKindJson,
+    errors: SchemaValueError[],
+    state: State,
   }>()
 
   const emit = defineEmits<{

--- a/src/schemas/components/SchemaFormPropertyObject.vue
+++ b/src/schemas/components/SchemaFormPropertyObject.vue
@@ -1,6 +1,6 @@
 <template>
   <p-card class="schema-form-property-object">
-    <SchemaFormProperties v-model:values="values" :parent="property" :properties="property.properties ?? {}" />
+    <SchemaFormProperties v-model:values="values" :parent="property" :properties="property.properties ?? {}" :errors="errors" />
   </p-card>
 </template>
 
@@ -9,10 +9,12 @@
   import SchemaFormProperties from '@/schemas/components/SchemaFormProperties.vue'
   import { SchemaProperty } from '@/schemas/types/schema'
   import { SchemaValues } from '@/schemas/types/schemaValues'
+  import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
 
   const props = defineProps<{
     property: SchemaProperty & { type: 'object' },
     values: SchemaValues | undefined,
+    errors: SchemaValueError[],
   }>()
 
   const emit = defineEmits<{

--- a/src/schemas/components/SchemaFormPropertyString.vue
+++ b/src/schemas/components/SchemaFormPropertyString.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { PTextInput } from '@prefecthq/prefect-design'
+  import { PTextInput, State } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import SchemaFormPropertyDate from '@/schemas/components/SchemaFormPropertyDate.vue'
   import SchemaFormPropertyDateTime from '@/schemas/components/SchemaFormPropertyDateTime.vue'
@@ -14,6 +14,7 @@
   const props = defineProps<{
     property: SchemaProperty & { type: 'string' },
     value: string | null | undefined,
+    state: State,
   }>()
 
   const emit = defineEmits<{
@@ -28,6 +29,7 @@
     if (format === 'date') {
       return withProps(SchemaFormPropertyDate, {
         value: props.value,
+        state: props.state,
         'onUpdate:value': update,
       })
     }
@@ -35,6 +37,7 @@
     if (format === 'date-time') {
       return withProps(SchemaFormPropertyDateTime, {
         value: props.value,
+        state: props.state,
         'onUpdate:value': update,
       })
     }
@@ -43,12 +46,14 @@
       return withProps(PTextInput, {
         type: 'password',
         modelValue: props.value,
+        state: props.state,
         'onUpdate:modelValue': update,
       })
     }
 
     return withProps(PTextInput, {
       modelValue: props.value,
+      state: props.state,
       'onUpdate:modelValue': update,
     })
   })

--- a/src/schemas/compositions/useSchemaPropertyInput.ts
+++ b/src/schemas/compositions/useSchemaPropertyInput.ts
@@ -5,19 +5,25 @@ import SchemaFormPropertyKindJson from '@/schemas/components/SchemaFormPropertyK
 import SchemaFormPropertyKindWorkspaceVariable from '@/schemas/components/SchemaFormPropertyKindWorkspaceVariable.vue'
 import { SchemaProperty } from '@/schemas/types/schema'
 import { isPrefectKindValue } from '@/schemas/types/schemaValues'
+import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
+import { getSchemaPropertyError } from '@/schemas/utilities/errors'
 import { SchemaValue } from '@/types'
 import { withProps } from '@/utilities/components'
 
 // this is a lot easier to just let typescript infer the return type
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useSchemaPropertyInput(schemaProperty: MaybeRefOrGetter<SchemaProperty>, propertyValue: Ref<SchemaValue>) {
+export function useSchemaPropertyInput(schemaProperty: MaybeRefOrGetter<SchemaProperty>, propertyValue: Ref<SchemaValue>, propertyErrors: MaybeRefOrGetter<SchemaValueError[]>) {
   const input = computed(() => {
     const property = toValue(schemaProperty)
+    const errors = toValue(propertyErrors)
+    const { state } = getSchemaPropertyError(errors)
 
     if (!isPrefectKindValue(propertyValue.value)) {
       return withProps(SchemaFormPropertyInput, {
         property: property,
         value: propertyValue.value,
+        errors,
+        state,
         'onUpdate:value': (value) => propertyValue.value = value,
       })
     }

--- a/src/schemas/compositions/useSchemaPropertyInput.ts
+++ b/src/schemas/compositions/useSchemaPropertyInput.ts
@@ -31,6 +31,8 @@ export function useSchemaPropertyInput(schemaProperty: MaybeRefOrGetter<SchemaPr
     if (isPrefectKindValue(propertyValue.value, 'json')) {
       return withProps(SchemaFormPropertyKindJson, {
         value: propertyValue.value,
+        errors,
+        state,
         'onUpdate:value': (value) => propertyValue.value = value,
       })
     }

--- a/src/schemas/mapper.ts
+++ b/src/schemas/mapper.ts
@@ -1,5 +1,66 @@
+/* eslint-disable no-dupe-class-members */
 import { maps } from '@/schemas/maps'
-import { Mapper } from '@/services/Mapper'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Map = (...args: any) => any
+type Maps = Record<string, Record<string, Map>>
+type MapsMember<T extends Maps, S extends keyof T> = T[S][keyof T[S]]
+type Mappers<T extends Maps, S extends keyof T> = Extract<MapsMember<T, S>, Map>
+type MapperSourceType<T extends Maps, S extends keyof T> = Parameters<Mappers<T, S>>[0]
+type MapperDestinationType<T extends Maps, S extends keyof T, D extends keyof T[S]> = ReturnType<T[S][D]>
+
+export class Mapper<T extends Maps> {
+  private readonly mapperFunctions: T
+
+  public constructor(mapperFunctions: T) {
+    this.mapperFunctions = mapperFunctions
+  }
+
+  public map<S extends keyof T, D extends keyof T[S]>(source: S, value: MapperSourceType<T, S>, destination: D): MapperDestinationType<T, S, D>
+  public map<S extends keyof T, D extends keyof T[S]>(source: S, value: MapperSourceType<T, S> | null, destination: D): MapperDestinationType<T, S, D> | null
+  public map<S extends keyof T, D extends keyof T[S]>(source: S, value: MapperSourceType<T, S> | undefined, destination: D): MapperDestinationType<T, S, D> | undefined
+  public map<S extends keyof T, D extends keyof T[S]>(source: S, value: MapperSourceType<T, S> | null | undefined, destination: D): MapperDestinationType<T, S, D> | null | undefined
+  public map<S extends keyof T, D extends keyof T[S]>(source: S, value: MapperSourceType<T, S>[], destination: D): MapperDestinationType<T, S, D>[]
+  public map<S extends keyof T, D extends keyof T[S]>(source: S, value: MapperSourceType<T, S> | MapperSourceType<T, S>[] | null | undefined, destination: D): MapperDestinationType<T, S, D> | MapperDestinationType<T, S, D>[] | null | undefined {
+    if (value === null || value === undefined) {
+      return value
+    }
+
+    const mapper = this.bindMapper(this.mapperFunctions[source][destination])
+
+    if (Array.isArray(value)) {
+      return value.map(mapper)
+    }
+
+    return mapper(value)
+  }
+
+  public mapEntries<S extends keyof T, D extends keyof T[S]>(source: S, value: Record<string, MapperSourceType<T, S>>, destination: D): Record<string, MapperDestinationType<T, S, D>>
+  public mapEntries<S extends keyof T, D extends keyof T[S]>(source: S, value: Record<string, MapperSourceType<T, S>> | null, destination: D): Record<string, MapperDestinationType<T, S, D>> | null
+  public mapEntries<S extends keyof T, D extends keyof T[S]>(source: S, value: Record<string, MapperSourceType<T, S>> | undefined, destination: D): Record<string, MapperDestinationType<T, S, D>> | undefined
+  public mapEntries<S extends keyof T, D extends keyof T[S]>(source: S, value: Record<string, MapperSourceType<T, S>> | null | undefined, destination: D): Record<string, MapperDestinationType<T, S, D>> | null | undefined
+  public mapEntries<S extends keyof T, D extends keyof T[S]>(source: S, value: Record<string, MapperSourceType<T, S>[]>, destination: D): Record<string, MapperDestinationType<T, S, D>[]>
+  public mapEntries<S extends keyof T, D extends keyof T[S]>(source: S, value: Record<string, MapperSourceType<T, S>[]> | null, destination: D): Record<string, MapperDestinationType<T, S, D>[]> | null
+  public mapEntries<S extends keyof T, D extends keyof T[S]>(source: S, value: Record<string, MapperSourceType<T, S>[]> | undefined, destination: D): Record<string, MapperDestinationType<T, S, D>[]> | undefined
+  public mapEntries<S extends keyof T, D extends keyof T[S]>(source: S, value: Record<string, MapperSourceType<T, S>[]> | null | undefined, destination: D): Record<string, MapperDestinationType<T, S, D>[]> | null | undefined
+  public mapEntries<S extends keyof T, D extends keyof T[S]>(source: S, value: Record<string, MapperSourceType<T, S> | MapperSourceType<T, S>[]> | null | undefined, destination: D): Record<string, MapperDestinationType<T, S, D> | MapperDestinationType<T, S, D>[]> | null | undefined {
+    if (value === null || value === undefined) {
+      return value
+    }
+
+    const response = {} as Record<string, MapperDestinationType<T, S, D>>
+
+    return Object.entries(value).reduce<Record<string, MapperDestinationType<T, S, D>>>((mapped, [key, value]) => {
+      mapped[key] = this.map(source, value, destination)
+
+      return mapped
+    }, response)
+  }
+
+  private bindMapper<S extends keyof T, D extends keyof T[S]>(mapper: MapsMember<T, S>): (source: MapperSourceType<T, S>) => MapperDestinationType<T, S, D> {
+    return mapper.bind(this)
+  }
+}
 
 export const mapper = new Mapper(maps)
 

--- a/src/schemas/maps/index.ts
+++ b/src/schemas/maps/index.ts
@@ -1,7 +1,10 @@
-import { mapSchemaPropertiesResponseToSchemaProperties, mapSchemaResponseToSchema, mapSchemaPropertyResponseToSchemaProperty } from '@/schemas/maps/schema'
+import { mapSchemaPropertiesResponseToSchemaProperties, mapSchemaResponseToSchema, mapSchemaPropertyResponseToSchemaProperty, mapSchemaToSchemaResponse, mapSchemaPropertyToSchemaPropertyResponse, mapSchemaPropertiesToSchemaPropertiesResponse } from '@/schemas/maps/schema'
 
 export const maps = {
   SchemaResponse: { Schema: mapSchemaResponseToSchema },
   SchemaPropertyResponse: { SchemaProperty: mapSchemaPropertyResponseToSchemaProperty },
   SchemaPropertiesResponse: { SchemaProperties: mapSchemaPropertiesResponseToSchemaProperties },
+  Schema: { SchemaResponse: mapSchemaToSchemaResponse },
+  SchemaProperty: { SchemaPropertyResponse: mapSchemaPropertyToSchemaPropertyResponse },
+  SchemaProperties: { SchemaPropertiesResponse: mapSchemaPropertiesToSchemaPropertiesResponse },
 }

--- a/src/schemas/maps/schema.ts
+++ b/src/schemas/maps/schema.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { MapFunction } from '@/schemas/mapper'
 import { Schema, SchemaProperties, SchemaProperty } from '@/schemas/types/schema'
 import { SchemaPropertiesResponse, SchemaPropertyResponse, SchemaResponse } from '@/schemas/types/schemaResponse'
@@ -44,6 +45,53 @@ export const mapSchemaPropertyResponseToSchemaProperty: MapFunction<SchemaProper
     format: source.format,
     items: source.items,
     properties: this.map('SchemaPropertiesResponse', source.properties, 'SchemaProperties'),
+    required: source.required,
+    title: source.title,
+    type: source.type,
+  }
+}
+
+export const mapSchemaToSchemaResponse: MapFunction<Schema, SchemaResponse> = function(source) {
+  return {
+    definitions: source.definitions,
+    position: source.position,
+    block_type_slug: source.blockTypeSlug,
+    $ref: source.$ref,
+    anyOf: source.anyOf,
+    allOf: source.allOf,
+    example: source.example,
+    default: source.default,
+    const: source.const,
+    description: source.description,
+    enum: source.enum,
+    format: source.format,
+    items: source.items,
+    properties: this.map('SchemaProperties', source.properties, 'SchemaPropertiesResponse'),
+    required: source.required,
+    title: source.title,
+    type: source.type,
+  }
+}
+
+export const mapSchemaPropertiesToSchemaPropertiesResponse: MapFunction<SchemaProperties, SchemaPropertiesResponse> = function(source) {
+  return mapValues(source, (key, value) => this.map('SchemaProperty', value, 'SchemaPropertyResponse'))
+}
+
+export const mapSchemaPropertyToSchemaPropertyResponse: MapFunction<SchemaProperty, SchemaPropertyResponse> = function(source) {
+  return {
+    position: source.position,
+    block_type_slug: source.blockTypeSlug,
+    $ref: source.$ref,
+    anyOf: source.anyOf,
+    allOf: source.allOf,
+    example: source.example,
+    default: source.default,
+    const: source.const,
+    description: source.description,
+    enum: source.enum,
+    format: source.format,
+    items: source.items,
+    properties: this.map('SchemaProperties', source.properties, 'SchemaPropertiesResponse'),
     required: source.required,
     title: source.title,
     type: source.type,

--- a/src/schemas/types/schemaResponse.ts
+++ b/src/schemas/types/schemaResponse.ts
@@ -23,7 +23,7 @@ export type SchemaPropertyResponse = {
   // exclusiveMaximum?: boolean | number,
   // exclusiveMinimum?: boolean | number,
   format?: SchemaStringFormat,
-  items?: SchemaPropertyResponse,
+  items?: SchemaPropertyResponse | SchemaPropertyResponse[],
   // maximum?: number,
   // maxItems?: number,
   // maxLength?: number,

--- a/src/schemas/types/schemaValuesValidationResponse.ts
+++ b/src/schemas/types/schemaValuesValidationResponse.ts
@@ -1,0 +1,16 @@
+export type SchemaValuesValidationError = string | SchemaValuesValidationPropertyError | SchemaValuesValidationIndexError
+
+export type SchemaValuesValidationPropertyError = {
+  property: string,
+  errors: SchemaValuesValidationError[],
+}
+
+export type SchemaValuesValidationIndexError = {
+  index: number,
+  errors: SchemaValuesValidationError[],
+}
+
+export type SchemaValuesValidationResponse = {
+  errors: SchemaValuesValidationError[],
+  valid: boolean,
+}

--- a/src/schemas/types/schemaValuesValidationResponse.ts
+++ b/src/schemas/types/schemaValuesValidationResponse.ts
@@ -1,16 +1,26 @@
-export type SchemaValuesValidationError = string | SchemaValuesValidationPropertyError | SchemaValuesValidationIndexError
+import { isRecord } from '@/utilities/object'
 
-export type SchemaValuesValidationPropertyError = {
+export type SchemaValueError = string | SchemaValuePropertyError | SchemaValueIndexError
+
+export type SchemaValuePropertyError = {
   property: string,
-  errors: SchemaValuesValidationError[],
+  errors: SchemaValueError[],
 }
 
-export type SchemaValuesValidationIndexError = {
+export function isSchemaValuePropertyError(value: SchemaValueError): value is SchemaValuePropertyError {
+  return isRecord(value) && 'property' in value
+}
+
+export type SchemaValueIndexError = {
   index: number,
-  errors: SchemaValuesValidationError[],
+  errors: SchemaValueError[],
+}
+
+export function isSchemaValueIndexError(value: SchemaValueError): value is SchemaValueIndexError {
+  return isRecord(value) && 'index' in value
 }
 
 export type SchemaValuesValidationResponse = {
-  errors: SchemaValuesValidationError[],
+  errors: SchemaValueError[],
   valid: boolean,
 }

--- a/src/schemas/utilities/errors.ts
+++ b/src/schemas/utilities/errors.ts
@@ -1,0 +1,30 @@
+import { State } from '@prefecthq/prefect-design'
+import { SchemaValueError, isSchemaValuePropertyError } from '@/schemas/types/schemaValuesValidationResponse'
+import { isString } from '@/utilities/strings'
+
+export function getSchemaPropertyErrors(propertyKey: string, errors: SchemaValueError[]): SchemaValueError[] {
+  return errors.filter(isSchemaValuePropertyError).filter(error => error.property === propertyKey).flatMap(error => error.errors)
+}
+
+export type SchemaPropertyError = {
+  state: State,
+  message: string | undefined,
+}
+
+export function getSchemaPropertyError(errors: SchemaValueError[]): SchemaPropertyError {
+  const propertyErrors = errors.filter(isString)
+  const state: State = { pending: false, valid: true, validated: true }
+
+  if (errors.length) {
+    state.valid = false
+    return {
+      state,
+      message: propertyErrors.join(' and '),
+    }
+  }
+
+  return {
+    state,
+    message: undefined,
+  }
+}

--- a/src/schemas/utilities/errors.ts
+++ b/src/schemas/utilities/errors.ts
@@ -1,9 +1,13 @@
 import { State } from '@prefecthq/prefect-design'
-import { SchemaValueError, isSchemaValuePropertyError } from '@/schemas/types/schemaValuesValidationResponse'
+import { SchemaValueError, isSchemaValueIndexError, isSchemaValuePropertyError } from '@/schemas/types/schemaValuesValidationResponse'
 import { isString } from '@/utilities/strings'
 
-export function getSchemaPropertyErrors(propertyKey: string, errors: SchemaValueError[]): SchemaValueError[] {
-  return errors.filter(isSchemaValuePropertyError).filter(error => error.property === propertyKey).flatMap(error => error.errors)
+export function getSchemaPropertyErrors(propertyKeyOrIndex: string | number, errors: SchemaValueError[]): SchemaValueError[] {
+  if (isString(propertyKeyOrIndex)) {
+    return errors.filter(isSchemaValuePropertyError).filter(error => error.property === propertyKeyOrIndex).flatMap(error => error.errors)
+  }
+
+  return errors.filter(isSchemaValueIndexError).filter(error => error.index == propertyKeyOrIndex).flatMap(error => error.errors)
 }
 
 export type SchemaPropertyError = {

--- a/src/services/WorkspaceSchemasWorkspaceApi.ts
+++ b/src/services/WorkspaceSchemasWorkspaceApi.ts
@@ -1,0 +1,19 @@
+import { mapper } from '@/schemas/mapper'
+import { Schema } from '@/schemas/types/schema'
+import { SchemaValues } from '@/schemas/types/schemaValues'
+import { SchemaValuesValidationResponse } from '@/schemas/types/schemaValuesValidationResponse'
+import { WorkspaceApi } from '@/services'
+
+export class WorkspaceSchemasWorkspaceApi extends WorkspaceApi {
+
+  protected override routePrefix = '/ui/schemas/'
+
+  public async validate(schema: Schema, values: SchemaValues): Promise<SchemaValuesValidationResponse> {
+    const { data } = await this.post<SchemaValuesValidationResponse>('/validate', {
+      schema: mapper.map('Schema', schema, 'SchemaResponse'),
+      values,
+    })
+
+    return data
+  }
+}

--- a/src/utilities/api.ts
+++ b/src/utilities/api.ts
@@ -17,6 +17,7 @@ import { WorkspaceFlowsApi } from '@/services/WorkspaceFlowsApi'
 import { WorkspaceLogsApi } from '@/services/WorkspaceLogsApi'
 import { WorkspaceNotificationsApi } from '@/services/WorkspaceNotificationsApi'
 import { WorkspaceSavedSearchesApi } from '@/services/WorkspaceSavedSearchesApi'
+import { WorkspaceSchemasWorkspaceApi } from '@/services/WorkspaceSchemasWorkspaceApi'
 import { WorkspaceTaskRunsApi } from '@/services/WorkspaceTaskRunsApi'
 import { WorkspaceVariablesApi } from '@/services/WorkspaceVariablesApi'
 import { WorkspaceWorkPoolQueuesApi } from '@/services/WorkspaceWorkPoolQueuesApi'
@@ -50,6 +51,7 @@ export function createApi(workspaceConfig: WorkspaceApiConfig) {
     workPools: createActions(new WorkspaceWorkPoolsApi(workspaceConfig)),
     workPoolWorkers: createActions(new WorkspaceWorkPoolWorkersApi(workspaceConfig)),
     workQueues: createActions(new WorkspaceWorkQueuesApi(workspaceConfig)),
+    schemas: createActions(new WorkspaceSchemasWorkspaceApi(workspaceConfig)),
   }
 }
 


### PR DESCRIPTION
# Description
Implements the new workspace level api endpoint `/ui/schemas/validate` to validate user entered values based on the schema provided. 

The example in this screenshot is validating individual items of a list. Which is something we've never been able to do. Also notice the specific errors. 
<img width="949" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/49872995-5e93-4026-9f67-8491627c4a09">

@znicholasbrown this uses prop drilling. Which isn't great. But considering we're already using v-models up and down adding props for validation seems like the best and simplest solution. 