### PR TITLE
Vertically align the work queue status icon in FlowRunListItem

### DIFF
--- a/src/components/FlowRunWorkQueue.vue
+++ b/src/components/FlowRunWorkQueue.vue
@@ -45,6 +45,6 @@
 
 <style>
 .flow-run-work-queue { @apply
-  flex gap-1
+  flex gap-1 items-center
 }
 </style>


### PR DESCRIPTION
The work queue _ready status_ indicator renders a little off (vertically) in the flow run list item component. 

| | **Before** | **After** |
| ---- | ---- | ---- |
| With health - `enable-work-queue-status==false` | <img width="807" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/3d464423-ffe5-4fe9-a870-2d004ee7110f"> <img width="807" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/97be9e59-2640-43da-8929-82b4db613217"> | <img width="812" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/a490cfd9-9d42-49be-ad06-aebfaf8d7c60"> <img width="809" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/2b486c8b-6739-4578-a843-3ab4dd30f4cf"> |
| With status - `enable-work-queue-status==true` | <img width="811" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/2e6f79cb-0930-4df2-9211-a9a2a6af5104"> <img width="810" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/3a0c6809-949c-45b2-b5da-112b05a1352f"> | <img width="824" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/f1b8c318-aab5-4272-a3e4-cdcefaf8744d"> <img width="812" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/f8005508-443c-4421-89df-9b4c9041d52a"> |
