### PR TITLE
Enhancement: add flow run graph states layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@prefecthq/prefect-ui-library",
             "version": "2.6.19",
             "dependencies": {
-                "@prefecthq/graphs": "2.2.3",
+                "@prefecthq/graphs": "2.2.5",
                 "@types/lodash.isequal": "4.5.8",
                 "axios": "1.6.2",
                 "cronstrue": "^2.48.0",
@@ -1219,9 +1219,9 @@
             }
         },
         "node_modules/@prefecthq/graphs": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-2.2.3.tgz",
-            "integrity": "sha512-LW34TLMZLYVimNiK/BWHQjDYssq2YDneLOz+w2me86dTia8X4c2UqKoAbO2Yc0SFvEKScoO4yWT+mcogn40AEQ==",
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-2.2.5.tgz",
+            "integrity": "sha512-+oINYfcEe5cSrwyZj4C2oHgTEOLy+jYiZJBxl3jd8XQVyriA451WE82p//FuqfIgn0oUkmjInubOF9RXEWGn/A==",
             "dependencies": {
                 "@pixi-essentials/cull": "2.0.0",
                 "d3": "7.8.5",
@@ -8449,9 +8449,9 @@
             }
         },
         "@prefecthq/graphs": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-2.2.3.tgz",
-            "integrity": "sha512-LW34TLMZLYVimNiK/BWHQjDYssq2YDneLOz+w2me86dTia8X4c2UqKoAbO2Yc0SFvEKScoO4yWT+mcogn40AEQ==",
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-2.2.5.tgz",
+            "integrity": "sha512-+oINYfcEe5cSrwyZj4C2oHgTEOLy+jYiZJBxl3jd8XQVyriA451WE82p//FuqfIgn0oUkmjInubOF9RXEWGn/A==",
             "requires": {
                 "@pixi-essentials/cull": "2.0.0",
                 "d3": "7.8.5",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "vue-router": "^4.0.12"
     },
     "dependencies": {
-        "@prefecthq/graphs": "2.2.3",
+        "@prefecthq/graphs": "2.2.5",
         "@types/lodash.isequal": "4.5.8",
         "axios": "1.6.2",
         "cronstrue": "^2.48.0",

--- a/src/components/FlowRunGraph.vue
+++ b/src/components/FlowRunGraph.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="showGraph" class="flow-run-graph">
+  <div class="flow-run-graph" :class="classes.root">
     <template v-if="load">
       <RunGraph
         v-model:viewport="viewport"
@@ -8,6 +8,9 @@
         :config="config"
         class="flow-run-graph__graph p-background"
       />
+      <p v-if="!hasGraphNodes" class="flow-run-graph__no-nodes-message">
+        No tasks or sub flows were called
+      </p>
     </template>
     <template v-else>
       <FlowRunGraphConfirmation @confirm="confirm" />
@@ -43,7 +46,7 @@
   const api = useWorkspaceApi()
   const { value: colorThemeValue } = useColorTheme()
   const load = ref(true)
-  const showGraph = ref(true)
+  const hasGraphNodes = ref(true)
 
   const viewport = computed({
     get() {
@@ -106,6 +109,9 @@
       node: node => ({
         background: stateTypeColors[node.state_type],
       }),
+      state: state => ({
+        background: stateTypeColors[state.type],
+      }),
     },
   }))
 
@@ -124,7 +130,13 @@
     load.value = false
   }
 
-  showGraph.value = count.value! > 0
+  hasGraphNodes.value = count.value! > 0
+
+  const classes = computed(() => ({
+    root: {
+      'flow-run-graph--no-nodes': !hasGraphNodes.value,
+    },
+  }))
 
   function confirm(): void {
     load.value = true
@@ -137,10 +149,34 @@
   --p-color-flow-run-graph-edge: var(--p-color-text-subdued);
 }
 
+.flow-run-graph { @apply
+  w-full
+  h-96
+  relative
+}
+
+.flow-run-graph--no-nodes { @apply
+  h-40
+}
+
 .flow-run-graph__graph {
   width: 100%;
-  height: 340px;
+  height: 100%;
 }
