### PR TITLE
Design: Update StateListItem.vue

### DIFF
--- a/src/components/StateListItem.vue
+++ b/src/components/StateListItem.vue
@@ -178,6 +178,7 @@
 
 .state-list-item__tags { @apply
   min-w-0
+  overflow-hidden
   grow;
 
   grid-area: tags;


### PR DESCRIPTION
In #1977 @WillRaphaelson reports that StateListItem cards do not properly wrap. 

It appears some fix has been done to address this, but still possess a small paper cut:
<img width="619" alt="Screenshot 2024-02-23 at 4 38 14 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/33043305/e006faf2-dcfb-4218-a748-63ea7075fb4c">

Our use of tag groups almost always collapses tags to a "+N" indicator in the presence of a large title. The collapsed tag group can't be interacted with, and so in the presence of a large title we basically present a count of tags, which is pretty useless IMO. 

This PR simply hides overflow from a shrunken tag container on the state list item. 
<img width="606" alt="Screenshot 2024-02-23 at 4 37 56 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/33043305/6a7d836a-925c-492c-a6a7-82f00ab8ca47">


This will be revisited in a future PR to prefect-design, to make tag-group "+N" indicators interactable. 