### PR TITLE
Chore: reveal graph options

### DIFF
--- a/src/components/FlowRunGraph.vue
+++ b/src/components/FlowRunGraph.vue
@@ -189,13 +189,4 @@
   -translate-y-1/2
   pointer-events-none
 }
-
-
-/* TODO: These temporarily hide the "Hide artifacts" and "Hide events" options until those layers go live */
-.run-graph-settings__menu > .p-checkbox:nth-last-child(2) {
-  display: none;
-}
-.run-graph-settings__menu > .p-checkbox:last-child {
-  display: none;
-}
 </style>


### PR DESCRIPTION
Reveals the graph options to hide artifacts.

Should these be feature flagged? They could be. If they were, I'd need to add the artifacts flag on the nebula side and both the events and artifacts flags on the OSS frontend side. Since these are on their way out and exposing these prematurely constitutes little to no risk, I personally don't feel it's worth.