### PR TITLE
Schemas: Fix component accidentally modifying the schema

### DIFF
--- a/src/schemas/components/SchemaFormPropertyAllOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAllOf.vue
@@ -38,12 +38,12 @@
   const property = computed(() => {
     const definitions = props.property.allOf.reduce<SchemaProperty>((property, definition) => {
       if (isPropertyWith(definition, '$ref')) {
-        return merge(getSchemaDefinition(schema, definition.$ref), property)
+        return merge({}, getSchemaDefinition(schema, definition.$ref), property)
       }
 
-      return merge(property, definition)
+      return merge({}, property, definition)
     }, {})
 
-    return merge(definitions, props.property)
+    return merge({}, definitions, props.property)
   })
 </script>


### PR DESCRIPTION
# Description
using `merge` to combine objects will update the reference of the first object. Merging into an empty object prevents updating the schema itself. 