### PR TITLE
Schemas: Add support for json-string

### DIFF
--- a/src/schemas/components/SchemaFormPropertyString.vue
+++ b/src/schemas/components/SchemaFormPropertyString.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { PTextInput, State } from '@prefecthq/prefect-design'
+  import { PCodeInput, PTextInput, State } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import SchemaFormPropertyDate from '@/schemas/components/SchemaFormPropertyDate.vue'
   import SchemaFormPropertyDateTime from '@/schemas/components/SchemaFormPropertyDateTime.vue'
@@ -45,6 +45,15 @@
     if (format === 'password') {
       return withProps(PTextInput, {
         type: 'password',
+        modelValue: props.value,
+        state: props.state,
+        'onUpdate:modelValue': update,
+      })
+    }
+
+    if (format === 'json-string') {
+      return withProps(PCodeInput, {
+        lang: 'json',
         modelValue: props.value,
         state: props.state,
         'onUpdate:modelValue': update,

--- a/src/schemas/types/schema.ts
+++ b/src/schemas/types/schema.ts
@@ -22,6 +22,7 @@ export const { values: schemaStringFormat, isValue: isSchemaStringFormat } = cre
   'date',
   'date-time',
   'password',
+  'json-string',
 ])
 
 export type SchemaStringFormat = typeof schemaStringFormat[number]


### PR DESCRIPTION
# Description
Add's support for the `json-string` format for properties of type `string`. 