### PR TITLE
Schemas: Add depth to object property component to customize appearance

### DIFF
--- a/src/schemas/components/SchemaFormPropertyObject.vue
+++ b/src/schemas/components/SchemaFormPropertyObject.vue
@@ -1,12 +1,13 @@
 <template>
-  <p-card class="schema-form-property-object">
+  <component :is="element" class="schema-form-property-object">
     <SchemaFormProperties v-model:values="values" :parent="property" :properties="property.properties ?? {}" :errors="errors" />
-  </p-card>
+  </component>
 </template>
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
+  import { computed, inject, provide } from 'vue'
   import SchemaFormProperties from '@/schemas/components/SchemaFormProperties.vue'
+  import { schemaPropertyObjectDepthSymbol } from '@/schemas/symbols'
   import { SchemaProperty } from '@/schemas/types/schema'
   import { PrefectKindJson, SchemaValues } from '@/schemas/types/schemaValues'
   import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
@@ -19,9 +20,21 @@
     errors: SchemaValueError[],
   }>()
 
+  const depth = inject(schemaPropertyObjectDepthSymbol, 0)
+
+  provide(schemaPropertyObjectDepthSymbol, depth + 1)
+
   const emit = defineEmits<{
     'update:values': [SchemaValues | undefined],
   }>()
+
+  const element = computed(() => {
+    if (depth === 0) {
+      return 'div'
+    }
+
+    return 'p-card'
+  })
 
   if (isNullish(props.property.properties)) {
     const json: PrefectKindJson = {

--- a/src/schemas/components/SchemaInput.vue
+++ b/src/schemas/components/SchemaInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="input.component" v-bind="input.props" flat class="schema-input" />
+  <component :is="input.component" v-bind="input.props" class="schema-input" />
 </template>
 
 <script lang="ts" setup>

--- a/src/schemas/symbols.ts
+++ b/src/schemas/symbols.ts
@@ -1,0 +1,3 @@
+import { InjectionKey } from 'vue'
+
+export const schemaPropertyObjectDepthSymbol: InjectionKey<number> = Symbol()


### PR DESCRIPTION
# Description
So that we don't use a p-card component for the top level parameters we'll keep track of depth of object properties. That way we can customize the appearance of the component based on depth. For now just using a div for top level and continuing to use `p-card` for nested objects. 

Before
<img width="745" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/60a295f2-c32e-4689-bc57-25551d3c123c">

After
<img width="764" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/71bd4e9d-bdb4-446d-bc75-baf014a6f4e8">
