### PR TITLE
CHore: Add new mappers and route for task run counts by state

### DIFF
--- a/src/maps/index.ts
+++ b/src/maps/index.ts
@@ -59,6 +59,7 @@ import { mapTaskInputToTaskInputResponse, mapTaskInputResponseToTaskInput } from
 import { mapTaskRunToTaskRunResponse, mapTaskRunResponseToTaskRun } from '@/maps/taskRun'
 import { mapTaskRunHistoryResponseToTaskRunHistory, mapTaskRunHistoryStateResponseToTaskRunHistoryState, mapTaskRunsFilterToTaskRunsHistoryFilter } from '@/maps/taskRunHistory'
 import { mapUiFlowRunHistoryResponseToUiFlowRunHistory } from '@/maps/uiFlowRunHistory'
+import { mapUiTaskRunCountsByStateResponseToUiTaskRunCountsByState } from '@/maps/uiTaskRunCountsByState'
 import { mapVariableResponseToVariable, mapVariableEditToVariableEditRequest, mapVariableCreateToVariableCreateRequest } from '@/maps/variable'
 import { mapPrefectWorkerCollectionResponseToWorkerCollectionItemArray, mapWorkerSchemaValuesToWorkerSchemaValuesRequest } from '@/maps/workerCollection'
 import { mapWorkerScheduledFlowRunResponseToWorkerScheduledFlowRun, mapWorkerScheduledFlowRunsToWorkerScheduledFlowRunsRequest } from '@/maps/workerScheduledFlowRun'
