### PR TITLE
Overridable single batch processing deployments n blocks

### DIFF
--- a/src/services/WorkspaceBlockDocumentsApi.ts
+++ b/src/services/WorkspaceBlockDocumentsApi.ts
@@ -15,9 +15,7 @@ export class WorkspaceBlockDocumentsApi extends WorkspaceApi {
   private readonly batcher = new BatchProcessor<string, BlockDocument>(async ids => {
     if (ids.length === 1) {
       const [id] = ids
-      const { data } = await this.get<BlockDocumentResponse>(`/${id}`)
-
-      return () => mapper.map('BlockDocumentResponse', data, 'BlockDocument')
+      return this.getSingleBlockDocument.bind(this, id)
     }
 
     const blockDocuments = await this.getBlockDocuments({
@@ -32,6 +30,12 @@ export class WorkspaceBlockDocumentsApi extends WorkspaceApi {
 
   public getBlockDocument(blockDocumentId: string): Promise<BlockDocument> {
     return this.batcher.batch(blockDocumentId)
+  }
+
+  protected async getSingleBlockDocument(blockDocumentId: string): Promise<BlockDocument> {
+    const { data } = await this.get<BlockDocumentResponse>(`/${blockDocumentId}`)
+
+    return mapper.map('BlockDocumentResponse', data, 'BlockDocument')
   }
 
   public async getBlockDocuments(filter: BlockDocumentsFilter = {}): Promise<BlockDocument[]> {

--- a/src/services/WorkspaceDeploymentsApi.ts
+++ b/src/services/WorkspaceDeploymentsApi.ts
@@ -17,9 +17,7 @@ export class WorkspaceDeploymentsApi extends WorkspaceApi {
   private readonly batcher = new BatchProcessor<string, Deployment>(async ids => {
     if (ids.length === 1) {
       const [id] = ids
-      const { data } = await this.get<DeploymentResponse>(`/${id}`)
-
-      return () => mapper.map('DeploymentResponse', data, 'Deployment')
+      return this.getSingleDeployment.bind(this, id)
     }
 
     const deployments = await this.getDeployments({
@@ -33,6 +31,12 @@ export class WorkspaceDeploymentsApi extends WorkspaceApi {
 
   public getDeployment(deploymentId: string): Promise<Deployment> {
     return this.batcher.batch(deploymentId)
+  }
+
+  protected async getSingleDeployment(deploymentId: string): Promise<Deployment> {
+    const { data } = await this.get<DeploymentResponse>(`/${deploymentId}`)
+
+    return mapper.map('DeploymentResponse', data, 'Deployment')
   }
 
   public async getDeployments(filter: DeploymentsFilter = {}): Promise<Deployment[]> {


### PR DESCRIPTION
This PR aims to enable fixing https://github.com/PrefectHQ/nebula-ui/issues/4196 by allowing the deployment and block documents apis' batch processor callback for processing a GET for a single object to be overridden in derived classes. 

For more on what/why this is useful, see a downstream implementation in - https://github.com/PrefectHQ/nebula-ui/pull/4220