### PR TITLE
Enhancement: Add a loading state for the blocks, deployments and flows table

### DIFF
--- a/src/components/BlockDocumentsTable.vue
+++ b/src/components/BlockDocumentsTable.vue
@@ -204,10 +204,4 @@
 .block-documents-table__name-img { @apply
   mr-1
 }
-
-.block-documents-table__loading { @apply
-  text-subdued
-  text-center
-  my-4
-}
 </style>

--- a/src/components/BlockDocumentsTable.vue
+++ b/src/components/BlockDocumentsTable.vue
@@ -15,7 +15,219 @@
               {{ row.blockType.name }} /
               <p-link :to="routes.block(row.id)">
                 {{ row.name }}
-              </p-link>
+              </p-link><template>
+                <div class="block-documents-table">
+                  <div class="block-documents-table__filters">
+                    <ResultsCount label="Block" :count="total" class="block-documents-table__results" />
+                    <SearchInput v-model="searchTerm" placeholder="Search blocks" label="Search blocks" class="block-documents-table__search" />
+                    <BlockSchemaCapabilitySelect v-model:selected="capabilities" class="block-documents-table__capability" />
+                    <BlockTypeSelect v-model:selected="blockTypes" class="block-documents-table__type" />
+                  </div>
+                  <p-table :data="blockDocuments" :columns="columns">
+                    <template #name="{ row }: { row: BlockDocument }">
+                      <div class="block-documents-table__name-column">
+                        <LogoImage :url="row.blockType.logoUrl" class="block-documents-table__name-img" />
+                        <div class="block-documents-table__name-content">
+                          <span class="block-documents-table__crumbs">
+                            {{ row.blockType.name }} /
+                            <p-link :to="routes.block(row.id)">
+                              {{ row.name }}
+                            </p-link>
+                          </span>
+                          <template v-if="!media.md">
+                            <BlockSchemaCapabilities :capabilities="row.blockSchema.capabilities" />
+                          </template>
+                        </div>
+                      </div>
+                    </template>
+
+                    <template #capabilities="{ row }">
+                      <BlockSchemaCapabilities :capabilities="row.blockSchema.capabilities" wrapper />
+                    </template>
+
+                    <template #action-heading>
+                      <span />
+                    </template>
+                    <template #action="{ row }">
+                      <BlockDocumentMenu :block-document="row" size="xs" @delete="onDelete" />
+                    </template>
+
+                    <template #empty-state>
+                      <PEmptyResults v-if="subscriptions.executed">
+                        <template #message>
+                          No blocks
+                        </template>
+                        <template #actions>
+                          <p-button small @click="clear">
+                            Clear Filters
+                          </p-button>
+                        </template>
+                      </PEmptyResults>
+                      <div v-else class="block-documents-table__loading">
+                        Loading blocks...
+                      </div>
+                    </template>
+                  </p-table>
+
+                  <p-pager v-if="pages > 1" v-model:page="page" :pages="pages" />
+                </div>
+              </template>
+
+              <script lang="ts" setup>
+                import { media, TableColumn, PEmptyResults } from '@prefecthq/prefect-design'
+                import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
+                import merge from 'lodash.merge'
+                import { computed, ref } from 'vue'
+                import BlockSchemaCapabilities from '@/components/BlockSchemaCapabilities.vue'
+                import BlockSchemaCapabilitySelect from '@/components/BlockSchemaCapabilitySelect.vue'
+                import BlockTypeSelect from '@/components/BlockTypeSelect.vue'
+                import LogoImage from '@/components/LogoImage.vue'
+                import ResultsCount from '@/components/ResultsCount.vue'
+                import SearchInput from '@/components/SearchInput.vue'
+                import { useBlockDocuments, useBlockDocumentsFilterFromRoute, useComponent, useWorkspaceRoutes } from '@/compositions'
+                import { BlockDocument } from '@/models/BlockDocument'
+                import { BlockDocumentsFilter } from '@/models/Filters'
+
+                const props = defineProps<{
+                filter?: BlockDocumentsFilter,
+                }>()
+
+                const emit = defineEmits<{
+                (event: 'delete'): void,
+                }>()
+
+                const { BlockDocumentMenu } = useComponent()
+                const routes = useWorkspaceRoutes()
+
+                const columns = computed<TableColumn<BlockDocument>[]>(() => [
+                {
+                label: 'Name',
+                property: 'name',
+                width: '300px',
+                },
+                {
+                label: 'Capabilities',
+                visible: media.md,
+                },
+                {
+                label: 'Action',
+                width: '0px',
+                },
+                ])
+
+                const page = useRouteQueryParam('page', NumberRouteParam, 1)
+                const capabilities = ref<string[]>([])
+                const blockTypes = ref<string[]>([])
+                const searchTerm = ref('')
+                const searchTermDebounced = useDebouncedRef(searchTerm, 500)
+
+                const { filter } = useBlockDocumentsFilterFromRoute({
+                blockSchemas: {
+                blockCapabilities: capabilities,
+                },
+                blockDocuments: {
+                nameLike: searchTermDebounced,
+                },
+                blockTypes: {
+                slug: blockTypes,
+                },
+                limit: 50,
+                sort: 'BLOCK_TYPE_AND_NAME_ASC',
+                })
+
+                const { blockDocuments, total, pages, subscriptions } = useBlockDocuments(() => merge({}, props.filter, filter), {
+                page,
+                })
+
+                function clear(): void {
+                searchTerm.value = ''
+                capabilities.value = []
+                blockTypes.value = []
+                }
+
+                function onDelete(): void {
+                subscriptions.refresh()
+                emit('delete')
+                }
+              </script>
+
+              <style>
+                .block-documents-table { @apply
+                grid
+                gap-4
+                }
+
+                .block-documents-table__filters { @apply
+                grid
+                md:flex
+                gap-2
+                justify-between
+                items-center
+                }
+
+                .block-documents-table__filters {
+                grid-template-columns: minmax(0, 1fr);
+                grid-template-areas: "search"
+                "capability"
+                "type"
+                "results";
+
+                }
+
+                @screen sm {
+                .block-documents-table__filters {
+                grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+                grid-template-areas: "search     search"
+                "capability type"
+                "results    results";
+                }
+                }
+
+                .block-documents-table__results { @apply
+                mt-2
+                md:mt-0
+                md:mr-auto
+                }
+
+                .block-documents-table__search {
+                grid-area: search;
+                }
+
+                .block-documents-table__capability {
+                grid-area: capability;
+                }
+
+                .block-documents-table__type {
+                grid-area: type;
+                }
+
+                .block-documents-table__results {
+                grid-area: results;
+                }
+
+                .block-documents-table__name-column { @apply
+                flex
+                md:items-center
+                gap-1
+                min-w-max
+                }
+
+                .block-documents-table__name-content { @apply
+                grid
+                gap-2
+                flex-grow
+                }
+
+                .block-documents-table__name-img { @apply
+                mr-1
+                }
+
+                .block-documents-table__loading { @apply
+                text-subdued
+                text-center
+                my-4
+                }
+              </style>
             </span>
             <template v-if="!media.md">
               <BlockSchemaCapabilities :capabilities="row.blockSchema.capabilities" />

