### PR TITLE
Schemas: wrap property key titles in the `titleCase` utility

### DIFF
--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -46,6 +46,7 @@
   import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
   import { getSchemaPropertyErrors } from '@/schemas/utilities/errors'
   import { SchemaValue } from '@/types'
+  import { titleCase } from '@/utilities/strings'
 
   const props = defineProps<{
     parent: SchemaProperty,
@@ -71,7 +72,7 @@
 
   function getProperty<T extends SchemaProperty>(property: T, key: string): T {
     if (!property.title) {
-      return { ...property, title: key }
+      return { ...property, title: titleCase(key) }
     }
 
     return property


### PR DESCRIPTION
# Description
When a property doesn't have a title we use the property's key as the title. Now capitalizing it to match what pydantic does by default when it does create titles. 