### PR TITLE
Schemas: Add support for `None` (`null`) values and improve `anyOf` property layout

### DIFF
--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -12,6 +12,8 @@
       </div>
     </template>
 
+    <slot />
+
     <template v-if="description" #description>
       <div class="schema-form-property__description">
         <p-markdown-renderer :text="description" class="schema-form-property__markdown" />
@@ -93,7 +95,7 @@
       return null
     },
     set(value) {
-      emit('update:value', value ?? undefined)
+      emit('update:value', value)
     },
   })
 

--- a/src/schemas/components/SchemaFormPropertyAnyOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOf.vue
@@ -1,15 +1,14 @@
 <template>
-  <div class="schema-form-property-any-of-input">
-    <p-button-group v-model="selectedPropertyIndex" :options="options" small />
-  </div>
-
-  <p-card>
-    <SchemaFormProperty :key="selectedPropertyIndexValue" v-model:value="value" :property="property" :required="required" :errors="errors" />
-  </p-card>
+  <keep-alive>
+    <SchemaFormProperty :key="selectedPropertyIndexValue" v-model:value="value" v-bind="{ property, required, errors }" class="schema-form-property-any-of-input">
+      <p-button-group v-model="selectedPropertyIndex" :options="options" small class="mb-2" />
+    </SchemaFormProperty>
+  </keep-alive>
 </template>
 
 <script lang="ts" setup>
   import { ButtonGroupOption } from '@prefecthq/prefect-design'
+  import merge from 'lodash.merge'
   import { computed, reactive, ref } from 'vue'
   import { useWorkspaceApi } from '@/compositions'
   import SchemaFormProperty from '@/schemas/components/SchemaFormProperty.vue'
@@ -73,10 +72,10 @@
     const selectedProperty = props.property.anyOf[selectedPropertyIndex.value]
 
     if (isPropertyWith(selectedProperty, '$ref')) {
-      return getSchemaDefinition(schema, selectedProperty.$ref)
+      return merge({}, getSchemaDefinition(schema, selectedProperty.$ref), props.property)
     }
 
