### PR TITLE
Schemas: Fix root level errors now showing up for array items

### DIFF
--- a/src/schemas/components/SchemaFormPropertyArrayItem.vue
+++ b/src/schemas/components/SchemaFormPropertyArrayItem.vue
@@ -1,20 +1,25 @@
 <template>
-  <div class="schema-form-property-array-item">
-    <PIcon icon="DragHandle" class="schema-form-property-array-item__handle" @mousedown="emit('handleDown')" @mouseup="emit('handleUp')" />
+  <p-content class="schema-form-property-array-item" secondary>
+    <div class="schema-form-property-array-item__control">
+      <PIcon icon="DragHandle" class="schema-form-property-array-item__handle" @mousedown="emit('handleDown')" @mouseup="emit('handleUp')" />
 
-    <component :is="input.component" v-bind="input.props" />
+      <component :is="input.component" v-bind="input.props" />
 
-    <SchemaFormPropertyMenu v-model:kind="kind" :property="property">
-      <template v-if="!isFirst">
-        <p-overflow-menu-item icon="ArrowSmallUpIcon" label="Move to top" @click="emit('moveToTop')" />
-      </template>
-      <template v-if="!isLast">
-        <p-overflow-menu-item icon="ArrowSmallDownIcon" label="Move to bottom" @click="emit('moveToBottom')" />
-      </template>
+      <SchemaFormPropertyMenu v-model:kind="kind" :property="property">
+        <template v-if="!isFirst">
+          <p-overflow-menu-item icon="ArrowSmallUpIcon" label="Move to top" @click="emit('moveToTop')" />
+        </template>
+        <template v-if="!isLast">
+          <p-overflow-menu-item icon="ArrowSmallDownIcon" label="Move to bottom" @click="emit('moveToBottom')" />
+        </template>
 
-      <p-overflow-menu-item icon="TrashIcon" label="Delete" @click="emit('deleteItem')" />
-    </SchemaFormPropertyMenu>
-  </div>
+        <p-overflow-menu-item icon="TrashIcon" label="Delete" @click="emit('deleteItem')" />
+      </SchemaFormPropertyMenu>
+    </div>
+    <p v-if="errorMessage" class="schema-form-property-array-item__error">
+      {{ errorMessage }}
+    </p>
+  </p-content>
 </template>
 
 <script lang="ts" setup>
@@ -25,6 +30,7 @@
   import { SchemaProperty } from '@/schemas/types/schema'
   import { SchemaValue } from '@/schemas/types/schemaValues'
   import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
+  import { getAllRootSchemaPropertyErrors, getSchemaPropertyError } from '@/schemas/utilities/errors'
 
   const props = defineProps<{
     property: SchemaProperty,
@@ -54,14 +60,27 @@
 
   const { input } = useSchemaPropertyInput(() => props.property, value, () => props.errors)
   const { kind } = usePrefectKind(value)
+  const errorMessage = computed(() => {
+    const errors = getAllRootSchemaPropertyErrors(props.errors)
+
+    const { message } = getSchemaPropertyError(errors)
+
+    return message
+  })
 </script>
 
 <style>
-.schema-form-property-array-item { @apply
+.schema-form-property-array-item__control { @apply
   grid
   gap-2
   items-start;
   grid-template-columns: min-content 1fr min-content;
+}
+
+.schema-form-property-array-item__error { @apply
+  text-sm
+  text-invalid;
+  margin-left: var(--schema-form-property-array-item-indent);
 }
 
 .schema-form-property-array-item__handle { @apply

--- a/src/schemas/components/SchemaFormPropertyKindJson.vue
+++ b/src/schemas/components/SchemaFormPropertyKindJson.vue
@@ -1,7 +1,7 @@
 <template>
   <p-content secondary class="schema-form-property-kind-json">
     <p-code-input v-model="value" lang="json" :state="state" show-line-numbers />
-    <SchemaFormPropertyErrors :errors="errors" />
+    <SchemaFormPropertyErrors :errors="childErrors" />
   </p-content>
 </template>
 
@@ -43,5 +43,5 @@
     },
   })
 
-  const errors = computed(() => getAllChildSchemaPropertyErrors(props.errors))
+  const childErrors = computed(() => getAllChildSchemaPropertyErrors(props.errors))
 </script>

--- a/src/schemas/utilities/errors.ts
+++ b/src/schemas/utilities/errors.ts
@@ -19,7 +19,7 @@ export function getSchemaPropertyError(errors: SchemaValueError[]): SchemaProper
   const propertyErrors = errors.filter(isString)
   const state: State = { pending: false, valid: true, validated: true }
 
-  if (errors.length) {
+  if (propertyErrors.length) {
     state.valid = false
     return {
       state,
@@ -34,10 +34,14 @@ export function getSchemaPropertyError(errors: SchemaValueError[]): SchemaProper
 }
 
 export function getAllSchemaPropertyErrors(errors: SchemaValueError[]): SchemaValueError[] {
-  const propertyErrors = errors.filter(isString)
+  const propertyErrors = getAllRootSchemaPropertyErrors(errors)
   const childErrors = getAllChildSchemaPropertyErrors(errors)
 
   return [...propertyErrors, ...childErrors]
+}
+
+export function getAllRootSchemaPropertyErrors(errors: SchemaValueError[]): SchemaValueError[] {
+  return errors.filter(isString)
 }
 
 export function getAllChildSchemaPropertyErrors(errors: SchemaValueError[]): SchemaValueError[] {


### PR DESCRIPTION
# Description
Fixes a bug where on individual list items errors that applied to the item itself were not displayed. This was because there was no p-label or error message ui at the item level itself. 

The "True is not of type 'integer'" error was previously hidden to the user even though the form failed validation. 

<img width="747" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/6af15a5b-d661-49cb-8220-037ab56d2574">
