### PR TITLE
Remove the volar typescript plugin

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "vue.vscode-typescript-vue-plugin",
     "vue.volar",
     "bradlc.vscode-tailwindcss"
   ]


### PR DESCRIPTION
# Description
This plugin is no longer needed as takeover mode is no longer supported. Default vscode typescript is now used. 