### PR TITLE
 Enhancement: Allow table artifact cells to render markdown content

### DIFF
--- a/src/components/ArtifactDataTable.vue
+++ b/src/components/ArtifactDataTable.vue
@@ -19,18 +19,30 @@
           <p-markdown-renderer :text="emptyDataText" />
         </p-empty-results>
       </template>
+
+      <template v-for="key in columnKeys" #[kebabCase(key)]="{ row, column }" :key="key">
+        <span class="artifact-data-table__cell">
+          <template v-if="column.property && isString(row[column.property])">
+            <p-markdown-renderer class="artifact-data-table__cell-renderer" :text="row[column.property]" />
+          </template>
+          <template v-else-if="column.property">
+            {{ row[column.property] }}
+          </template>
+        </span>
+      </template>
     </p-table>
   </p-content>
 </template>
 
 <script lang="ts" setup>
-  import { TableData, toPluralString } from '@prefecthq/prefect-design'
+  import { TableData, kebabCase, toPluralString } from '@prefecthq/prefect-design'
   import { useDebouncedRef } from '@prefecthq/vue-compositions'
   import { computed, ref } from 'vue'
   import { SearchInput } from '@/components'
   import { localization } from '@/localization'
   import { TableArtifact } from '@/models'
   import { isTableArtifactData, isArrayOfMaps, isMapOfArrays } from '@/types/artifact'
+  import { isString } from '@/utilities'
   import { parseUnknownJson } from '@/utilities/parseUnknownJson'
 
   const props = defineProps<{
@@ -59,6 +71,14 @@
     }
 
     return []
+  })
+
+  const columnKeys = computed(() => {
+    if (normalizedData.value.length === 0) {
+      return []
+    }
+
+    return Object.keys(normalizedData.value[0])
   })
 
   const search = ref('')
@@ -100,5 +120,10 @@
 
 .artifact-data-table__count { @apply
   font-medium
+}
+
+.artifact-data-table__cell-renderer,
+.artifact-data-table__cell { @apply
+  text-sm
 }
 </style>


### PR DESCRIPTION
This PR updates the artifact data table renderer to allow rendering markdown in table cells.

Before:

![Screenshot 2024-03-08 at 2 05 56 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/26b9ce7f-8739-4ea0-bef9-fe67223430ce)


After:

![Screenshot 2024-03-08 at 2 05 53 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/af8ffd24-bb13-4ada-9c8e-94619350909d)

Resolves: https://github.com/PrefectHQ/prefect/issues/12222
