### PR TITLE
Fix usePagination count parameters not being deeply reactive

### DIFF
--- a/src/compositions/usePagination.ts
+++ b/src/compositions/usePagination.ts
@@ -1,5 +1,6 @@
 import { Getter } from '@prefecthq/prefect-design'
 import { SubscriptionOptions, UseSubscription, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
+import merge from 'lodash.merge'
 import { ComputedRef, MaybeRef, Ref, computed, onScopeDispose, reactive, ref, toRef, watch } from 'vue'
 import { GLOBAL_API_LIMIT } from '@/compositions/useFilterPagination'
 import { UseSubscriptions, useSubscriptions } from '@/compositions/useSubscriptions'
@@ -74,13 +75,20 @@ export function usePagination<
   const page = getPageRef()
   const pages = computed(() => Math.ceil(total.value / getLimit()))
 
-  const countSubscriptionParameters = toRef(() => {
+  const countSubscriptionParameters = computed(() => {
     if (page.value) {
-      return countParametersGetter()
+      const parameters = countParametersGetter()
+
+      if (parameters) {
+        return merge([], parameters)
+      }
+
+      return parameters
     }
 
     return null
   })
+
   const countSubscription = useSubscriptionWithDependencies(countMethod, countSubscriptionParameters, options)
   const total = computed(() => countSubscription.response ?? 0)
 


### PR DESCRIPTION
# Description
Because the parameters getter can return a nested object we need to make sure vue tracks nested values. Using `merge` makes sure the effect scope of the computed tracks all the nested values in case only a nested value changes. Basically makes the computed `deep`. 

Closes: https://github.com/PrefectHQ/prefect/issues/11834