### PR TITLE
Add counts by state type to the flow run task runs tab

### DIFF
--- a/src/components/FlowRunTaskCounts.vue
+++ b/src/components/FlowRunTaskCounts.vue
@@ -1,0 +1,48 @@
+<template>
+  <span v-if="counts" class="flow-run-task-counts">
+    ({{ counts }})
+  </span>
+</template>
+
+<script lang="ts" setup>
+  import { useSubscription } from '@prefecthq/vue-compositions'
+  import { computed } from 'vue'
+  import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
+  import { TaskRunsFilter } from '@/models/Filters'
+
+  const props = defineProps<{
+    flowRunId: string,
+  }>()
+
+  const api = useWorkspaceApi()
+  const filter = computed<TaskRunsFilter>(() => ({
+    flowRuns: {
+      id: [props.flowRunId],
+    },
+  }))
+
+  const subscription = useSubscription(api.ui.getTaskRunsCountByState, [filter])
+  const counts = computed(() => {
+    if (!subscription.response) {
+      return ''
+    }
+
+    return Object.entries(subscription.response).reduce<string[]>((response, [key, value]) => {
+      if (!value) {
+        return response
+      }
+
+      response.push(`${value} ${key}`)
+
+      return response
+    }, []).join(', ')
+  })
+</script>
+
+<style>
+.flow-run-task-counts { @apply
+  text-subdued
+  text-xs
+  capitalize
+}
+</style>

--- a/src/components/FlowRunTaskCounts.vue
+++ b/src/components/FlowRunTaskCounts.vue
@@ -21,7 +21,7 @@
     },
   }))
 
-  const subscription = useSubscription(api.ui.getTaskRunsCountByState, [filter])
+  const subscription = useSubscription(api.ui.getTaskRunsCountByState, [filter], { interval: 30000 })
   const counts = computed(() => {
     if (!subscription.response) {
       return ''

--- a/src/components/FlowRunTaskRuns.vue
+++ b/src/components/FlowRunTaskRuns.vue
@@ -1,7 +1,10 @@
 <template>
   <p-content class="flow-run-task-runs">
     <p-list-header sticky>
-      <ResultsCount :count="count" label="Task run" />
+      <div class="flow-run-task-runs__count">
+        <ResultsCount :count="count" label="Task run" />
+        <FlowRunTaskCounts :flow-run-id="flowRunId" />
+      </div>
       <template #controls>
         <SearchInput v-model="searchTerm" placeholder="Search by run name" label="Search by run name" class="flow-run-task-runs__search" />
         <StateNameSelect v-model:selected="states" empty-message="All states" multiple />
@@ -36,6 +39,7 @@
     TaskRunList,
     TaskRunsSort
   } from '@/components'
+  import FlowRunTaskCounts from '@/components/FlowRunTaskCounts.vue'
   import { useTaskRunsCount, useTaskRunsFilter, useWorkspaceApi } from '@/compositions'
   import { usePaginatedSubscription } from '@/compositions/usePaginatedSubscription'
   import { TaskRun } from '@/models/TaskRun'
@@ -77,5 +81,11 @@
 <style>
 .flow-run-task-runs__search { @apply
   min-w-[224px]
+}
+
+.flow-run-task-runs__count { @apply
+  grid
+  grid-cols-1
+  gap-1
 }
 </style>


### PR DESCRIPTION
# Description
Adds a count of tasks by their state type below the total count to easily identify how many tasks

Closes https://github.com/PrefectHQ/prefect/issues/12102

@brandonreid if you have some design feedback on this let me know. 

![image](https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/f1961838-d52c-4f10-bb0a-574c36614125)
