### PR TITLE
Schemas: Don't allow switching to a form input if the property has no type

### DIFF
--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -4,7 +4,7 @@
       <div class="schema-form-property__header">
         <span class="schema-form-property__label" :class="classes.label">{{ label }}</span>
 
-        <SchemaFormPropertyMenu v-model:kind="kind" class="ml-auto" :disabled="omitted" flat>
+        <SchemaFormPropertyMenu v-model:kind="kind" class="ml-auto" :property="property" :disabled="omitted" flat>
           <template v-if="!required" #default>
             <p-overflow-menu-item :label="omitLabel" @click="toggleValue" />
           </template>

--- a/src/schemas/components/SchemaFormPropertyArrayItem.vue
+++ b/src/schemas/components/SchemaFormPropertyArrayItem.vue
@@ -6,7 +6,7 @@
       <component :is="input.component" v-bind="input.props" />
     </keep-alive>
 
-    <SchemaFormPropertyMenu v-model:kind="kind">
+    <SchemaFormPropertyMenu v-model:kind="kind" :property="property">
       <template v-if="!isFirst">
         <p-overflow-menu-item icon="ArrowSmallUpIcon" label="Move to top" @click="emit('moveToTop')" />
       </template>

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -1,7 +1,9 @@
 <template>
   <p-icon-button-menu v-if="showMenu" small class="schema-form-property-menu">
     <template v-if="!disabled">
-      <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="emit('update:kind', 'none')" />
+      <template v-if="showNone">
+        <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="emit('update:kind', 'none')" />
+      </template>
       <p-overflow-menu-item v-if="showKind('json')" label="Use JSON input" @click="emit('update:kind', 'json')" />
       <p-overflow-menu-item v-if="showKind('workspace_variable')" label="Select variable" @click="emit('update:kind', 'workspace_variable')" />
       <p-overflow-menu-item v-if="showKind('jinja')" label="Create a template" @click="emit('update:kind', 'jinja')" />
@@ -17,10 +19,12 @@
 <script lang="ts" setup>
   import { computed, useSlots } from 'vue'
   import { useSchemaFormKinds } from '@/schemas/compositions/useSchemaFormKinds'
+  import { SchemaProperty } from '@/schemas/types/schema'
   import { PrefectKind } from '@/schemas/types/schemaValues'
 
   const props = defineProps<{
     kind: PrefectKind,
+    property: SchemaProperty,
     disabled?: boolean,
   }>()
 
@@ -33,6 +37,8 @@
 
   const showMenu = computed(() => kinds.length || slots.default)
   const showDivider = computed(() => !props.disabled && kinds.length)
+
+  const showNone = computed(() => props.property.type !== undefined)
 
   function showKind(kind: PrefectKind): boolean {
     return props.kind !== kind && (kinds.includes(kind) || kind === 'none')


### PR DESCRIPTION
# Description
Removes the "Use form input" if the property has no `type`. 