-    return selectedProperty
+    return merge({}, selectedProperty, props.property)
   })
 
   const options = computed<ButtonGroupOption[]>(() => props.property.anyOf.map((property, index) => ({

--- a/src/schemas/components/SchemaFormPropertyArray.vue
+++ b/src/schemas/components/SchemaFormPropertyArray.vue
@@ -35,7 +35,7 @@
 
   const props = defineProps<{
     property: SchemaProperty & { type: 'array' },
-    value: unknown[] | null,
+    value: unknown[] | undefined,
     errors: SchemaValueError[],
     state: State,
   }>()
@@ -44,7 +44,7 @@
   const empty = computed(() => !props.value?.length)
 
   const emit = defineEmits<{
-    'update:value': [unknown[] | null],
+    'update:value': [unknown[] | undefined],
   }>()
 
   const value = computed({
@@ -53,7 +53,7 @@
     },
     set(value) {
       if (value.length === 0) {
-        emit('update:value', null)
+        emit('update:value', undefined)
         return
       }
 

--- a/src/schemas/components/SchemaFormPropertyBlockDocument.vue
+++ b/src/schemas/components/SchemaFormPropertyBlockDocument.vue
@@ -9,15 +9,16 @@
   import { SchemaProperty } from '@/schemas/types/schema'
   import { BlockDocumentReferenceValue } from '@/schemas/types/schemaValues'
   import { Require } from '@/types/utilities'
+  import { isNullish } from '@/utilities/variables'
 
   const props = defineProps<{
     property: Require<SchemaProperty, 'blockTypeSlug'>,
-    value: BlockDocumentReferenceValue | null | undefined,
+    value: BlockDocumentReferenceValue | undefined,
     state: State,
   }>()
 
   const emit = defineEmits<{
-    'update:value': [BlockDocumentReferenceValue | null | undefined],
+    'update:value': [BlockDocumentReferenceValue | undefined],
   }>()
 
   const value = computed({
@@ -25,8 +26,8 @@
       return props.value?.$ref ?? null
     },
     set(value) {
-      if (value === null) {
-        emit('update:value', value)
+      if (isNullish(value)) {
+        emit('update:value', undefined)
         return
       }
 

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -10,6 +10,7 @@
   import SchemaFormPropertyArray from '@/schemas/components/SchemaFormPropertyArray.vue'
   import SchemaFormPropertyBlockDocument from '@/schemas/components/SchemaFormPropertyBlockDocument.vue'
   import SchemaFormPropertyInteger from '@/schemas/components/SchemaFormPropertyInteger.vue'
+  import SchemaFormPropertyNull from '@/schemas/components/SchemaFormPropertyNull.vue'
   import SchemaFormPropertyObject from '@/schemas/components/SchemaFormPropertyObject.vue'
   import SchemaFormPropertyString from '@/schemas/components/SchemaFormPropertyString.vue'
   import { useSchemaProperty } from '@/schemas/compositions/useSchemaProperty'
@@ -30,10 +31,6 @@
     'update:value': [SchemaValue],
   }>()
 
-  function update(value: unknown): void {
-    emit('update:value', value)
-  }
-
   const { property } = useSchemaProperty(() => props.property)
 
   const input = computed(() => {
@@ -45,7 +42,7 @@
         property: property.value,
         state: props.state,
         value: asBlockDocumentReferenceValue(value),
-        'onUpdate:value': update,
+        'onUpdate:value': (value) => emit('update:value', value),
       })
     }
 
@@ -53,7 +50,7 @@
       return withProps(PToggle, {
         modelValue: asType(value, Boolean),
         state: props.state,
-        'onUpdate:modelValue': update,
+        'onUpdate:modelValue': (value) => emit('update:value', asType(value, Boolean)),
       })
     }
 
@@ -62,7 +59,7 @@
         property: { ...property.value, type },
         value: asType(value, String),
         state: props.state,
-        'onUpdate:value': update,
+        'onUpdate:value': (value) => emit('update:value', asType(value, String)),
       })
     }
 
@@ -71,7 +68,7 @@
         property: { ...property.value, type },
         value: asType(value, Number),
         state: props.state,
-        'onUpdate:value': update,
+        'onUpdate:value': (value) => emit('update:value', asType(value, Number)),
       })
     }
 
@@ -80,7 +77,7 @@
         modelValue: asType(value, Number),
         step: '0.01',
         state: props.state,
-        'onUpdate:modelValue': update,
+        'onUpdate:modelValue': (value) => emit('update:value', asType(value, Number)),
       })
     }
 
@@ -90,7 +87,7 @@
         value: asType(value, Array),
         errors: props.errors,
         state: props.state,
-        'onUpdate:value': update,
+        'onUpdate:value': (value) => emit('update:value', asType(value, Array)),
       })
     }
 
@@ -99,12 +96,16 @@
         property: { ...property.value, type },
         values: asType(value, Object),
         errors: props.errors,
-        'onUpdate:values': update,
+        'onUpdate:values': (value) => emit('update:value', asType(value, Object)),
       })
     }
 
     if (isSchemaPropertyType(type, 'null')) {
-      return { component: null, props: {} }
+      return withProps(SchemaFormPropertyNull, {
+        property: { ...property.value, type },
+        value: null,
+        'onUpdate:value': (value) => emit('update:value', value),
+      })
     }
 
     if (isSchemaPropertyType(type, undefined)) {
@@ -113,7 +114,7 @@
         value: asJson(value),
       }
 
-      update(json)
+      emit('update:value', json)
 
       return { component: null, props: {} }
     }

--- a/src/schemas/components/SchemaFormPropertyInteger.vue
+++ b/src/schemas/components/SchemaFormPropertyInteger.vue
@@ -36,7 +36,7 @@
       modelValue: asType(props.value, Number),
       step: '1',
       state: props.state,