--- a/src/components/BlockDocumentsTable.vue
+++ b/src/components/BlockDocumentsTable.vue
@@ -15,219 +15,7 @@
               {{ row.blockType.name }} /
               <p-link :to="routes.block(row.id)">
                 {{ row.name }}
-              </p-link><template>
-                <div class="block-documents-table">
-                  <div class="block-documents-table__filters">
-                    <ResultsCount label="Block" :count="total" class="block-documents-table__results" />
-                    <SearchInput v-model="searchTerm" placeholder="Search blocks" label="Search blocks" class="block-documents-table__search" />
-                    <BlockSchemaCapabilitySelect v-model:selected="capabilities" class="block-documents-table__capability" />
-                    <BlockTypeSelect v-model:selected="blockTypes" class="block-documents-table__type" />
-                  </div>
-                  <p-table :data="blockDocuments" :columns="columns">
-                    <template #name="{ row }: { row: BlockDocument }">
-                      <div class="block-documents-table__name-column">
-                        <LogoImage :url="row.blockType.logoUrl" class="block-documents-table__name-img" />
-                        <div class="block-documents-table__name-content">
-                          <span class="block-documents-table__crumbs">
-                            {{ row.blockType.name }} /
-                            <p-link :to="routes.block(row.id)">
-                              {{ row.name }}
-                            </p-link>
-                          </span>
-                          <template v-if="!media.md">
-                            <BlockSchemaCapabilities :capabilities="row.blockSchema.capabilities" />
-                          </template>
-                        </div>
-                      </div>
-                    </template>
-
-                    <template #capabilities="{ row }">
-                      <BlockSchemaCapabilities :capabilities="row.blockSchema.capabilities" wrapper />
-                    </template>
-
-                    <template #action-heading>
-                      <span />
-                    </template>
-                    <template #action="{ row }">
-                      <BlockDocumentMenu :block-document="row" size="xs" @delete="onDelete" />
-                    </template>
-
-                    <template #empty-state>
-                      <PEmptyResults v-if="subscriptions.executed">
-                        <template #message>
-                          No blocks
-                        </template>
-                        <template #actions>
-                          <p-button small @click="clear">
-                            Clear Filters
-                          </p-button>
-                        </template>
-                      </PEmptyResults>
-                      <div v-else class="block-documents-table__loading">
-                        Loading blocks...
-                      </div>
-                    </template>
-                  </p-table>
-
-                  <p-pager v-if="pages > 1" v-model:page="page" :pages="pages" />
-                </div>
-              </template>
-
-              <script lang="ts" setup>
-                import { media, TableColumn, PEmptyResults } from '@prefecthq/prefect-design'
-                import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
-                import merge from 'lodash.merge'
-                import { computed, ref } from 'vue'
-                import BlockSchemaCapabilities from '@/components/BlockSchemaCapabilities.vue'
-                import BlockSchemaCapabilitySelect from '@/components/BlockSchemaCapabilitySelect.vue'
-                import BlockTypeSelect from '@/components/BlockTypeSelect.vue'
-                import LogoImage from '@/components/LogoImage.vue'
-                import ResultsCount from '@/components/ResultsCount.vue'
-                import SearchInput from '@/components/SearchInput.vue'
-                import { useBlockDocuments, useBlockDocumentsFilterFromRoute, useComponent, useWorkspaceRoutes } from '@/compositions'
-                import { BlockDocument } from '@/models/BlockDocument'
-                import { BlockDocumentsFilter } from '@/models/Filters'
-
-                const props = defineProps<{
-                filter?: BlockDocumentsFilter,
-                }>()
-
-                const emit = defineEmits<{
-                (event: 'delete'): void,
-                }>()
-
-                const { BlockDocumentMenu } = useComponent()
-                const routes = useWorkspaceRoutes()
-
-                const columns = computed<TableColumn<BlockDocument>[]>(() => [
-                {
-                label: 'Name',
-                property: 'name',
-                width: '300px',
-                },
-                {
-                label: 'Capabilities',
-                visible: media.md,
-                },
-                {
-                label: 'Action',
-                width: '0px',
-                },
-                ])
-
-                const page = useRouteQueryParam('page', NumberRouteParam, 1)
-                const capabilities = ref<string[]>([])
-                const blockTypes = ref<string[]>([])
-                const searchTerm = ref('')
-                const searchTermDebounced = useDebouncedRef(searchTerm, 500)
-
-                const { filter } = useBlockDocumentsFilterFromRoute({
-                blockSchemas: {
-                blockCapabilities: capabilities,
-                },
-                blockDocuments: {
-                nameLike: searchTermDebounced,
-                },
-                blockTypes: {
-                slug: blockTypes,
-                },
-                limit: 50,
-                sort: 'BLOCK_TYPE_AND_NAME_ASC',
-                })
-
-                const { blockDocuments, total, pages, subscriptions } = useBlockDocuments(() => merge({}, props.filter, filter), {
-                page,
-                })
-
-                function clear(): void {
-                searchTerm.value = ''
-                capabilities.value = []
-                blockTypes.value = []
-                }
-
-                function onDelete(): void {
-                subscriptions.refresh()
-                emit('delete')
-                }
-              </script>
-
-              <style>
-                .block-documents-table { @apply
-                grid
-                gap-4
-                }
-
-                .block-documents-table__filters { @apply
-                grid
-                md:flex
-                gap-2
-                justify-between
-                items-center
-                }
-
-                .block-documents-table__filters {
-                grid-template-columns: minmax(0, 1fr);
-                grid-template-areas: "search"
-                "capability"
-                "type"
-                "results";
-
-                }
-
-                @screen sm {
-                .block-documents-table__filters {
-                grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-                grid-template-areas: "search     search"
-                "capability type"
-                "results    results";
-                }
-                }
-
-                .block-documents-table__results { @apply
-                mt-2
-                md:mt-0
-                md:mr-auto
-                }
-
-                .block-documents-table__search {
-                grid-area: search;
-                }
-
-                .block-documents-table__capability {
-                grid-area: capability;
-                }
-
-                .block-documents-table__type {
-                grid-area: type;
-                }
-
-                .block-documents-table__results {
-                grid-area: results;
-                }
-
-                .block-documents-table__name-column { @apply
-                flex
-                md:items-center
-                gap-1
-                min-w-max
-                }
-
-                .block-documents-table__name-content { @apply
-                grid
-                gap-2
-                flex-grow
-                }
-
-                .block-documents-table__name-img { @apply
-                mr-1
-                }
-
-                .block-documents-table__loading { @apply
-                text-subdued
-                text-center
-                my-4
-                }
-              </style>
+              </p-link>
             </span>
             <template v-if="!media.md">
               <BlockSchemaCapabilities :capabilities="row.blockSchema.capabilities" />
