### PR TITLE
Chore: Add missing sort options for task and flow runs

### DIFF
--- a/src/types/SortOptionTypes.ts
+++ b/src/types/SortOptionTypes.ts
@@ -67,7 +67,7 @@ export const deploymentSortOptions = [
   { label: 'Z to A', value: 'NAME_DESC' },
 ]
 
-export const flowRunSortValues = ['CREATED_DESC', 'NAME_DESC', 'NAME_ASC', 'EXPECTED_START_TIME_DESC', 'EXPECTED_START_TIME_ASC', 'NEXT_SCHEDULED_START_TIME_ASC', 'START_TIME_DESC', 'START_TIME_ASC'] as const
+export const flowRunSortValues = ['ID_DESC', 'END_TIME_DESC', 'CREATED_DESC', 'NAME_DESC', 'NAME_ASC', 'EXPECTED_START_TIME_DESC', 'EXPECTED_START_TIME_ASC', 'NEXT_SCHEDULED_START_TIME_ASC', 'START_TIME_DESC', 'START_TIME_ASC'] as const
 export type FlowRunSortValues = typeof flowRunSortValues[number]
 export const defaultFlowRunSort: FlowRunSortValues = 'START_TIME_DESC'
 
@@ -79,7 +79,7 @@ export function isFlowRunSortValue(value: MaybeRef<unknown>): value is MaybeRef<
 
 export type FlowRunSortOptions = { label: string, value: FlowRunSortValues }[]
 
-export const taskRunSortValues = ['ID_DESC', 'EXPECTED_START_TIME_ASC', 'EXPECTED_START_TIME_DESC', 'NEXT_SCHEDULED_START_TIME_ASC', 'END_TIME_DESC'] as const
+export const taskRunSortValues = ['ID_DESC', 'EXPECTED_START_TIME_ASC', 'EXPECTED_START_TIME_DESC', 'NAME_DESC', 'NAME_ASC', 'NEXT_SCHEDULED_START_TIME_ASC', 'END_TIME_DESC'] as const
 export type TaskRunSortValues = typeof taskRunSortValues[number]
 export const defaultTaskRunSort: TaskRunSortValues = 'EXPECTED_START_TIME_DESC'
 


### PR DESCRIPTION
I think these sorts were added later so we missed them in the initial type definitions. This shouldn't impact any dropdowns afaict since options there are hardcoded by the components themselves and this is purely additive. 