### PR TITLE
Update wording to integrations

### DIFF
--- a/src/components/PageHeadingBlocksCatalog.vue
+++ b/src/components/PageHeadingBlocksCatalog.vue
@@ -5,9 +5,9 @@
     <p-message>
       If you don't see a block for the service you're using, check out our
       <p-link :to="localization.docs.collections">
-        Collections Catalog
+        Integrations
       </p-link>
-      to view a list of integrations and their corresponding blocks.
+      to view a list of integration libraries and their corresponding blocks.
     </p-message>
   </p-content>
 </template>


### PR DESCRIPTION
We try to use the term integrations over collections in all other outward facing language, updating the message in the blocks creation page to match.