### PR TITLE
Remove usages of enhanced scheduling UI flag

### DIFF
--- a/src/components/DeploymentToggle.vue
+++ b/src/components/DeploymentToggle.vue
@@ -40,13 +40,7 @@
     const message = value ? localization.success.activateDeployment : localization.success.pauseDeployment
 
     try {
-      if (can.access.enhancedSchedulingUi) {
-        await api.deployments.updateDeployment(props.deployment.id, { paused: !value })
-      } else if (value) {
-        await api.deployments.resumeDeployment(props.deployment.id)
-      } else {
-        await api.deployments.pauseDeployment(props.deployment.id)
-      }
+      await api.deployments.updateDeployment(props.deployment.id, { paused: !value })
 
       showToast(message, 'success')
       emit('update')

--- a/src/components/DeploymentToggle.vue
+++ b/src/components/DeploymentToggle.vue
@@ -7,12 +7,10 @@
 <script lang="ts" setup>
   import { showToast } from '@prefecthq/prefect-design'
   import { computed, ref } from 'vue'
-  import { useCan, useWorkspaceApi } from '@/compositions'
+  import { useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { Deployment } from '@/models'
   import { getApiErrorMessage } from '@/utilities/errors'
-
-  const can = useCan()
 
   const props = defineProps<{
     deployment: Deployment,

--- a/src/components/ScheduleFormModal.vue
+++ b/src/components/ScheduleFormModal.vue
@@ -34,7 +34,7 @@
   import { computed, ref, watch } from 'vue'
   import CronScheduleForm from '@/components/CronScheduleForm.vue'
   import IntervalScheduleForm from '@/components/IntervalScheduleForm.vue'
-  import { useCan, useShowModal } from '@/compositions'
+  import { useShowModal } from '@/compositions'
   import { DeploymentScheduleCompatible, getScheduleType, Schedule, ScheduleType, isCronSchedule, isIntervalSchedule, CronSchedule, IntervalSchedule } from '@/models'
 
   const { showModal, open, close } = useShowModal()
@@ -44,8 +44,6 @@
   }
 
   defineExpose({ publicOpen })
-
-  const can = useCan()
 
   const props = defineProps<DeploymentScheduleCompatible>()
 

--- a/src/components/ScheduleFormModal.vue
+++ b/src/components/ScheduleFormModal.vue
@@ -5,9 +5,7 @@
       <p-button-group v-model="scheduleForm" :options="scheduleFormOptions" small />
     </p-label>
 
-    <p-label v-if="can.access.enhancedSchedulingUi" label="Active">
-      <p-toggle v-model="internalActive" />
-    </p-label>
+    <p-toggle v-model="internalActive" />
 
     <template v-if="scheduleForm == 'rrule'">
       <p>


### PR DESCRIPTION
This removes usages of the `enhancedSchedulingUi` flag, I'll follow up afterwards with a PR to remove the flag itself.

Related to https://github.com/PrefectHQ/nebula/issues/7115