@@ -189,6 +190,7 @@ export const maps = {
   TaskRunsHistoryFilter: { TaskRunsHistoryFilterRequest: mapTaskRunsHistoryFilter },
   UiFlowRunHistory: { ScatterPlotItem: mapUiFlowRunHistoryToScatterPlotItem },
   UiFlowRunHistoryResponse: { UiFlowRunHistory: mapUiFlowRunHistoryResponseToUiFlowRunHistory },
+  UiTaskRunCountsByStateResponse: { UiTaskRunCountsByState: mapUiTaskRunCountsByStateResponseToUiTaskRunCountsByState },
   VariableCreate: { VariableCreateRequest: mapVariableCreateToVariableCreateRequest },
   VariableEdit: { VariableEditRequest: mapVariableEditToVariableEditRequest },
   VariableFilter: { VariableFilterRequest: mapVariableFilter },

--- a/src/maps/uiTaskRunCountsByState.ts
+++ b/src/maps/uiTaskRunCountsByState.ts
@@ -1,0 +1,14 @@
+
+import { UiTaskRunCountsByStateResponse } from '@/models/api/UiTaskRunCountsByStateResponse'
+import { ServerStateType, isStateType } from '@/models/StateType'
+import { UiTaskRunCountsByState } from '@/models/UiTaskRunCountsByState'
+import { MapFunction, mapper } from '@/services/Mapper'
+
+export const mapUiTaskRunCountsByStateResponseToUiTaskRunCountsByState: MapFunction<UiTaskRunCountsByStateResponse, UiTaskRunCountsByState> = function(source) {
+  return Object.entries(source).reduce <UiTaskRunCountsByState>((acc, [key, value]) => {
+    if (isStateType(key)) {
+      acc[mapper.map('ServerStateType', key as ServerStateType, 'StateType')] = value
+    }
+    return acc
+  }, {})
+}

--- a/src/maps/uiTaskRunCountsByState.ts
+++ b/src/maps/uiTaskRunCountsByState.ts
@@ -1,11 +1,11 @@
 import { UiTaskRunCountsByStateResponse } from '@/models/api/UiTaskRunCountsByStateResponse'
-import { ServerStateType, isStateType } from '@/models/StateType'
+import { ServerStateType, isServerStateType } from '@/models/StateType'
 import { UiTaskRunCountsByState } from '@/models/UiTaskRunCountsByState'
 import { MapFunction, mapper } from '@/services/Mapper'
 
 export const mapUiTaskRunCountsByStateResponseToUiTaskRunCountsByState: MapFunction<UiTaskRunCountsByStateResponse, UiTaskRunCountsByState> = function(source) {
   return Object.entries(source).reduce <UiTaskRunCountsByState>((acc, [key, value]) => {
-    if (isStateType(key)) {
+    if (isServerStateType(key)) {
       acc[mapper.map('ServerStateType', key as ServerStateType, 'StateType')] = value
     }
     return acc

--- a/src/maps/uiTaskRunCountsByState.ts
+++ b/src/maps/uiTaskRunCountsByState.ts
@@ -1,4 +1,3 @@
-
 import { UiTaskRunCountsByStateResponse } from '@/models/api/UiTaskRunCountsByStateResponse'
 import { ServerStateType, isStateType } from '@/models/StateType'
 import { UiTaskRunCountsByState } from '@/models/UiTaskRunCountsByState'

--- a/src/models/StateType.ts
+++ b/src/models/StateType.ts
@@ -17,6 +17,10 @@ export function isStateType(value: unknown): value is StateType {
   return typeof value === 'string' && stateType.includes(value as StateType)
 }
 
+export function isServerStateType(value: unknown): value is ServerStateType {
+  return typeof value === 'string' && stateType.includes(value.toLowerCase() as StateType)
+}
+
 export const pendingStateType = ['scheduled', 'pending']
 export type PendingStateType = typeof pendingStateType[number]
 

--- a/src/models/UiTaskRunCountsByState.ts
+++ b/src/models/UiTaskRunCountsByState.ts
@@ -1,4 +1,3 @@
-
 import { StateType } from '@/models/StateType'
 
 export type UiTaskRunCountsByState = {

--- a/src/models/UiTaskRunCountsByState.ts
+++ b/src/models/UiTaskRunCountsByState.ts
@@ -1,0 +1,6 @@
+
+import { StateType } from '@/models/StateType'
+
+export type UiTaskRunCountsByState = {
+  [key in StateType]?: number
+}

--- a/src/models/api/UiTaskRunCountsByStateResponse.ts
+++ b/src/models/api/UiTaskRunCountsByStateResponse.ts
@@ -1,4 +1,3 @@
-
 import { ServerStateType } from '@/models/StateType'
 
 export type UiTaskRunCountsByStateResponse = {

--- a/src/models/api/UiTaskRunCountsByStateResponse.ts
+++ b/src/models/api/UiTaskRunCountsByStateResponse.ts
@@ -1,0 +1,6 @@
+
+import { ServerStateType } from '@/models/StateType'
+
+export type UiTaskRunCountsByStateResponse = {
+  [key in ServerStateType]?: number
+}

--- a/src/services/UiApi.ts
+++ b/src/services/UiApi.ts
@@ -1,6 +1,6 @@
 import { UiFlowRunHistoryResponse } from '@/models/api/UiFlowRunHistoryResponse'
 import { UiTaskRunCountsByStateResponse } from '@/models/api/UiTaskRunCountsByStateResponse'
-import { FlowRunsFilter } from '@/models/Filters'
+import { FlowRunsFilter, TaskRunsFilter } from '@/models/Filters'
 import { UiFlowRunHistory } from '@/models/UiFlowRunHistory'
 import { UiTaskRunCountsByState } from '@/models/UiTaskRunCountsByState'
 import { mapper } from '@/services/Mapper'
@@ -20,8 +20,8 @@ export class UiApi extends WorkspaceApi implements IUiApi {
     return mapper.map('UiFlowRunHistoryResponse', data, 'UiFlowRunHistory')
   }
 
-  public async getTaskRunsCountByState(filter: FlowRunsFilter): Promise<UiTaskRunCountsByState> {
-    const request = mapper.map('FlowRunsFilter', filter, 'FlowRunsFilterRequest')
+  public async getTaskRunsCountByState(filter: TaskRunsFilter): Promise<UiTaskRunCountsByState> {
+    const request = mapper.map('TaskRunsFilter', filter, 'TaskRunsFilterRequest')
     const { data } = await this.post<UiTaskRunCountsByStateResponse>('/task_runs/count', request)
 
     return mapper.map('UiTaskRunCountsByStateResponse', data, 'UiTaskRunCountsByState')

--- a/src/services/UiApi.ts
+++ b/src/services/UiApi.ts
@@ -1,6 +1,8 @@
 import { UiFlowRunHistoryResponse } from '@/models/api/UiFlowRunHistoryResponse'
+import { UiTaskRunCountsByStateResponse } from '@/models/api/UiTaskRunCountsByStateResponse'
 import { FlowRunsFilter } from '@/models/Filters'
 import { UiFlowRunHistory } from '@/models/UiFlowRunHistory'
+import { UiTaskRunCountsByState } from '@/models/UiTaskRunCountsByState'
 import { mapper } from '@/services/Mapper'
 import { WorkspaceApi } from '@/services/WorkspaceApi'
 
@@ -18,4 +20,10 @@ export class UiApi extends WorkspaceApi implements IUiApi {
     return mapper.map('UiFlowRunHistoryResponse', data, 'UiFlowRunHistory')
   }
 
+  public async getTaskRunsCountByState(filter: FlowRunsFilter): Promise<UiTaskRunCountsByState> {
+    const request = mapper.map('FlowRunsFilter', filter, 'FlowRunsFilterRequest')
+    const { data } = await this.post<UiTaskRunCountsByStateResponse>('/task_runs/count', request)
+
+    return mapper.map('UiTaskRunCountsByStateResponse', data, 'UiTaskRunCountsByState')
+  }
 }


### PR DESCRIPTION
This PR introduces a new UI-specific API for reading task run counts broken down by state type.
