### PR TITLE
Schemas: Add json to the quick run modal

### DIFF
--- a/src/components/QuickRunParametersModalV2.vue
+++ b/src/components/QuickRunParametersModalV2.vue
@@ -1,6 +1,16 @@
 <template>
-  <p-modal v-model:showModal="internalShowModal" class="parameters-modal" title="Run Deployment">
-    <SchemaFormV2 :id="formId" v-model:values="parameters" :schema="deployment.parameterOpenApiSchemaV2" :kinds="['json']" @submit="submit" />
+  <p-modal v-model:showModal="internalShowModal" class="quick-run-parameters-modal-v2" title="Run Deployment">
+    <p-content>
+      <div class="quick-run-parameters-modal-v2__header">
+        <h3>{{ localization.info.parameters }}</h3>
+        <p-icon-button-menu small>
+          <p-overflow-menu-item v-if="kind === 'json'" label="Use form input" @click="kind = 'none'" />
+          <p-overflow-menu-item v-if="kind === 'none'" label="Use JSON input" @click="kind = 'json'" />
+        </p-icon-button-menu>
+      </div>
+
+      <SchemaFormV2 :id="formId" v-model:values="parameters" :schema="deployment.parameterOpenApiSchemaV2" :kinds="['json']" @submit="submit" />
+    </p-content>
 
     <template #actions>
       <slot name="actions">
@@ -21,6 +31,7 @@
   import { localization } from '@/localization'
   import { Deployment, DeploymentFlowRunCreateV2 } from '@/models'
   import { SchemaFormV2, SchemaValuesV2 } from '@/schemas'
+  import { usePrefectKind } from '@/schemas/compositions/usePrefectKind'
   import { getApiErrorMessage } from '@/utilities/errors'
 
   const props = defineProps<{
@@ -38,7 +49,7 @@
   }>()
 
   const parameters = ref<SchemaValuesV2>({ ...props.deployment.parametersV2 })
-
+  const { kind } = usePrefectKind(parameters)
 
   const internalShowModal = computed({
     get() {
@@ -72,3 +83,11 @@
     internalShowModal.value = false
   }
 </script>
+
+<style>
+.quick-run-parameters-modal-v2__header { @apply
+  flex
+  items-center
+  justify-between
+}
+</style>


### PR DESCRIPTION
# Description
Adds the ability to use a single json value for all parameters in the quick run modal. 

After
<img width="586" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/c1ad8c2f-d186-47fc-bf85-46ac206b9403">
