### PR TITLE
Fix: Update SavedFiltersMenu.vue

### DIFF
--- a/src/components/SavedFiltersMenu.vue
+++ b/src/components/SavedFiltersMenu.vue
@@ -95,7 +95,7 @@
 
   const can = useCan()
   const route = useRoute()
-  const fullRoute = computed(() => window.location.origin + route.path)
+  const fullRoute = computed(() => window.location.origin + route.fullPath)
 
   const { showModal: showSaveModal, open: openSaveModal } = useShowModal()
   const { showModal: showDeleteModal, open: openDeleteModal } = useShowModal()


### PR DESCRIPTION
Addresses #2103, where @NodeJSmith reports that sharing a saved view does not copy the url's search params. 

 