### PR TITLE
Disambiguate work queues across work pools in `<WorkQueueCombobox>`

### DIFF
--- a/src/components/WorkQueueCombobox.vue
+++ b/src/components/WorkQueueCombobox.vue
@@ -17,14 +17,16 @@
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed, watch } from 'vue'
   import { useWorkspaceApi } from '@/compositions'
-  import { WorkPoolFilter, WorkQueue } from '@/models'
+  import { WorkQueue } from '@/models'
+
+  export type WorkPoolFilterByIdOrName = { id?: string[], name?: string[] }
 
   const props = defineProps<{
     selected: string | string[] | null | undefined,
     emptyMessage?: string,
     allowUnset?: boolean,
     multiple?: boolean,
-    workPoolFilter?: WorkPoolFilter,
+    workPoolFilter?: WorkPoolFilterByIdOrName,
   }>()
 
   const emits = defineEmits<{

--- a/src/components/WorkQueueCombobox.vue
+++ b/src/components/WorkQueueCombobox.vue
@@ -62,7 +62,7 @@
       options.push({
         label: workPoolName,
         options: workQueues.map(workQueue => ({
-          value: workQueue.name,
+          value: workQueue.id,
           label: workQueue.name,
         })),
       })


### PR DESCRIPTION
> [!Warning]
> This PR includes a breaking change to the `<WorkQueueCombobox` component as its component interface now expects to work directly with work queue ids instead of names for it's v-model.

### The problem:
The `<WorkQueueCombobox>` renders a picklist of work queues keyed on and labeled with work queue _name_ only; however **work queue names are only unique within a work pool.**

So if you have more than 1 hybrid (a type that uses queues) work pool in your workspace, then you likely already have 2 work queues with the name "default" belonging to 2 different work pools. So then when using the `<WorkQueueCombobox>`, you end up with duplicate options. 

### Proposed solution:
> [!Note]
> I considered amping up `<WorkPoolQueueCombobox>` here instead but I suspect that path to need more careful refactors as the interface is quite different (for example dealing with names instead of ids which I'd prefer for my use-case). 

WorkQueueCombobox seems old. I don't see it being used much so I'm thinking of repurposing it a bit in the following ways:
1. Group the dropdown options by work pool - now 2 work queues named "default" are distinguishable
2. add client-side filtering by 0 or 1+ work pool ids
3. deal with work queue ids instead of names (both as input and output)

#### 👀 Show me
| **Description** | **📸** |
| ---- | ---- |
| Status quo - flat list of all work queues in current workspace with buggy experience for overlapping work queue names | <img width="1240" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/7bf2f1c2-4109-4dcf-aa7a-e1008cdc9c84"> |
| Work queues options are now grouped by work pool. Picking "default" no longer selects all options labeled as "default". | <img width="833" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/9d7c958f-f749-42da-a373-401ed14e14c3"> |
| Using the workPoolFilter prop, the options can be filtered (client-side) by work pool. When the workPoolFilter prop changes and it would invalidate any of the already-selected options, then those options are automatically removed. | <img width="813" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/a0519d5f-509b-479c-ae3f-1084691884ce"> |
| The component now works with `id`s directly instead of names in order to uniquely identify work queues _outside_ of their respective work pool | <img width="401" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/cb9f0da3-6069-4083-90d5-cd4808701406"> |