+
+.flow-run-graph__no-nodes-message { @apply
+  text-center
+  text-subdued
+  max-w-full
+  px-3
+  absolute
+  top-1/2
+  left-1/2
+  -translate-x-1/2
+  -translate-y-1/2
+  pointer-events-none
+}
+
 
 /* TODO: This temporarily hides the "Hide artifacts" option until that layer goes live */
 .run-graph-settings__menu > .p-checkbox:last-child {

--- a/src/components/FlowRunGraphArtifactsPopover.vue
+++ b/src/components/FlowRunGraphArtifactsPopover.vue
@@ -2,16 +2,15 @@
   <FlowRunGraphPopover
     v-if="selection.position"
     :position="selection.position"
+    @on-close="onClose"
   >
-    <div class="flow-run-graph-artifacts-popover">
-      <h4 class="flow-run-graph-artifacts-popover__label">
-        Artifacts
-      </h4>
-      <div class="flow-run-graph-artifacts-popover__content">
-        <template v-for="artifactId in selection.ids" :key="artifactId">
-          <FlowRunGraphArtifactCard :artifact-id="artifactId" />
-        </template>
-      </div>
+    <h4 class="flow-run-graph-artifacts-popover__label">
+      Artifacts
+    </h4>
+    <div class="flow-run-graph-artifacts-popover__content">
+      <template v-for="artifactId in selection.ids" :key="artifactId">
+        <FlowRunGraphArtifactCard :artifact-id="artifactId" />
+      </template>
     </div>
   </FlowRunGraphPopover>
 </template>
@@ -23,14 +22,17 @@
   defineProps<{
     selection: ArtifactsSelection,
   }>()
+
+  const emit = defineEmits<{
+    'update:selection': [null],
+  }>()
+
+  const onClose = (): void => {
+    emit('update:selection', null)
+  }
 </script>
 
 <style>
-.flow-run-graph-artifacts-popover { @apply
-  max-h-80
-  overflow-auto
-}
-
 .flow-run-graph-artifacts-popover__label { @apply
   w-full
   text-xs

--- a/src/components/FlowRunGraphPopover.vue
+++ b/src/components/FlowRunGraphPopover.vue
@@ -4,6 +4,7 @@
     auto-close
     :placement="placement"
     :style="invisibleTargetStyles"
+    @open="checkOpenState"
   >
     <div class="flow-run-graph-popover">
       <slot />
@@ -18,6 +19,10 @@
 
   const props = defineProps<{
     position: GraphSelectionPosition,
+  }>()
+
+  const emit = defineEmits<{
+    'onClose': [null],
   }>()
 
   const popOver = ref<InstanceType<typeof PPopOver>>()
@@ -38,6 +43,14 @@
       popOver.value?.open()
     }, 0)
   })
+
+  const checkOpenState = (): void => {
+    if (popOver.value?.visible) {
+      return
+    }
+
+    emit('onClose', null)
+  }
 </script>
 
 <style>
@@ -47,5 +60,7 @@
   p-3
   m-1
   shadow-lg
+  max-h-80
+  overflow-auto
 }
 </style>

--- a/src/components/FlowRunGraphStatePopover.vue
+++ b/src/components/FlowRunGraphStatePopover.vue
@@ -1,0 +1,53 @@
+<template>
+  <FlowRunGraphPopover
+    v-if="selection.position"
+    :position="selection.position"
+    @on-close="onClose"
+  >
+    <div class="flow-run-graph-state-popover">
+      <p-key-value label="State">
+        <template #value>
+          {{ selection.name }}
+        </template>
+      </p-key-value>
+      <p-key-value label="Occurred">
+        <template #value>
+          {{ formatDateTimeNumeric(selection.timestamp) }}
+        </template>
+      </p-key-value>
+    </div>
+  </FlowRunGraphPopover>
+</template>
+
+<script lang="ts" setup>
+  import { StateSelection } from '@prefecthq/graphs'
+  import { FlowRunGraphPopover } from '@/components'
+  import { formatDateTimeNumeric } from '@/utilities'
+
+  defineProps<{
+    selection: StateSelection,
+  }>()
+
+  const emit = defineEmits<{
+    'update:selection': [null],
+  }>()
+
+  const onClose = (): void => {
+    emit('update:selection', null)
+  }
+</script>
+
+<style>
+.flow-run-graph-state-popover { @apply
+  flex
+  flex-col
+  gap-2
+}
+
+.flow-run-graph-artifacts-popover__label { @apply
+  w-full
+  text-xs
+  text-subdued
+  mb-1
+}
+</style>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -116,6 +116,7 @@ export { default as FlowRunGraphArtifactDrawer } from './FlowRunGraphArtifactDra
 export { default as FlowRunGraphArtifactsPopover } from './FlowRunGraphArtifactsPopover.vue'
 export { default as FlowRunGraphConfirmation } from '@/components/FlowRunGraphConfirmation.vue'
 export { default as FlowRunGraphPopover } from './FlowRunGraphPopover.vue'
