### PR TITLE
Schemas: Fix not being able to clear an input because the default value always appears

### DIFF
--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -34,7 +34,7 @@
 
 <script lang="ts" setup>
   import { isNotNullish } from '@prefecthq/prefect-design'
-  import { computed, ref } from 'vue'
+  import { computed, ref, onMounted } from 'vue'
   import SchemaFormPropertyMenu from '@/schemas/components/SchemaFormPropertyMenu.vue'
   import { usePrefectKind } from '@/schemas/compositions/usePrefectKind'
   import { useSchemaProperty } from '@/schemas/compositions/useSchemaProperty'
@@ -61,6 +61,11 @@
   const omitted = ref(false)
   const omittedValue = ref<SchemaValue>(null)
   const omitLabel = computed(() => omitted.value ? 'Include value' : 'Omit value')
+  const initialized = ref(false)
+
+  onMounted(() => {
+    initialized.value = true
+  })
 
   const classes = computed(() => ({
     label: {
@@ -81,7 +86,7 @@
         return props.value
       }
 
-      if (isNotNullish(property.value.default)) {
+      if (!initialized.value && isNotNullish(property.value.default)) {
         return property.value.default
       }
 


### PR DESCRIPTION
# Description
When generating forms, the SchemaFormProperty component is responsible for detecting and populating default values. It emits the value up and passes the value down (so that children with default values don't emit their default value). But once the form is generated the default value shouldn't be passed down again if the value becomes null. Adding an `initialized` boolean means we can have logic that only happens when the form is initially being generated. 