### PR TITLE
Schemas: Make sure boolean properties default to false

### DIFF
--- a/src/schemas/components/SchemaFormPropertyBoolean.vue
+++ b/src/schemas/components/SchemaFormPropertyBoolean.vue
@@ -1,0 +1,27 @@
+<template>
+  <p-toggle v-model="value" :state="state" />
+</template>
+
+<script lang="ts" setup>
+  import { State, isDefined } from '@prefecthq/prefect-design'
+  import { SchemaProperty } from '@/schemas/types/schema'
+
+  defineProps<{
+    // eslint-disable-next-line vue/no-unused-properties
+    property: SchemaProperty & { type: 'boolean' },
+    state: State,
+  }>()
+
+  const value = defineModel<boolean | undefined>({ default: undefined })
+
+  if (!isDefined(value.value)) {
+    value.value = false
+  }
+</script>
+
+<style>
+.schema-form-property-null { @apply
+  text-subdued
+  text-sm
+}
+</style>

--- a/src/schemas/components/SchemaFormPropertyBoolean.vue
+++ b/src/schemas/components/SchemaFormPropertyBoolean.vue
@@ -18,10 +18,3 @@
     value.value = false
   }
 </script>
-
-<style>
-.schema-form-property-null { @apply
-  text-subdued
-  text-sm
-}
-</style>

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -3,10 +3,11 @@
 </template>
 
 <script lang="ts" setup>
-  import { PNumberInput, PToggle, State } from '@prefecthq/prefect-design'
+  import { PNumberInput, State } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import SchemaFormPropertyArray from '@/schemas/components/SchemaFormPropertyArray.vue'
   import SchemaFormPropertyBlockDocument from '@/schemas/components/SchemaFormPropertyBlockDocument.vue'
+  import SchemaFormPropertyBoolean from '@/schemas/components/SchemaFormPropertyBoolean.vue'
   import SchemaFormPropertyInteger from '@/schemas/components/SchemaFormPropertyInteger.vue'
   import SchemaFormPropertyNull from '@/schemas/components/SchemaFormPropertyNull.vue'
   import SchemaFormPropertyObject from '@/schemas/components/SchemaFormPropertyObject.vue'
@@ -46,8 +47,9 @@
     }
 
     if (isSchemaPropertyType(type, 'boolean')) {
-      return withProps(PToggle, {
-        modelValue: asType(value, Boolean),
+      return withProps(SchemaFormPropertyBoolean, {
+        property: { ...property.value, type },
+        value: asType(value, Boolean),
         state: props.state,
         'onUpdate:modelValue': (value) => emit('update:value', asType(value, Boolean)),
       })


### PR DESCRIPTION
# Description
Make sure that when a boolean property mounts if the value is undefined it automatically sets it to false. Otherwise the value (`undefined`) will be omitted from the validation and flow run create causing validation errors and runtime errors. 