### PR TITLE
Schemas: Move validate parameters checkbox

### DIFF
--- a/src/components/FlowRunCreateFormV2.vue
+++ b/src/components/FlowRunCreateFormV2.vue
@@ -18,6 +18,8 @@
           </div>
 
           <SchemaInputV2 v-model:values="parameters" :schema="schema" :errors="errors" :kinds="['json', 'workspace_variable']" />
+
+          <p-checkbox v-model="shouldValidate" label="Validate parameters before submitting" />
         </p-content>
       </template>
 
@@ -61,8 +63,6 @@
         </template>
       </p-accordion>
     </p-content>
-
-    <p-checkbox v-model="shouldValidate" label="Validate parameters before submitting" />
 
     <template #footer>
       <p-button @click="emit('cancel')">


### PR DESCRIPTION
# Description
The checkbox was at the bottom of the form which is disconnected with the actual parameters. Also, it would show up even if there were no parameters. Moving it up into the parameters section makes more sense and is consistent with how the quick run modal orders things. 