### PR TITLE
Schemas: Default to json when an object has no properties defined

### DIFF
--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -19,8 +19,9 @@
 <script lang="ts" setup>
   import { computed, useSlots } from 'vue'
   import { useSchemaFormKinds } from '@/schemas/compositions/useSchemaFormKinds'
-  import { SchemaProperty } from '@/schemas/types/schema'
+  import { SchemaProperty, isSchemaPropertyType } from '@/schemas/types/schema'
   import { PrefectKind } from '@/schemas/types/schemaValues'
+  import { isNullish } from '@/utilities'
 
   const props = defineProps<{
     kind: PrefectKind,
@@ -38,7 +39,13 @@
   const showMenu = computed(() => kinds.length || slots.default)
   const showDivider = computed(() => !props.disabled && kinds.length)
 
-  const showNone = computed(() => props.property.type !== undefined)
+  const showNone = computed(() => {
+    if (isSchemaPropertyType(props.property.type, 'object') && isNullish(props.property.properties)) {
+      return false
+    }
+
+    return props.property.type !== undefined
+  })
 
   function showKind(kind: PrefectKind): boolean {
     return props.kind !== kind && (kinds.includes(kind) || kind === 'none')

--- a/src/schemas/components/SchemaFormPropertyObject.vue
+++ b/src/schemas/components/SchemaFormPropertyObject.vue
@@ -8,8 +8,10 @@
   import { computed } from 'vue'
   import SchemaFormProperties from '@/schemas/components/SchemaFormProperties.vue'
   import { SchemaProperty } from '@/schemas/types/schema'
-  import { SchemaValues } from '@/schemas/types/schemaValues'
+  import { PrefectKindJson, SchemaValues } from '@/schemas/types/schemaValues'
   import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
+  import { isNullish } from '@/utilities'
+  import { asJson } from '@/utilities/types'
 
   const props = defineProps<{
     property: SchemaProperty & { type: 'object' },
@@ -20,6 +22,15 @@
   const emit = defineEmits<{
     'update:values': [SchemaValues | undefined],
   }>()
+
+  if (isNullish(props.property.properties)) {
+    const json: PrefectKindJson = {
+      __prefect_kind: 'json',
+      value: asJson(props.values),
+    }
+
+    emit('update:values', json)
+  }
 
   const values = computed({
     get() {

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -1,3 +1,4 @@
+import { stringify } from '@/utilities/json'
 import { isString } from '@/utilities/strings'
 import { isNullish } from '@/utilities/variables'
 
@@ -25,5 +26,5 @@ export function asJson(value: unknown): string {
     // silence is golden
   }
 
-  return JSON.stringify(value)
+  return stringify(value)
 }


### PR DESCRIPTION
# Description
When a schema property of type `object` has no `properties` we cannot generate a form for it. So when we detect that situation we need to force a json `kind`.