### PR TITLE
Schemas: Add support for enums when the type is unknown

### DIFF
--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -13,6 +13,7 @@
   import SchemaFormPropertyNull from '@/schemas/components/SchemaFormPropertyNull.vue'
   import SchemaFormPropertyObject from '@/schemas/components/SchemaFormPropertyObject.vue'
   import SchemaFormPropertyString from '@/schemas/components/SchemaFormPropertyString.vue'
+  import SchemaFormPropertyUnknown from '@/schemas/components/SchemaFormPropertyUnknown.vue'
   import { useSchemaProperty } from '@/schemas/compositions/useSchemaProperty'
   import { SchemaProperty, isPropertyWith, isSchemaPropertyType } from '@/schemas/types/schema'
   import { PrefectKindJson, SchemaValue, asBlockDocumentReferenceValue } from '@/schemas/types/schemaValues'
@@ -109,14 +110,11 @@
     }
 
     if (isSchemaPropertyType(type, undefined)) {
-      const json: PrefectKindJson = {
-        __prefect_kind: 'json',
-        value: asJson(value),
-      }
-
-      emit('update:value', json)
-
-      return { component: null, props: {} }
+      return withProps(SchemaFormPropertyUnknown, {
+        property: { ...property.value, type },
+        value: value,
+        state: props.state,
+      })
     }
 
     const exhaustive: never = type

--- a/src/schemas/components/SchemaFormPropertyUnknown.vue
+++ b/src/schemas/components/SchemaFormPropertyUnknown.vue
@@ -1,0 +1,60 @@
+<template>
+  <component :is="input?.component" v-bind="input?.props" class="schema-form-property-string" />
+</template>
+
+<script lang="ts" setup>
+  import { PCombobox, SelectModelValue, SelectOption, State } from '@prefecthq/prefect-design'
+  import { computed } from 'vue'
+  import { useSchemaProperty } from '@/schemas/compositions/useSchemaProperty'
+  import { SchemaProperty } from '@/schemas/types/schema'
+  import { PrefectKindJson } from '@/schemas/types/schemaValues'
+  import { isNumber, isString, withProps } from '@/utilities'
+  import { isBoolean } from '@/utilities/boolean'
+  import { asJson } from '@/utilities/types'
+
+  function isSelectModelValue(value: unknown): value is SelectModelValue {
+    return isString(value) || isBoolean(value) || isNumber(value) || value === null
+  }
+
+  function asSelectModelValue(value: unknown): SelectModelValue | undefined {
+    if (isSelectModelValue(value)) {
+      return value
+    }
+
+    return undefined
+  }
+
+  const props = defineProps<{
+    property: SchemaProperty & { type: undefined },
+    value: unknown,
+    state: State,
+  }>()
+
+  const emit = defineEmits<{
+    'update:value': [unknown],
+  }>()
+
+  const { property } = useSchemaProperty(() => props.property)
+
+  const input = computed(() => {
+    const { enum: unknownEnum } = property.value
+
+    if (unknownEnum) {
+      return withProps(PCombobox, {
+        modelValue: asSelectModelValue(props.value),
+        state: props.state,
+        options: unknownEnum.filter(isSelectModelValue).map<SelectOption>(value => ({ value, label: value?.toString() ?? 'None' })),
+        'onUpdate:modelValue': value => emit('update:value', value),
+      })
+    }
+
+    const json: PrefectKindJson = {
+      __prefect_kind: 'json',
+      value: asJson(props.value),
+    }
+
+    emit('update:value', json)
+
+    return { component: null, props: {} }
+  })
+</script>

--- a/src/utilities/boolean.ts
+++ b/src/utilities/boolean.ts
@@ -1,0 +1,3 @@
+export function isBoolean(value: unknown): value is boolean {
+  return typeof value === 'boolean'
+}


### PR DESCRIPTION
# Description
When creating an enum without a specific type like
```
class MyEnum(Enum):
    FOO = 'foo'
    BAR = 'bar'
```
The `type` for the property is undefined which ended up defaulting to a json value. This can be fixed in python by specifying the enum type like `class MyEnum(str, Enum)` but in v1 we supported the other syntax. So adding a `SchemaFormPropertyUnknown` component that checks the `enum` property and displays a combobox if it can. 

Closes: https://github.com/PrefectHQ/prefect/issues/12069