### PR TITLE
Schemas: Use the property key as the title if the property's schema does not have a title

### DIFF
--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -4,7 +4,7 @@
       <template v-if="isPropertyWith(property, 'allOf')">
         <SchemaFormPropertyAllOf
           :value="getValue(key)"
-          :property="property"
+          :property="getProperty(property, key)"
           :required="getRequired(key)"
           :errors="getSchemaPropertyErrors(key, errors)"
           @update:value="setValue(key, $event)"
@@ -14,7 +14,7 @@
       <template v-else-if="isPropertyWith(property, 'anyOf')">
         <SchemaFormPropertyAnyOf
           :value="getValue(key)"
-          :property="property"
+          :property="getProperty(property, key)"
           :required="getRequired(key)"
           :errors="getSchemaPropertyErrors(key, errors)"
           @update:value="setValue(key, $event)"
@@ -24,7 +24,7 @@
       <template v-else>
         <SchemaFormProperty
           :value="getValue(key)"
-          :property="property"
+          :property="getProperty(property, key)"
           :required="getRequired(key)"
           :errors="getSchemaPropertyErrors(key, errors)"
           @update:value="setValue(key, $event)"
@@ -68,6 +68,14 @@
       return positionA - positionB
     })
   })
+
+  function getProperty<T extends SchemaProperty>(property: T, key: string): T {
+    if (!property.title) {
+      return { ...property, title: key }
+    }
+
+    return property
+  }
 
   function getValue(propertyKey: string): unknown {
     return props.values?.[propertyKey] ?? undefined


### PR DESCRIPTION
# Description
When a definition exists for a property the definition is merged with the property itself in order to generate the proper form field(s). But this means the title from the definition can show up if the property itself does not have a title. 

This updates the way properties are passed to sub components from the SchemaFormProperties component so that the property key is used if a title is missing 

## Example
```
class OptionsEnum(Enum):
    YES = "Yes, continue"
    NO = "No, cancel flow"

class UserInput(BaseModel):
    approved: OptionsEnum = Field(
        default=OptionsEnum.NO,
    )

@flow
def schema_testing(input: UserInput):
  pass
```

Before
<img width="792" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/d5d43bdf-078b-48fa-80ea-9b32e395af12">

After
<img width="791" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/213e4278-2fc6-4198-bc07-8d42ecf47bcb">
