### PR TITLE
prevent overflowing tags

### DIFF
--- a/src/components/FlowRunBreadCrumbs.vue
+++ b/src/components/FlowRunBreadCrumbs.vue
@@ -39,6 +39,7 @@
 <style>
 .flow-run-bread-crumbs { @apply
   text-subdued
+  whitespace-normal
 }
 
 .flow-run-bread-crumbs__flow-link { @apply

--- a/src/components/FlowRunBreadCrumbs.vue
+++ b/src/components/FlowRunBreadCrumbs.vue
@@ -39,7 +39,6 @@
 <style>
 .flow-run-bread-crumbs { @apply
   text-subdued
-  whitespace-normal
 }
 
 .flow-run-bread-crumbs__flow-link { @apply

--- a/src/components/StateListItem.vue
+++ b/src/components/StateListItem.vue
@@ -134,7 +134,7 @@
 .state-list-item__top-section { @apply
   grid
   w-full
-  items-center
+  items-start
   gap-2;
 
   grid-template-columns: 1fr auto;

--- a/src/components/StateListItem.vue
+++ b/src/components/StateListItem.vue
@@ -153,12 +153,7 @@
 
 .state-list-item__name { @apply
   text-base
-  text-subdued
-  shrink-0
-  whitespace-nowrap
-  grow-0
-  text-ellipsis
-  overflow-hidden;
+  text-subdued;
 
   grid-area: name;
 }

--- a/src/components/StateListItem.vue
+++ b/src/components/StateListItem.vue
@@ -177,8 +177,7 @@
 }
 
 .state-list-item__tags { @apply
-  min-w-0
-  overflow-hidden
+  min-w-12
   grow;
 
   grid-area: tags;

--- a/src/components/StateListItem.vue
+++ b/src/components/StateListItem.vue
@@ -178,6 +178,7 @@
 
 .state-list-item__tags { @apply
   min-w-0
+  overflow-hidden
   grow;
 
   grid-area: tags;


### PR DESCRIPTION
This is a riff on @aaazzam 's [PR](https://github.com/PrefectHQ/prefect-ui-library/pull/2133/files). Here instead of allowing tags to overflow, which can sort of half way happen at times and prevents the user from at least hovering the tags to see what they are (not an amazing experience, granted). This removes some unneeded styles which allows long run names to wrap. The ellipsis styles that were there weren't working anyway, so now the full run name can be visible too.

<img width="765" alt="Screenshot 2024-02-26 at 7 59 26 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/f5ccdce4-f108-4d84-9419-f0fc96b95d4b">

Thanks for attacking these UI issues @aaazzam 