### PR TITLE
Hide work queue health for push pools

### DIFF
--- a/src/components/WorkPoolQueueHealthIcon.vue
+++ b/src/components/WorkPoolQueueHealthIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <p-tooltip
-    v-if="workPoolQueue && workQueueStatus"
+    v-if="workPoolQueue && workQueueStatus && !workPool?.isPushPool"
     class="work-pool-queue-health-icon"
     text="Work queue health is deprecated and will be removed in a future release. Please use work pool status instead."
   >
@@ -25,7 +25,7 @@
   import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
   import StatusIcon from '@/components/StatusIcon.vue'
-  import { useInterval, useWorkQueueStatus, useWorkspaceApi } from '@/compositions'
+  import { useInterval, useWorkQueueStatus, useWorkspaceApi, useWorkPool } from '@/compositions'
 
   const props = defineProps<{
     workQueueName: string,
@@ -38,6 +38,8 @@
 
   const workPoolQueuesSubscription = useSubscriptionWithDependencies(api.workPoolQueues.getWorkPoolQueueByName, workPoolQueueArgs, options)
   const workPoolQueue = computed(() => workPoolQueuesSubscription.response)
+
+  const { workPool } = useWorkPool(() => props.workPoolName)
 
   const workQueueId = computed(() => workPoolQueue.value?.id)
   const { workQueueStatus } = useWorkQueueStatus(workQueueId)

--- a/src/components/WorkPoolQueueStatusArray.vue
+++ b/src/components/WorkPoolQueueStatusArray.vue
@@ -6,12 +6,17 @@
           v-if="can.access.workQueueStatus"
           :work-pool-queue="workQueue"
         />
-        <WorkPoolQueueHealthIcon
-          v-else
-          :work-queue-name="workQueue.name"
-          :work-pool-name="workPool.name"
-          class="work-pool-queue-status-badge__icon"
-        />
+        <template v-else>
+          <span v-if="workPool.isPushPool" class="work-pool-queue-status-array__none">
+            N/A
+          </span>
+          <WorkPoolQueueHealthIcon
+            v-else
+            :work-queue-name="workQueue.name"
+            :work-pool-name="workPool.name"
+            class="work-pool-queue-status-badge__icon"
+          />
+        </template>
       </template>
     </template>
     <span v-if="!showTooMany && workPoolQueues.length < 1" class="work-pool-queue-status-array__none">N/A</span>


### PR DESCRIPTION
We're adding work queue status for push pools but have not updated work queue health.  Since work queue status is not yet fully released, there's misleading work queue health warnings on some push pools.  This PR hides the deprecated work queue health icon for push pools. 

After:

<img width="974" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/839d80cb-d67c-48c0-8458-68d6b2ec6cb9">


Before:
<img width="998" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/c534bfd6-1a67-4989-8c4e-d717a13fe2fb">

