### PR TITLE
Schemas: Add v2 schema and properties to the deployment model

### DIFF
--- a/src/maps/deployment.ts
+++ b/src/maps/deployment.ts
@@ -1,5 +1,5 @@
 import { sortStringArray } from '@prefecthq/prefect-design'
-import { DeploymentFlowRunCreate, DeploymentFlowRunRequest, DeploymentUpdate, DeploymentUpdateRequest } from '@/models'
+import { DeploymentFlowRunCreate, DeploymentFlowRunRequest, DeploymentUpdate, DeploymentUpdateRequest, SchemaResponse } from '@/models'
 import { DeploymentResponse } from '@/models/api/DeploymentResponse'
 import { Deployment } from '@/models/Deployment'
 import { createObjectLevelCan } from '@/models/ObjectLevelCan'
@@ -9,7 +9,7 @@ import { Schema } from '@/types/schemas'
 
 export const mapDeploymentResponseToDeployment: MapFunction<DeploymentResponse, Deployment> = function(source) {
   const rawSchema = source.parameter_openapi_schema ?? {}
-  const schema = this.map('SchemaResponse', rawSchema as Schema, 'Schema')
+  const schema = this.map('SchemaResponse', rawSchema as SchemaResponse, 'Schema')
   const values = this.map('SchemaValuesResponse', { values: source.parameters, schema }, 'SchemaValues')
 
   return new Deployment({

--- a/src/maps/deployment.ts
+++ b/src/maps/deployment.ts
@@ -3,11 +3,13 @@ import { DeploymentFlowRunCreate, DeploymentFlowRunRequest, DeploymentUpdate, De
 import { DeploymentResponse } from '@/models/api/DeploymentResponse'
 import { Deployment } from '@/models/Deployment'
 import { createObjectLevelCan } from '@/models/ObjectLevelCan'
+import { SchemaResponseV2, schemaV2Mapper } from '@/schemas'
 import { MapFunction } from '@/services/Mapper'
+import { Schema } from '@/types/schemas'
 
 export const mapDeploymentResponseToDeployment: MapFunction<DeploymentResponse, Deployment> = function(source) {
   const rawSchema = source.parameter_openapi_schema ?? {}
-  const schema = this.map('SchemaResponse', rawSchema, 'Schema')
+  const schema = this.map('SchemaResponse', rawSchema as Schema, 'Schema')
   const values = this.map('SchemaValuesResponse', { values: source.parameters, schema }, 'SchemaValues')
 
   return new Deployment({
@@ -24,7 +26,9 @@ export const mapDeploymentResponseToDeployment: MapFunction<DeploymentResponse, 
     isScheduleActive: source.is_schedule_active,
     parameters: values,
     rawParameters: source.parameters,
-    rawSchema,
+    rawSchema: rawSchema as Schema,
+    parametersV2: source.parameters,
+    parameterOpenApiSchemaV2: schemaV2Mapper.map('SchemaResponse', rawSchema as SchemaResponseV2, 'Schema'),
     tags: source.tags ? sortStringArray(source.tags) : null,
     manifestPath: source.manifest_path,
     path: source.path,

--- a/src/mocks/deployment.ts
+++ b/src/mocks/deployment.ts
@@ -24,6 +24,8 @@ export const randomDeployment: MockFunction<Deployment, [Partial<Deployment>?]> 
     isScheduleActive: schedule ? this.create('boolean') : false,
     parameters,
     parameterOpenApiSchema: schema,
+    parametersV2: {},
+    parameterOpenApiSchemaV2: {},
     rawParameters,
     rawSchema: schema,
     tags: this.createMany('noun', this.create('number', [0, 5])),

--- a/src/models/Deployment.ts
+++ b/src/models/Deployment.ts
@@ -3,6 +3,7 @@ import { CreatedOrUpdatedBy } from '@/models/CreatedOrUpdatedBy'
 import { DeploymentStatus } from '@/models/DeploymentStatus'
 import { ObjectLevelCan } from '@/models/ObjectLevelCan'
 import { Schedule } from '@/models/Schedule'
+import { SchemaV2, SchemaValuesV2 } from '@/schemas'
 import { Schema, SchemaValues } from '@/types/schemas'
 
 
@@ -20,6 +21,8 @@ export interface IDeployment {
   isScheduleActive: boolean,
   parameters: SchemaValues,
   parameterOpenApiSchema: Schema,
+  parametersV2: SchemaValuesV2,
+  parameterOpenApiSchemaV2: SchemaV2,
   tags: string[] | null,
   manifestPath: string | null,
   path: string | null,
@@ -51,6 +54,8 @@ export class Deployment implements IDeployment {
   public isScheduleActive: boolean
   public parameters: SchemaValues
   public parameterOpenApiSchema: Schema
+  public parametersV2: SchemaValuesV2
+  public parameterOpenApiSchemaV2: SchemaV2
   public readonly rawParameters: SchemaValues
   public readonly rawSchema: SchemaResponse
   public tags: string[] | null
@@ -81,6 +86,8 @@ export class Deployment implements IDeployment {
     this.isScheduleActive = deployment.isScheduleActive
     this.parameters = deployment.parameters
     this.parameterOpenApiSchema = deployment.parameterOpenApiSchema
+    this.parametersV2 = deployment.parametersV2
+    this.parameterOpenApiSchemaV2 = deployment.parameterOpenApiSchemaV2
     this.tags = deployment.tags
     this.manifestPath = deployment.manifestPath
     this.rawParameters = deployment.rawParameters

--- a/src/models/api/DeploymentResponse.ts
+++ b/src/models/api/DeploymentResponse.ts
@@ -2,6 +2,7 @@ import { CreatedOrUpdatedByResponse } from '@/models/api/CreatedOrUpdatedByRespo
 import { ScheduleResponse } from '@/models/api/ScheduleResponse'
 import { SchemaResponse } from '@/models/api/SchemaResponse'
 import { ServerDeploymentStatus } from '@/models/DeploymentStatus'
+import { SchemaResponseV2 } from '@/schemas'
 import { DateString } from '@/types/dates'
 import { SchemaValues } from '@/types/schemas'
 
@@ -23,7 +24,7 @@ export type DeploymentResponse = {
   manifest_path: string | null,
   path: string | null,
   entrypoint: string | null,
-  parameter_openapi_schema: SchemaResponse | null,
+  parameter_openapi_schema: SchemaResponse | SchemaResponseV2 | null,
   storage_document_id: string | null,
   infrastructure_document_id: string | null,
   infra_overrides: Record<string, unknown> | null,

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,3 +1,16 @@
 import SchemaForm from '@/schemas/components/SchemaForm.vue'
+import { mapper } from '@/schemas/mapper'
+import { Schema } from '@/schemas/types/schema'
+import { SchemaResponse } from '@/schemas/types/schemaResponse'
+import { SchemaValues } from '@/schemas/types/schemaValues'
 
-export { SchemaForm as SchemaFormV2 }
+export {
+  SchemaForm as SchemaFormV2,
+  mapper as schemaV2Mapper
+}
+
+export type {
+  Schema as SchemaV2,
+  SchemaResponse as SchemaResponseV2,
+  SchemaValues as SchemaValuesV2
+}


### PR DESCRIPTION
# Description
Updates the `Deployment` model and associated types and mappers to include v2 properties. The existing parameter and schema properties are left as is for backwards compatibility. 