### PR TITLE
BugFix: Deployment interval schedules not being created or displayed accurately in the ui

### DIFF
--- a/src/components/IntervalScheduleForm.vue
+++ b/src/components/IntervalScheduleForm.vue
@@ -18,7 +18,7 @@
 
       <div>
         <p-label label="Anchor date">
-          <DateInput v-model="anchorDate" show-time />
+          <p-date-input v-model="anchorDate" show-time />
         </p-label>
       </div>
 
@@ -46,10 +46,9 @@
   import { SelectOption } from '@prefecthq/prefect-design'
   import { useField } from 'vee-validate'
   import { computed, ref, watch, onMounted } from 'vue'
-  import DateInput from '@/components/DateInput.vue'
   import TimezoneSelect from '@/components/TimezoneSelect.vue'
   import { IntervalSchedule } from '@/models'
-  import { toPluralString } from '@/utilities'
+  import { setTimezone, toPluralString, unsetTimezone } from '@/utilities'
   import { IntervalOption, secondsToClosestIntervalOption, secondsToClosestIntervalValue, intervalOptionsToSecondsMap } from '@/utilities/timeIntervals'
   import { fieldRules, isGreaterThanOrEqual, isRequired } from '@/utilities/validation'
 
@@ -72,6 +71,11 @@
 
   const anchorDate = ref(props.schedule.anchorDate)
   const timezone = ref(props.schedule.timezone)
+
+  if (anchorDate.value && timezone.value) {
+    anchorDate.value = unsetTimezone(anchorDate.value, timezone.value)
+  }
+
   const { value: interval, meta: intervalState, errors: intervalErrors } = useField<number>('interval', rules.interval, { initialValue: secondsToClosestIntervalValue(props.schedule.interval) })
   const intervalOption = ref<IntervalOption>(secondsToClosestIntervalOption(props.schedule.interval))
 

--- a/src/maps/schedule.ts
+++ b/src/maps/schedule.ts
@@ -1,6 +1,6 @@
 import { CronSchedule, IntervalSchedule, RRuleSchedule, Schedule, ScheduleResponse, isCronScheduleResponse, isIntervalScheduleResponse, isRRuleScheduleResponse, isIntervalSchedule, isRRuleSchedule, isCronSchedule, IntervalScheduleRequest, RRuleScheduleRequest, CronScheduleRequest } from '@/models'
 import { MapFunction } from '@/services/Mapper'
-import { setToTimezone } from '@/utilities/timezone'
+import { setTimezone, unsetTimezone } from '@/utilities/timezone'
 
 export const mapScheduleResponseToSchedule: MapFunction<ScheduleResponse, Schedule> = function(source) {
   if (isRRuleScheduleResponse(source)) {
@@ -19,10 +19,18 @@ export const mapScheduleResponseToSchedule: MapFunction<ScheduleResponse, Schedu
   }
 
   if (isIntervalScheduleResponse(source)) {
+    if (source.anchor_date && source.timezone) {
+      return new IntervalSchedule({
+        timezone: source.timezone,
+        interval: source.interval,
+        anchorDate: this.map('string', source.anchor_date, 'Date'),
+      })
+    }
+
     return new IntervalSchedule({
-      timezone: source.timezone,
       interval: source.interval,
-      anchorDate: this.map('string', source.anchor_date, 'Date'),
+      timezone: null,
+      anchorDate: null,
     })
   }
 
@@ -50,7 +58,7 @@ export const mapScheduleToScheduleRequest: MapFunction<Schedule, ScheduleRespons
       return {
         timezone: source.timezone,
         interval: source.interval,
-        anchor_date: this.map('Date', setToTimezone(source.anchorDate, source.timezone), 'string'),
+        anchor_date: this.map('Date', setTimezone(source.anchorDate, source.timezone), 'string'),
       } satisfies IntervalScheduleRequest
     }
 

--- a/src/models/IntervalSchedule.ts
+++ b/src/models/IntervalSchedule.ts
@@ -2,8 +2,9 @@ import { toPluralString } from '@prefecthq/prefect-design'
 import { zonedTimeToUtc } from 'date-fns-tz'
 import { ISchedule } from '@/models'
 import { IntervalScheduleResponse } from '@/models/api/ScheduleResponse'
-import { formatDate, formatTimeNumeric, secondsInMinute, minutesInHour } from '@/utilities/dates'
+import { formatDate, formatTimeNumeric, secondsInMinute, minutesInHour, dateFormat, timeNumericFormat } from '@/utilities/dates'
 import { floor } from '@/utilities/math'
