### PR TITLE
Restrict logs to only `a` html elements

### DIFF
--- a/src/components/LogRow.vue
+++ b/src/components/LogRow.vue
@@ -39,6 +39,7 @@
   }>()
 
   const config = {
+    ALLOWED_TAGS: ['a'],
     ALLOWED_ATTR: ['href', 'target', 'rel'],
   }
 


### PR DESCRIPTION
# Description
Log rows use v-html but first passes the content of the log through `p-sanitize-html` with a custom config. That config is overriding the default config which seems to mean all html tags are allowed. Specifying only the specific tags we want to allow prevents css and js injection. 