+export { default as FlowRunGraphStatePopover } from './FlowRunGraphStatePopover.vue'
 export { default as FlowRunGraphSelectionPanel } from './FlowRunGraphSelectionPanel.vue'
 export { default as FlowRunHistoryCard } from './FlowRunHistoryCard.vue'
 export { default as FlowRunIconText } from './FlowRunIconText.vue'

--- a/src/maps/index.ts
+++ b/src/maps/index.ts
@@ -41,7 +41,7 @@ import { mapNotificationCreateToNotificationCreateRequest } from '@/maps/notific
 import { mapNotificationUpdateToNotificationUpdateRequest } from '@/maps/notificationUpdate'
 import { mapNumberToString, mapStringToNumber } from '@/maps/number'
 import { mapOrchestrationResultResponseToOrchestrationResult } from '@/maps/orchestrationResult'
-import { mapRunGraphDataResponse, mapRunGraphNodeResponse, mapRunGraphArtifactResponse } from '@/maps/runGraphData'
+import { mapRunGraphDataResponse, mapRunGraphNodeResponse, mapRunGraphArtifactResponse, mapRunGraphStateResponse } from '@/maps/runGraphData'
 import { mapSavedSearchResponseToSavedSearch, mapSavedSearchToLocationQuery } from '@/maps/savedSearch'
 import { mapSavedSearchCreateToSavedSearchCreateRequest } from '@/maps/savedSearchCreate'
 import { mapSavedSearchFilterToFlowRunsFilter } from '@/maps/savedSearchFilter'
@@ -143,6 +143,7 @@ export const maps = {
   RunGraphDataResponse: { RunGraphData: mapRunGraphDataResponse },
   RunGraphNodeResponse: { RunGraphNode: mapRunGraphNodeResponse },
   RunGraphArtifactResponse: { RunGraphArtifact: mapRunGraphArtifactResponse },
+  RunGraphStateResponse: { RunGraphStateEvent: mapRunGraphStateResponse },
   RunHistory: { FlowRunHistoryResponse: mapRunHistoryToFlowRunHistoryResponse, DivergingBarChartItem: mapRunHistoryToDivergingBarChartItem },
   SavedSearchCreate: { SavedSearchCreateRequest: mapSavedSearchCreateToSavedSearchCreateRequest },
   SavedSearchesFilter: { SavedSearchesFilterRequest: mapSavedSearchesFilter },

--- a/src/maps/runGraphData.ts
+++ b/src/maps/runGraphData.ts
@@ -1,5 +1,5 @@
-import { RunGraphData, RunGraphNode, RunGraphArtifact } from '@prefecthq/graphs'
-import { RunGraphDataResponse, RunGraphNodeResponse, RunGraphArtifactResponse } from '@/models/api/RunGraphDataResponse'
+import { RunGraphData, RunGraphNode, RunGraphArtifact, RunGraphStateEvent, StateType } from '@prefecthq/graphs'
+import { RunGraphDataResponse, RunGraphNodeResponse, RunGraphArtifactResponse, RunGraphStateResponse } from '@/models/api/RunGraphDataResponse'
 import { MapFunction } from '@/services/Mapper'
 import { isKnownArtifactType } from '@/types/artifact'
 
@@ -31,6 +31,15 @@ export const mapRunGraphArtifactResponse: MapFunction<RunGraphArtifactResponse, 
   }
 }
 
