### PR TITLE
Make state badge prefer its state prop's type if present.

### DIFF
--- a/src/components/StateBadge.vue
+++ b/src/components/StateBadge.vue
@@ -18,7 +18,7 @@
     dismissible?: boolean,
   }>()
 
-  const type = computed(() => mapStateNameToStateType(props.state?.name).type)
+  const type = computed(() => props.state?.type ?? mapStateNameToStateType(props.state?.name).type)
   const stateWithNoType = computed(() => props.state && !type.value)
   const name = computed(() => props.state?.name ?? 'Unknown')
 


### PR DESCRIPTION
This PR contains a small change to have the StateBadge use its state type directly for styling if present _else_ fallback to the current method of deriving the type from its name. 

This enables custom flow run states to render in styled like their actual, inherent state type while maintaining the custom name. 

```python
@flow
def hello_world():
    return State(
        type=StateType.COMPLETED,
        name="My custom name",
        message="My custom message.",
    )
```

| **Before** | **After** |
| ---- | ---- |
| <img width="409" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/c2017cd4-8f03-4796-9018-75d936716712"> | <img width="407" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/fccf03eb-616e-48ef-aeb5-facf16d2d379"> |

