### PR TITLE
Render the work pool queue status icon in deployment page header 

### DIFF
--- a/src/components/FlowRunWorkQueue.vue
+++ b/src/components/FlowRunWorkQueue.vue
@@ -3,7 +3,7 @@
     <span>Work Queue</span>
     <WorkQueueIconText :work-queue-name="workQueueName" :work-pool-name="workPoolName" />
 
-    <template v-if="isNotTerminal && workPoolName">
+    <template v-if="showWorkPoolQueueStatus && workPoolName">
       <WorkPoolQueueStatusIcon v-if="can.access.workQueueStatus && workPoolQueue" :work-pool-queue="workPoolQueue" />
       <WorkPoolQueueHealthIcon v-else-if="!can.access.workQueueStatus" :work-queue-name="workQueueName" :work-pool-name="workPoolName" />
     </template>
@@ -26,7 +26,7 @@
 
   const can = useCan()
 
-  const isNotTerminal = computed(() => props.flowRunState && !isTerminalStateType(props.flowRunState))
+  const showWorkPoolQueueStatus = computed(() => props.flowRunState == undefined || !isTerminalStateType(props.flowRunState))
   const { workPoolName } = toRefs(props)
   const { workPool } = useWorkPool(workPoolName)
 

--- a/src/components/FlowRunWorkQueue.vue
+++ b/src/components/FlowRunWorkQueue.vue
@@ -3,7 +3,7 @@
     <span>Work Queue</span>
     <WorkQueueIconText :work-queue-name="workQueueName" :work-pool-name="workPoolName" />
 
-    <template v-if="showWorkPoolQueueStatus && workPoolName">
+    <template v-if="!hideWorkPoolQueueStatus && workPoolName">
       <WorkPoolQueueStatusIcon v-if="can.access.workQueueStatus && workPoolQueue" :work-pool-queue="workPoolQueue" />
       <WorkPoolQueueHealthIcon v-else-if="!can.access.workQueueStatus" :work-queue-name="workQueueName" :work-pool-name="workPoolName" />
     </template>
@@ -26,7 +26,7 @@
 
   const can = useCan()
 
-  const showWorkPoolQueueStatus = computed(() => props.flowRunState == undefined || !isTerminalStateType(props.flowRunState))
+  const hideWorkPoolQueueStatus = computed(() => props.flowRunState && isTerminalStateType(props.flowRunState))
   const { workPoolName } = toRefs(props)
   const { workPool } = useWorkPool(workPoolName)
 


### PR DESCRIPTION
If a deployment has a work pool and work queue, then we currently render the work queue's name on the deployment's page under its name in the header. However, that work queue's _status_ is not currently showing because the boolean check relies on there being a flow run state (with the intention of hiding the status for flow runs that have already terminated since the current status of the terminated flow run's work queue is no longer relevant). 

For a deployment, it could be useful to show the work queue's status here (if there is one to show) so this PR tweaks the condition to make that happen.

| **Before** | **After** |
| ---- | ---- |
| <img width="1268" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/6a9c16d8-9528-4e28-a013-977efe5e31da"> | <img width="1272" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/21ad1ef7-56f1-4b75-96ef-e775df29fea4"> |