+export const mapRunGraphStateResponse: MapFunction<RunGraphStateResponse, RunGraphStateEvent> = function(source) {
+  return {
+    id: source.id,
+    timestamp: this.map('string', source.timestamp, 'Date'),
+    type: source.type as StateType,
+    name: source.name,
+  }
+}
+
 export const mapRunGraphDataResponse: MapFunction<RunGraphDataResponse, RunGraphData> = function(source) {
   const nodes: [string, RunGraphNode][] = source.nodes.map(([nodeId, node]) => [
     nodeId,
@@ -41,11 +50,16 @@ export const mapRunGraphDataResponse: MapFunction<RunGraphDataResponse, RunGraph
     return this.map('RunGraphArtifactResponse', artifact, 'RunGraphArtifact')
   }) ?? []
 
+  const states: RunGraphStateEvent[] = source.states?.map(state => {
+    return this.map('RunGraphStateResponse', state, 'RunGraphStateEvent')
+  }) ?? []
+
   return {
     root_node_ids: source.root_node_ids,
     start_time: this.map('string', source.start_time, 'Date'),
     end_time: this.map('string', source.end_time, 'Date'),
     nodes: new Map(nodes),
     artifacts,
+    states,
   }
 }

--- a/src/maps/runGraphData.ts
+++ b/src/maps/runGraphData.ts
@@ -1,4 +1,4 @@
-import { RunGraphData, RunGraphNode, RunGraphArtifact, RunGraphStateEvent, StateType } from '@prefecthq/graphs'
+import { RunGraphData, RunGraphNode, RunGraphArtifact, RunGraphStateEvent } from '@prefecthq/graphs'
 import { RunGraphDataResponse, RunGraphNodeResponse, RunGraphArtifactResponse, RunGraphStateResponse } from '@/models/api/RunGraphDataResponse'
 import { MapFunction } from '@/services/Mapper'
 import { isKnownArtifactType } from '@/types/artifact'
@@ -35,7 +35,7 @@ export const mapRunGraphStateResponse: MapFunction<RunGraphStateResponse, RunGra
   return {
     id: source.id,
     timestamp: this.map('string', source.timestamp, 'Date'),
-    type: source.type as StateType,
+    type: source.type,
     name: source.name,
   }
 }

--- a/src/models/api/RunGraphDataResponse.ts
+++ b/src/models/api/RunGraphDataResponse.ts
@@ -7,6 +7,7 @@ export type RunGraphDataResponse = {
   root_node_ids: string[],
   nodes: [string, RunGraphNodeResponse][],
   artifacts?: RunGraphArtifactResponse[],
+  states?: RunGraphStateResponse[],
 }
 
 export type RunGraphNodeResponse = {
@@ -28,4 +29,11 @@ export type RunGraphArtifactResponse = {
   created: string,
   key: string,
   type: string,
+}
+
+export type RunGraphStateResponse = {
+  id: string,
+  timestamp: string,
+  type: string,
+  name: string,
 }

--- a/src/models/api/RunGraphDataResponse.ts
+++ b/src/models/api/RunGraphDataResponse.ts
@@ -1,4 +1,4 @@
-import { RunGraphEdge, RunGraphNodeKind } from '@prefecthq/graphs'
+import { RunGraphEdge, RunGraphNodeKind, StateType } from '@prefecthq/graphs'
 import { ServerStateType } from '@/models/StateType'
 
 export type RunGraphDataResponse = {
@@ -34,6 +34,6 @@ export type RunGraphArtifactResponse = {
 export type RunGraphStateResponse = {
   id: string,
   timestamp: string,
-  type: string,
+  type: StateType,
   name: string,
 }


### PR DESCRIPTION
Adds the root flow run graph states layer. This is feature flagged from the API level. The flag is on for staging and off for prod. State events are opt in so the graph will be fine.

What isn't feature flagged is the empty state. So this will go out, I don't think it's worth feature flagging. If no state is added, it will appear like this on a graph with no nodes:
<img width="1250" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/29c3521d-c747-45d5-9ad0-2aaf59948c0d">


Also updates the selection popover to emit when the popover has been dismissed. This way when dismissing the popover by clicking somewhere outside of the graph, the selection is still cleared. One UX nit I'm still facing is when selecting another of the same type (e.g. a state bar is selected and I immediately click another state bar), it clears the selection rather than selecting the next thing I clicked on. This is still an improvement for now and I'll work out how to check for that down the line.

https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/edb3dd5b-66d7-41f9-b466-7ba528a745a6