-      'onUpdate:modelValue': value => emit('update:value', value),
+      'onUpdate:modelValue': value => emit('update:value', asType(value, Number)),
     })
   })
 </script>

--- a/src/schemas/components/SchemaFormPropertyNull.vue
+++ b/src/schemas/components/SchemaFormPropertyNull.vue
@@ -1,0 +1,15 @@
+<!-- eslint-disable vue/no-unused-properties -->
+<script lang="ts" setup>
+  import { SchemaProperty } from '@/schemas/types/schema'
+
+  defineProps<{
+    property: SchemaProperty & { type: 'null' },
+    value: null,
+  }>()
+
+  const emit = defineEmits<{
+    'update:value': [null],
+  }>()
+
+  emit('update:value', null)
+</script>

--- a/src/schemas/components/SchemaFormPropertyString.vue
+++ b/src/schemas/components/SchemaFormPropertyString.vue
@@ -14,12 +14,12 @@
 
   const props = defineProps<{
     property: SchemaProperty & { type: 'string' },
-    value: string | null | undefined,
+    value: string | undefined,
     state: State,
   }>()
 
   const emit = defineEmits<{
-    'update:value': [string | null | undefined],
+    'update:value': [string | undefined],
   }>()
 
   const { property } = useSchemaProperty(() => props.property)
@@ -66,7 +66,7 @@
         modelValue: props.value,
         state: props.state,
         options: stringEnum.filter(isString),
-        'onUpdate:modelValue': (value) => update(asType(value, String)),
+        'onUpdate:modelValue': update,
       })
     }
 
@@ -77,12 +77,7 @@
     })
   })
 
-  function update(value: string | null | undefined): void {
-    if (!value) {
-      emit('update:value', undefined)
-      return
-    }
-
-    emit('update:value', value)
+  function update(value: unknown): void {
+    emit('update:value', asType(value, String))
   }
 </script>

--- a/src/schemas/types/schemaValues.ts
+++ b/src/schemas/types/schemaValues.ts
@@ -76,10 +76,10 @@ export function isBlockDocumentReferenceValue(value: unknown): value is BlockDoc
   return isRecord(value) && isString(value.$ref)
 }
 
-export function asBlockDocumentReferenceValue(value: unknown): BlockDocumentReferenceValue | null {
+export function asBlockDocumentReferenceValue(value: unknown): BlockDocumentReferenceValue | undefined {
   if (isBlockDocumentReferenceValue(value)) {
     return value
   }
 
-  return null
+  return undefined
 }

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -2,12 +2,12 @@ import { stringify } from '@/utilities/json'
 import { isString } from '@/utilities/strings'
 import { isNullish } from '@/utilities/variables'
 
-export function asType<T extends() => unknown>(value: unknown, type: T): ReturnType<T> | null {
+export function asType<T extends() => unknown>(value: unknown, type: T): ReturnType<T> | undefined {
   if (typeof value === typeof type()) {
     return value as ReturnType<T>
   }
 
-  return null
+  return undefined
 }
 
 export function asJson(value: unknown): string {


### PR DESCRIPTION
# Description
This PR focuses on two related concepts. 

1. Use `undefined` specifically for an "empty" value. Previously both `null` and `undefined` were used interchangeable for this. This allows `null` to be used as an actual value

2. Add a component for properties with a type of `null` which sets the value to `null` when selected. This allows specifically using a `null` (`None`) value. 

## Example
For this flow
```
class User(BaseModel):
  ...

class Param(BaseModel):
  foo: Union[User, int, None] = Field(title="Foo", description="Some description")

@flow
def schema_testing(test: Param):
  pass
```

The "Foo" parameter now has this layout (there should be a card box around the user properties, somethings not working correctly on my local but should be fine, it not I'll address)
<img width="777" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/a2955480-ee5e-44a2-a8aa-c71287f8b386">

Which used to look like this
<img width="1279" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/b5ca2ede-24d5-41d7-af03-ea6e89ed3294">
