### PR TITLE
Schemas: Fix prop and v-model not matching up for boolean properties

### DIFF
--- a/src/schemas/components/SchemaFormPropertyBoolean.vue
+++ b/src/schemas/components/SchemaFormPropertyBoolean.vue
@@ -12,7 +12,7 @@
     state: State,
   }>()
 
-  const value = defineModel<boolean | undefined>({ default: undefined })
+  const value = defineModel<boolean | undefined>('value', { default: undefined })
 
   if (!isDefined(value.value)) {
     value.value = asType(props.property.default, Boolean) ?? false

--- a/src/schemas/components/SchemaFormPropertyInput.vue
+++ b/src/schemas/components/SchemaFormPropertyInput.vue
@@ -51,7 +51,7 @@
         property: { ...property.value, type },
         value: asType(value, Boolean),
         state: props.state,
-        'onUpdate:modelValue': (value) => emit('update:value', asType(value, Boolean)),
+        'onUpdate:value': (value) => emit('update:value', asType(value, Boolean)),
       })
     }
 


### PR DESCRIPTION
# Description
The v-model was broken because the prop being passed was `value` but the v-model was `modelValue`. Updated all references to use `value`. 

Closes: https://github.com/PrefectHQ/prefect/issues/12241