### PR TITLE
Chore: Add work pool queue status icon to bucket exports

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -293,6 +293,7 @@ export { default as WorkPoolQueuePriorityLabel } from './WorkPoolQueuePriorityLa
 export { default as WorkPoolQueuesDeleteButton } from './WorkPoolQueuesDeleteButton.vue'
 export { default as WorkPoolQueuesTable } from './WorkPoolQueuesTable.vue'
 export { default as WorkPoolQueueStatusBadge } from './WorkPoolQueueStatusBadge.vue'
+export { default as WorkPoolQueueStatusIcon } from './WorkPoolQueueStatusIcon.vue'
 export { default as WorkPoolQueueToggle } from './WorkPoolQueueToggle.vue'
 export { default as WorkPoolQueueUpcomingFlowRunsList } from './WorkPoolQueueUpcomingFlowRunsList.vue'
 export { default as WorkPools } from './WorkPools.vue'


### PR DESCRIPTION
This was being used by several components but wasn't exported itself (despite deprecation notices on other bucket exports pointing to this)