### PR TITLE
Enhancement: Graph empty state message

### DIFF
--- a/src/components/FlowRunGraph.vue
+++ b/src/components/FlowRunGraph.vue
@@ -9,7 +9,7 @@
         class="flow-run-graph__graph p-background"
       />
       <p v-if="!hasGraphNodes" class="flow-run-graph__no-nodes-message">
-        No tasks or sub flows were called
+        {{ emptyMessage }}
       </p>
     </template>
     <template v-else>
@@ -26,7 +26,7 @@
   import { useTaskRunsCount } from '@/compositions/useTaskRunsCount'
   import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
   import { FlowRun } from '@/models/FlowRun'
-  import { ServerStateType } from '@/models/StateType'
+  import { ServerStateType, isTerminalStateType } from '@/models/StateType'
 
   const NODE_COUNT_TO_REQUIRED_OPT_IN = 2000
 
@@ -75,6 +75,15 @@
       emit('update:selected', value)
     },
   })
+
+  const emptyMessage = computed(() => {
+    if (isTerminalStateType(props.flowRun.state?.type)) {
+      return 'This flow run did not generate any task or flow runs'
+    }
+
+    return 'This flow run has not yet generated any task or flow runs'
+  })
+
 
   // these will be replaced with brandon's styles
   const stateTypeColors = {


### PR DESCRIPTION
This PR updates the flow run graph component to better account for terminal and non-terminal states. 

Before (regardless of state):
![Screenshot 2024-03-06 at 3 38 56 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/f8a1a486-95a7-4cb7-b028-637e8437b1cc)

After (non-terminal):
![Screenshot 2024-03-06 at 4 28 28 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/5fbff16c-cbc1-4d5f-8962-fefba50cc658)


After (terminal):
![Screenshot 2024-03-06 at 4 29 09 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/65deeaed-37a3-4f77-9f7d-8a76cabead16)


As flow run and task run lines become blurrier we might trim this language a bit but for now I think this is at least correct