+import { formatDateInTimezone } from '@/utilities/timezone'
 
 export type Intervals = {
   seconds: number,
@@ -101,7 +102,9 @@ export class IntervalSchedule implements IIntervalSchedule {
     }
 
     if (this.anchorDate && verbose) {
-      str += ` using ${formatDate(this.anchorDate)} at ${formatTimeNumeric(this.anchorDate)} (${this.timezone ?? 'UTC'}) as the anchor date`
+      const date = formatDateInTimezone(this.anchorDate, dateFormat, this.timezone ?? 'UTC')
+      const time = formatDateInTimezone(this.anchorDate, timeNumericFormat, this.timezone ?? 'UTC')
+      str += ` using ${date} at ${time} (${this.timezone ?? 'UTC'}) as the anchor date`
     }
 
     if (str == '') {

--- a/src/utilities/dates.ts
+++ b/src/utilities/dates.ts
@@ -4,15 +4,15 @@ import { dateFunctions, toDate, formatDateInTimezone } from '@/utilities/timezon
 
 // formats defined by the style guide
 // https://www.notion.so/prefect/Formatting-Basics-1d4d83bcb2ba471ead90910aeb5913b2?pvs=4#b79673ff9e9b47f58236c449e5fe764a
-const dateFormat = 'MMM do, yyyy'
-const timeFormat = 'hh:mm a'
-const dateTimeFormat = `${dateFormat} 'at' ${timeFormat}`
+export const dateFormat = 'MMM do, yyyy'
+export const timeFormat = 'hh:mm a'
+export const dateTimeFormat = `${dateFormat} 'at' ${timeFormat}`
 
-const timeNumericFormat = 'hh:mm:ss a'
-const timeNumericShortFormat = 'hh:mm a'
-const dateNumericFormat = 'yyyy/MM/dd'
-const dateTimeNumericFormat = `${dateNumericFormat} ${timeNumericFormat}`
-const dateTimeNumericShortFormat = `${dateNumericFormat} ${timeNumericShortFormat}`
+export const timeNumericFormat = 'hh:mm:ss a'
+export const timeNumericShortFormat = 'hh:mm a'
+export const dateNumericFormat = 'yyyy/MM/dd'
+export const dateTimeNumericFormat = `${dateNumericFormat} ${timeNumericFormat}`
+export const dateTimeNumericShortFormat = `${dateNumericFormat} ${timeNumericShortFormat}`
 
 export {
   daysInWeek,

--- a/src/utilities/timezone.ts
+++ b/src/utilities/timezone.ts
@@ -115,14 +115,27 @@ export const dateFunctions = new Proxy({ ...dateFns }, {
 /**
  * Converts a date in local time into the same date/time in a different timezone
  *
- * @param {Date} date - The date to be converted. If null, the function will return null.
- * @param {string} timezone - The timezone to which the date should be converted. If null, the function will return the date in ISO string format.
+ * @param {Date} date - The date to be converted.
+ * @param {string} timezone - The timezone the date should be offset to.
  * @returns {Date}
  */
-export function setToTimezone(date: Date, timezone: string): Date {
-
+export function setTimezone(date: Date, timezone: string): Date {
   const offset = date.getHours() - assignTimezone(date, timezone).getHours()
   const offsetDate = dateFns.addHours(date, offset)
+
+  return offsetDate
+}
+
+/**
+ * Converts a date in a timezone into the same date/time in a local date
+ *
+ * @param {Date} date - The date to be converted.
+ * @param {string} timezone - The timezone the date should be offset from.
+ * @returns {Date}
+ */
+export function unsetTimezone(date: Date, timezone: string): Date {
+  const offset = date.getHours() - assignTimezone(date, timezone).getHours()
+  const offsetDate = dateFns.subHours(date, offset)
 
   return offsetDate
 }

--- a/src/utilities/timezone.ts
+++ b/src/utilities/timezone.ts
@@ -111,3 +111,18 @@ export const dateFunctions = new Proxy({ ...dateFns }, {
     }
   },
 })
+
+/**
+ * Converts a date in local time into the same date/time in a different timezone
+ *
+ * @param {Date} date - The date to be converted. If null, the function will return null.
+ * @param {string} timezone - The timezone to which the date should be converted. If null, the function will return the date in ISO string format.
+ * @returns {Date}
+ */
+export function setToTimezone(date: Date, timezone: string): Date {
+
+  const offset = date.getHours() - assignTimezone(date, timezone).getHours()
+  const offsetDate = dateFns.addHours(date, offset)
+
+  return offsetDate
+}


### PR DESCRIPTION
# Description
Interval schedules that use a different timezone than the devices local time could produce weird schedules because the selected timezone was not factored into the date the schedule was being created with. This fixed both the creation and display of the anchor date so that it works the way users expect. 

Closes https://github.com/PrefectHQ/prefect/issues/11924