### PR TITLE
[Flow run infra overrides] Make flow run job vars available for reading

### DIFF
--- a/src/maps/flowRun.ts
+++ b/src/maps/flowRun.ts
@@ -36,6 +36,6 @@ export const mapFlowRunResponseToFlowRun: MapFunction<FlowRunResponse, FlowRun> 
     workQueueName: source.work_queue_name,
     workPoolName: source.work_pool_name,
     workPoolQueueName: source.work_pool_queue_name,
-    jobVariables: source.job_variables,
+    jobVariables: source.job_variables ?? {},
   })
 }

--- a/src/maps/flowRun.ts
+++ b/src/maps/flowRun.ts
@@ -36,5 +36,6 @@ export const mapFlowRunResponseToFlowRun: MapFunction<FlowRunResponse, FlowRun> 
     workQueueName: source.work_queue_name,
     workPoolName: source.work_pool_name,
     workPoolQueueName: source.work_pool_queue_name,
+    jobVariables: source.job_variables,
   })
 }

--- a/src/mocks/flowRun.ts
+++ b/src/mocks/flowRun.ts
@@ -37,6 +37,7 @@ export const randomFlowRun: MockFunction<FlowRun, [Partial<FlowRun>?]> = functio
     workQueueName: random() > 0.7 ? this.create('noun') : null,
     workPoolName: random() > 0.7 ? this.create('noun') : null,
     workPoolQueueName: random() > 0.7 ? this.create('noun') : null,
+    jobVariables: {},
     ...overrides,
   })
 }

--- a/src/models/FlowRun.ts
+++ b/src/models/FlowRun.ts
@@ -39,6 +39,7 @@ export interface IFlowRun {
   workQueueName: string | null,
   workPoolName: string | null,
   workPoolQueueName: string | null,
+  jobVariables: Record<string, unknown> | null,
 }
 
 export class FlowRun extends StorageItem implements IFlowRun {
@@ -73,6 +74,7 @@ export class FlowRun extends StorageItem implements IFlowRun {
   public updated: Date
   public workPoolName: string | null
   public workPoolQueueName: string | null
+  public jobVariables: Record<string, unknown> | null
 
   public constructor(flowRun: IFlowRun) {
     super()
@@ -108,6 +110,7 @@ export class FlowRun extends StorageItem implements IFlowRun {
     this.workQueueName = flowRun.workQueueName
     this.workPoolName = flowRun.workPoolName
     this.workPoolQueueName = flowRun.workPoolQueueName
+    this.jobVariables = flowRun.jobVariables
   }
 
   public get duration(): number {

--- a/src/models/FlowRun.ts
+++ b/src/models/FlowRun.ts
@@ -39,7 +39,7 @@ export interface IFlowRun {
   workQueueName: string | null,
   workPoolName: string | null,
   workPoolQueueName: string | null,
-  jobVariables: Record<string, unknown> | null,
+  jobVariables: Record<string, unknown>,
 }
 
 export class FlowRun extends StorageItem implements IFlowRun {
@@ -74,7 +74,7 @@ export class FlowRun extends StorageItem implements IFlowRun {
   public updated: Date
   public workPoolName: string | null
   public workPoolQueueName: string | null
-  public jobVariables: Record<string, unknown> | null
+  public jobVariables: Record<string, unknown>
 
   public constructor(flowRun: IFlowRun) {
     super()

--- a/src/models/api/FlowRunResponse.ts
+++ b/src/models/api/FlowRunResponse.ts
@@ -38,5 +38,5 @@ export type FlowRunResponse = {
   work_queue_name: string | null,
   work_pool_name: string | null,
   work_pool_queue_name: string | null,
-  job_variables: Record<string, unknown> | null,
+  job_variables?: Record<string, unknown> | null,
 }

--- a/src/models/api/FlowRunResponse.ts
+++ b/src/models/api/FlowRunResponse.ts
@@ -38,5 +38,6 @@ export type FlowRunResponse = {
   work_queue_name: string | null,
   work_pool_name: string | null,
   work_pool_queue_name: string | null,
+  // TODO: Remove optionality when api changes are fully merged
   job_variables?: Record<string, unknown> | null,
 }

--- a/src/models/api/FlowRunResponse.ts
+++ b/src/models/api/FlowRunResponse.ts
@@ -38,4 +38,5 @@ export type FlowRunResponse = {
   work_queue_name: string | null,
   work_pool_name: string | null,
   work_pool_queue_name: string | null,
+  job_variables: Record<string, unknown> | null,
 }


### PR DESCRIPTION
PR exposes new `job_variables` field on flow run responses. 