### PR TITLE
Schemas: Add variables to quick run forms

### DIFF
--- a/src/components/QuickRunParametersModal.vue
+++ b/src/components/QuickRunParametersModal.vue
@@ -9,7 +9,7 @@
         </p-icon-button-menu>
       </div>
 
-      <SchemaFormV2 :id="formId" v-model:values="parameters" :schema="deployment.parameterOpenApiSchemaV2" :kinds="['json']" @submit="submit" />
+      <SchemaFormV2 :id="formId" v-model:values="parameters" :schema="deployment.parameterOpenApiSchemaV2" :kinds="['json', 'workspace_variable']" @submit="submit" />
     </p-content>
 
     <template #actions>


### PR DESCRIPTION
# Description
Missing the workspace variables feature on the quick run modal