### PR TITLE
Schemas: Fix boolean properties always defaulting to false

### DIFF
--- a/src/schemas/components/SchemaFormPropertyBoolean.vue
+++ b/src/schemas/components/SchemaFormPropertyBoolean.vue
@@ -15,8 +15,6 @@
   const value = defineModel<boolean | undefined>({ default: undefined })
 
   if (!isDefined(value.value)) {
-    const valueOrDefaultValue = isDefined(value.value) ? value.value : asType(props.property.default, Boolean)
-
-    value.value = valueOrDefaultValue
+    value.value = asType(props.property.default, Boolean) ?? false
   }
 </script>

--- a/src/schemas/components/SchemaFormPropertyBoolean.vue
+++ b/src/schemas/components/SchemaFormPropertyBoolean.vue
@@ -5,9 +5,9 @@
 <script lang="ts" setup>
   import { State, isDefined } from '@prefecthq/prefect-design'
   import { SchemaProperty } from '@/schemas/types/schema'
+  import { asType } from '@/utilities/types'
 
-  defineProps<{
-    // eslint-disable-next-line vue/no-unused-properties
+  const props = defineProps<{
     property: SchemaProperty & { type: 'boolean' },
     state: State,
   }>()
@@ -15,6 +15,8 @@
   const value = defineModel<boolean | undefined>({ default: undefined })
 
   if (!isDefined(value.value)) {
-    value.value = false
+    const valueOrDefaultValue = isDefined(value.value) ? value.value : asType(props.property.default, Boolean)
+
+    value.value = valueOrDefaultValue
   }
 </script>


### PR DESCRIPTION
# Description
Fixes a bug introduced in https://github.com/PrefectHQ/prefect-ui-library/pull/2171 which made all boolean properties default to `false` even if the property had a default value of `true`. Fixed by making sure the default value is used if one exists, then falling back to `false`. 

Closes https://github.com/PrefectHQ/prefect/issues/12198