### PR TITLE
Schemas: Fix `number` support for integers and disable browser vendor validation

### DIFF
--- a/src/components/FlowRunCreateFormV2.vue
+++ b/src/components/FlowRunCreateFormV2.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-form class="flow-run-create-form-v2 p-background" @submit="submit">
+  <p-form class="flow-run-create-form-v2 p-background" novalidate @submit="submit">
     <p-content>
       <p-label label="Run Name" :state="nameState" :message="nameError">
         <FlowRunNameInput v-model="name" :state="nameState" />

--- a/src/schemas/components/SchemaForm.vue
+++ b/src/schemas/components/SchemaForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-form class="schema-form" @submit="submit">
+  <p-form class="schema-form" novalidate @submit="submit">
     <template v-if="schema.properties">
       <SchemaFormProperties v-model:values="values" :parent="schema" :properties="schema.properties" :errors="errors" />
     </template>

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -65,9 +65,18 @@
       })
     }
 
-    if (isSchemaPropertyType(type, 'integer') || isSchemaPropertyType(type, 'number')) {
+    if (isSchemaPropertyType(type, 'integer')) {
       return withProps(PNumberInput, {
         modelValue: asType(value, Number),
+        state: props.state,
+        'onUpdate:modelValue': update,
+      })
+    }
+
+    if (isSchemaPropertyType(type, 'number')) {
+      return withProps(PNumberInput, {
+        modelValue: asType(value, Number),
+        step: '0.01',
         state: props.state,
         'onUpdate:modelValue': update,
       })

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -68,6 +68,7 @@
     if (isSchemaPropertyType(type, 'integer')) {
       return withProps(PNumberInput, {
         modelValue: asType(value, Number),
+        step: '1',
         state: props.state,
         'onUpdate:modelValue': update,
       })


### PR DESCRIPTION
# Description
Fixes floats not allowing the form to be submitted because of the browsers vendor validation preventing the form from being submitted because of an invalid step