### PR TITLE
Schemas: Adds support for prefix items for properties of type array

### DIFF
--- a/src/schemas/components/SchemaFormPropertyArray.vue
+++ b/src/schemas/components/SchemaFormPropertyArray.vue
@@ -81,6 +81,10 @@
   })
 
   function getPropertyForIndex(index: number): SchemaProperty {
+    if (isArray(property.value.prefixItems)) {
+      return property.value.prefixItems[index] ?? {}
+    }
+
     if (isArray(property.value.items)) {
       return property.value.items[index] ?? {}
     }


### PR DESCRIPTION
# Description
pydantic v2 correctly uses prefixItems for tuples but pydantic v1 uses the items property (in an incorrect way). So we'll prefer using prefixItems if it exists but also support the items array syntax pydantic 1 produces