@@ -248,7 +36,7 @@
       </template>
 
       <template #empty-state>
-        <PEmptyResults>
+        <PEmptyResults v-if="subscriptions.executed">
           <template #message>
             No blocks
           </template>
@@ -258,6 +46,9 @@
             </p-button>
           </template>
         </PEmptyResults>
+        <div v-else class="block-documents-table__loading">
+          Loading blocks...
+        </div>
       </template>
     </p-table>
 
@@ -339,7 +130,6 @@
 
   function onDelete(): void {
     subscriptions.refresh()
-
     emit('delete')
   }
 </script>
@@ -413,5 +203,11 @@
 
 .block-documents-table__name-img { @apply
   mr-1
+}
+
+.block-documents-table__loading { @apply
+  text-subdued
+  text-center
+  my-4
 }
 </style>

--- a/src/components/BlockDocumentsTable.vue
+++ b/src/components/BlockDocumentsTable.vue
@@ -46,9 +46,11 @@
             </p-button>
           </template>
         </PEmptyResults>
-        <div v-else class="block-documents-table__loading">
-          Loading blocks...
-        </div>
+        <PEmptyResults v-else>
+          <template #message>
+            Loading...
+          </template>
+        </PEmptyResults>
       </template>
     </p-table>
 

--- a/src/components/DeploymentsList.vue
+++ b/src/components/DeploymentsList.vue
@@ -91,7 +91,7 @@
       </template>
 
       <template #empty-state>
