### PR TITLE
fix(sec): bump axios to v1.6.7 to resolve 3 vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@prefecthq/graphs": "2.2.9",
                 "@types/lodash.isequal": "4.5.8",
-                "axios": "1.6.2",
+                "axios": "1.6.7",
                 "cronstrue": "^2.48.0",
                 "d3": "7.8.5",
                 "date-fns": "2.30.0",
@@ -2654,11 +2654,11 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
             "dependencies": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.4",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -9530,11 +9530,11 @@
             "dev": true
         },
         "axios": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
             "requires": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.4",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "2.6.31",
             "dependencies": {
                 "@prefecthq/graphs": "2.2.9",
-                "@types/lodash.isequal": "4.5.8",
                 "axios": "1.6.7",
                 "cronstrue": "^2.48.0",
                 "d3": "7.8.5",
@@ -24,6 +23,7 @@
                 "@types/d3": "7.4.3",
                 "@types/lodash.camelcase": "4.3.9",
                 "@types/lodash.debounce": "4.0.9",
+                "@types/lodash.isequal": "^4.5.8",
                 "@types/lodash.merge": "4.6.9",
                 "@types/node": "^20.11.24",
                 "@types/prismjs": "^1.26.3",
@@ -1832,6 +1832,7 @@
             "version": "4.5.8",
             "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
             "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
+            "dev": true,
             "dependencies": {
                 "@types/lodash": "*"
             }
@@ -8946,6 +8947,7 @@
             "version": "4.5.8",
             "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
             "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
+            "dev": true,
             "requires": {
                 "@types/lodash": "*"
             }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "dependencies": {
         "@prefecthq/graphs": "2.2.9",
         "@types/lodash.isequal": "4.5.8",
-        "axios": "1.6.2",
+        "axios": "1.6.7",
         "cronstrue": "^2.48.0",
         "d3": "7.8.5",
         "date-fns": "2.30.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@types/d3": "7.4.3",
         "@types/lodash.camelcase": "4.3.9",
         "@types/lodash.debounce": "4.0.9",
+        "@types/lodash.isequal": "^4.5.8",
         "@types/lodash.merge": "4.6.9",
         "@types/node": "^20.11.24",
         "@types/prismjs": "^1.26.3",
@@ -70,7 +71,6 @@
     },
     "dependencies": {
         "@prefecthq/graphs": "2.2.9",
-        "@types/lodash.isequal": "4.5.8",
         "axios": "1.6.7",
         "cronstrue": "^2.48.0",
         "d3": "7.8.5",


### PR DESCRIPTION
Bump `axios` to latest minor version as of writing, to resolve following vulnerabilities

* SNYK-JS-AXIOS-6144788 (resolved in v1.6.4)
* CVE-2023-26159 (resolved in v1.6.4)
* SNYK-JS-AXIOS-6124857 (resolved in v1.6.3)

In addition, I've detected a seemingly accidental dependency of `@types/lodash.isequal` instead of dev dependency. Run the `npm install @types/lodash.isequal --save-dev`, run `npm run build && npm run test` and found no issue.