### PR TITLE
Remove --force from dev command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "scripts": {
         "build": "vue-tsc && tsc-alias && vite build",
         "changelog": "auto-changelog --package --commit-limit 0",
-        "dev": "vue-tsc -w & tsc-alias -w & vite build -w --force",
+        "dev": "vue-tsc -w & tsc-alias -w & vite build -w",
         "lint:fix": "eslint src --fix",
         "lint": "eslint src",
         "test": "vitest",


### PR DESCRIPTION
Looking at the [changelog from Vite 5.1](https://github.com/PrefectHQ/prefect-ui-library/pull/2087), we can [remove](https://github.com/vitejs/vite/pull/15837) the `--force` from `build --force` in our dev script.  This fixes an error I was getting when running `npm run dev`