### PR TITLE
Remove cursor-help from work queue and work pool icon

### DIFF
--- a/src/components/WorkPoolQueueStatusIcon.vue
+++ b/src/components/WorkPoolQueueStatusIcon.vue
@@ -45,10 +45,6 @@
 </script>
 
 <style>
-.work-pool-queue-status-icon { @apply
-  cursor-help
-}
-
 .work-pool-queue-status-icon--not_ready { @apply
   text-sentiment-negative
 }

--- a/src/components/WorkPoolStatusIcon.vue
+++ b/src/components/WorkPoolStatusIcon.vue
@@ -38,14 +38,9 @@
 </script>
 
 <style>
-.work-pool-status-icon { @apply
-  cursor-help
-}
-
 .work-pool-status-icon--paused { @apply
   flex
   items-center
-  cursor-help
   text-subdued
 }
 </style>


### PR DESCRIPTION
Before:

https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/f30bcc98-634f-4eac-a4ef-c3dfe63c739f

After:

https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/3827b7e8-b8ca-41fe-814e-507590523016

