### PR TITLE
Bugfix: clear run graph empty message

### DIFF
--- a/src/components/FlowRunGraph.vue
+++ b/src/components/FlowRunGraph.vue
@@ -137,7 +137,7 @@
     },
   }), taskRunCountOptions)
 
-  const hasGraphNodes = computed(() => count.value! > 0)
+  const hasGraphNodes = computed(() => count.value && count.value > 0)
 
   await subscription.promise()
 

--- a/src/components/FlowRunGraph.vue
+++ b/src/components/FlowRunGraph.vue
@@ -47,7 +47,6 @@
   const api = useWorkspaceApi()
   const { value: colorThemeValue } = useColorTheme()
   const load = ref(true)
-  const hasGraphNodes = ref(true)
 
   const viewport = computed({
     get() {
@@ -126,6 +125,9 @@
     },
   }))
 
+  const taskRunCountOptions = computed(() => ({
+    interval: isTerminalStateType(props.flowRun.state?.type) ? undefined : 1000,
+  }))
   const { count, subscription } = useTaskRunsCount(() => ({
     flowRuns: {
       id: [props.flowRun.id],
@@ -133,15 +135,15 @@
     taskRuns: {
       subFlowRunsExist: undefined,
     },
-  }))
+  }), taskRunCountOptions)
+
+  const hasGraphNodes = computed(() => count.value! > 0)
 
   await subscription.promise()
 
   if (count.value! > NODE_COUNT_TO_REQUIRED_OPT_IN) {
     load.value = false
   }
-
-  hasGraphNodes.value = count.value! > 0
 
   const classes = computed(() => ({
     root: {

--- a/src/compositions/useTaskRunsCount.ts
+++ b/src/compositions/useTaskRunsCount.ts
@@ -4,12 +4,13 @@ import { computed, MaybeRefOrGetter, toRef, toValue } from 'vue'
 import { useCan, useWorkspaceApi } from '@/compositions'
 import { TaskRunsFilter } from '@/models/Filters'
 import { WorkspaceTaskRunsApi } from '@/services/WorkspaceTaskRunsApi'
+import { MaybeRef } from '@/types'
 import { Getter } from '@/types/reactivity'
 import { UseEntitySubscription } from '@/types/useEntitySubscription'
 
 export type UseTaskRunsCount = UseEntitySubscription<WorkspaceTaskRunsApi['getTaskRunsCount'], 'count'>
 
-export function useTaskRunsCount(filter: MaybeRefOrGetter<TaskRunsFilter | null | undefined>, options?: SubscriptionOptions): UseTaskRunsCount {
+export function useTaskRunsCount(filter: MaybeRefOrGetter<TaskRunsFilter | null | undefined>, options?: MaybeRef<SubscriptionOptions>): UseTaskRunsCount {
   const api = useWorkspaceApi()
   const can = useCan()
 


### PR DESCRIPTION
When a graph was loading with no nodes, the empty message would show, but for non-terminal runs it would persist when nodes did start rendering. This makes it so that message is cleared if the task count updates to more than zero.


https://github.com/PrefectHQ/prefect-ui-library/assets/6776415/c7953408-5903-4ea7-99f5-96557074d577

