### PR TITLE
Bugfix: Properly bucket future runs in flow run histogram 

### DIFF
--- a/src/components/FlowRunsBarChart.vue
+++ b/src/components/FlowRunsBarChart.vue
@@ -130,19 +130,36 @@
     const buckets: (FlowRun | null)[] = new Array(bars.value).fill(null)
     const maxBucketIndex = buckets.length - 1
 
+    const isFutureTimeSpan = expectedStartTimeBefore.getTime() > new Date().getTime()
+
+    const bucketIncrementDirection = isFutureTimeSpan ? 1 : -1
+    const sortedRuns = isFutureTimeSpan
+      ? flowRuns.sort((runA, runB) => {
+        const aStartTime = runA.startTime ?? runA.expectedStartTime
+        const bStartTime = runB.startTime ?? runB.expectedStartTime
+
+        if (!aStartTime || !bStartTime) {
+          return 0
+        }
+
+        return aStartTime.getTime() - bStartTime.getTime()
+      })
+      : flowRuns
+
+    // const bucketStepper = expectedStartTimeBefore.getTime() > new Date().getTime() ? 1 : -1
     function getEmptyBucket(index: number): number | null {
       if (index < 0) {
         return null
       }
 
       if (buckets[index]) {
-        return getEmptyBucket(index - 1)
+        return getEmptyBucket(index + bucketIncrementDirection)
       }
 
       return index
     }
 
-    flowRuns.forEach((flowRun) => {
+    sortedRuns.forEach((flowRun) => {
       const startTime = flowRun.startTime ?? flowRun.expectedStartTime
 
       if (!startTime) {


### PR DESCRIPTION
Related to: https://github.com/PrefectHQ/prefect/issues/11977

When viewing timespans in the future, the flow run history graph was incorrectly bucketing runs. This is due to two factors:

1. When requesting runs we request them sorted by `START_TIME_DESC`, but runs in the future don't have a start time, they only have an expected_start_time. So this PR will sort the runs accordingly if looking at future time spans.
2. The bucketing function was designed to bucket right to left, working on the latest run to the earliest. Timespans in the future need to bucket from the left to the right, earliest to latest. So the increment direction is now conditional based on if looking at future time spans.

Before:
https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/250dfaef-6833-47d0-83a5-1682fdad507b

After:
https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/1ae1be88-dab5-47c6-880d-1074196e7cd6