-        <PEmptyResults>
+        <PEmptyResults v-if="subscriptions.executed">
           <template #message>
             No deployments
           </template>
@@ -99,6 +99,11 @@
             <p-button small @click="clear">
               Clear Filters
             </p-button>
+          </template>
+        </PEmptyResults>
+        <PEmptyResults v-else>
+          <template #message>
+            Loading...
           </template>
         </PEmptyResults>
       </template>

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -64,7 +64,7 @@
       </template>
 
       <template #empty-state>
-        <PEmptyResults>
+        <PEmptyResults v-if="subscriptions.executed">
           <template #message>
             No flows
           </template>
@@ -72,6 +72,11 @@
             <p-button small @click="clear">
               Clear Filters
             </p-button>
+          </template>
+        </PEmptyResults>
+        <PEmptyResults v-else>
+          <template #message>
+            Loading...
           </template>
         </PEmptyResults>
       </template>


### PR DESCRIPTION
A simple update for an issue that's been bugging me for a while.  Follows the text and style used in the memberships and invitations tables in cloud. 
After:

https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/c8b31fdf-bb28-462d-8022-a560f75db1bc

Before:

https://github.com/PrefectHQ/prefect-ui-library/assets/40272060/289f36d6-b9bc-4d27-ab04-c122a1e270c3

Open to push back that this should be done in prefect-design rather than the individual tables - I started with blocks then realized it could usefully be added in a few other places. 

