### PR TITLE
Use p table multiselect behavior in tables

### DIFF
--- a/src/components/DeploymentsList.vue
+++ b/src/components/DeploymentsList.vue
@@ -3,7 +3,7 @@
     <p-list-header sticky>
       <ResultsCount v-if="selectedDeployments.length == 0" label="Deployment" :count="total" />
       <SelectedCount v-else :count="selectedDeployments.length" />
-      <DeploymentsDeleteButton v-if="can.delete.deployment" :selected="selectedDeployments" small @delete="deleteDeployments" />
+      <DeploymentsDeleteButton v-if="can.delete.deployment" :selected="selectedDeployments.map(deployment => deployment.id)" small @delete="deleteDeployments" />
 
       <template #controls>
         <SearchInput v-model="deploymentNameLike" placeholder="Deployment names" label="Search deployments" />
@@ -15,15 +15,7 @@
       </template>
     </p-list-header>
 
-    <p-table :data="deployments" :columns="columns" class="deployments-list__table">
-      <template #selection-heading>
-        <p-checkbox v-model="model" @update:model-value="selectAllDeployments" />
-      </template>
-
-      <template #selection="{ row }">
-        <p-checkbox v-model="selectedDeployments" :value="row.id" />
-      </template>
-
+    <p-table :selected="can.delete.deployment ? selectedDeployments : undefined" :data="deployments" :columns="columns" class="deployments-list__table" @update:selected="selectedDeployments = $event">
       <template #deployment-name="{ row }">
         <div class="deployment-list__name-col">
           <span class="deployment-list__name">
@@ -109,11 +101,11 @@
 </template>
 
 <script lang="ts" setup>
-  import { CheckboxModel, TableColumn, media } from '@prefecthq/prefect-design'
+  import { TableColumn, media } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
   import { secondsInDay } from 'date-fns/constants'
   import merge from 'lodash.merge'
-  import { computed, ref } from 'vue'
+  import { ref } from 'vue'
   import {
     DeploymentsDeleteButton,
     ResultsCount,
@@ -166,11 +158,6 @@
 
   const columns: TableColumn<Deployment>[] = [
     {
-      label: 'selection',
-      width: '20px',
-      visible: can.delete.deployment,
-    },
-    {
       property: 'name',
       label: 'Deployment name',
     },
@@ -195,22 +182,7 @@
     },
   ]
 
-  const selectedDeployments = ref<string[]>([])
-  const selectAllDeployments = (allDeploymentsSelected: CheckboxModel): string[] => {
-    if (allDeploymentsSelected) {
-      return selectedDeployments.value = [...deployments.value.map(deployment => deployment.id)]
-    }
-    return selectedDeployments.value = []
-  }
-
-  const model = computed({
-    get() {
-      return selectedDeployments.value.length === deployments.value.length
-    },
-    set(value: boolean) {
-      selectAllDeployments(value)
-    },
-  })
+  const selectedDeployments = ref<Deployment[]>([])
 
   function refresh(): void {
     subscriptions.refresh()

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -3,7 +3,7 @@
     <p-list-header sticky>
       <ResultsCount v-if="selectedFlows.length == 0" label="Flow" :count="total" />
       <SelectedCount v-else :count="selectedFlows.length" />
-      <FlowsDeleteButton v-if="can.delete.flow" :selected="selectedFlows" small @delete="deleteFlows" />
+      <FlowsDeleteButton v-if="can.delete.flow" :selected="selectedFlows.map(flow => flow.id)" small @delete="deleteFlows" />
 
       <template #controls>
         <SearchInput v-model="flowNameLike" placeholder="Flow names" label="Search flows" />
@@ -15,15 +15,7 @@
       </template>
     </p-list-header>
 
-    <p-table :data="flows" :columns="columns" class="flow-list__table">
-      <template #selection-heading>
-        <p-checkbox v-model="model" @update:model-value="selectAllFlows" />
-      </template>
-
-      <template #selection="{ row }">
-        <p-checkbox v-model="selectedFlows" :value="row.id" />
-      </template>
-
+    <p-table :selected="can.delete.flow ? selectedFlows : undefined" :data="flows" :columns="columns" class="flow-list__table" @update:selected="selectedFlows = $event">
       <template #name="{ row }">
         <div class="flow-list__name-col">
           <p-link :to="routes.flow(row.id)" class="flow-list__name">
@@ -82,11 +74,11 @@
 </template>
 
 <script lang="ts" setup>
-  import { CheckboxModel, TableColumn } from '@prefecthq/prefect-design'
+  import { TableColumn } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
   import { secondsInDay } from 'date-fns/constants'
   import merge from 'lodash.merge'
-  import { computed, ref } from 'vue'
+  import { ref } from 'vue'
   import {
     FlowsDeleteButton,
     LastFlowRun,
@@ -131,11 +123,6 @@
 
   const columns: TableColumn<Flow>[] = [
     {
-      label: 'selection',
-      width: '20px',
-      visible: can.delete.flow,
-    },
-    {
       property: 'name',
       label: 'Name',
     },
@@ -156,22 +143,7 @@
     },
   ]
 
-  const selectedFlows = ref<string[]>([])
-  const selectAllFlows = (allFlowsSelected: CheckboxModel): string[] => {
-    if (allFlowsSelected) {
-      return selectedFlows.value = [...flows.value.map(flow => flow.id)]
-    }
-    return selectedFlows.value = []
-  }
-
-  const model = computed({
-    get() {
-      return selectedFlows.value.length === flows.value.length
-    },
-    set(value: boolean) {
-      selectAllFlows(value)
-    },
-  })
+  const selectedFlows = ref<Flow[]>([])
 
   function refresh(): void {
     subscriptions.refresh()

--- a/src/components/WorkPoolQueuesTable.vue
+++ b/src/components/WorkPoolQueuesTable.vue
@@ -1,20 +1,18 @@
 <template>
   <p-content class="work-pool-queues-table">
     <p-list-header sticky>
-      <template v-if="selected">
-        <ResultsCount v-if="selected.length == 0" label="Work Queue" :count="filteredWorkPoolQueues.length" />
-        <SelectedCount v-else :count="selected.length" />
-        <p-button v-if="can.create.work_queue && !selected.length" small icon="PlusIcon" :to="routes.workPoolQueueCreate(workPoolName)" />
+      <ResultsCount v-if="selected.length == 0" label="Work Queue" :count="filteredWorkPoolQueues.length" />
+      <SelectedCount v-else :count="selected.length" />
+      <p-button v-if="can.create.work_queue && !selected.length" small icon="PlusIcon" :to="routes.workPoolQueueCreate(workPoolName)" />
 
-        <WorkPoolQueuesDeleteButton :work-pool-name="workPoolName" :work-pool-queues="selected" @delete="handleDelete" />
-      </template>
+      <WorkPoolQueuesDeleteButton v-if="can.delete.work_queue" :work-pool-name="workPoolName" :work-pool-queues="selected" @delete="handleDelete" />
 
       <template #controls>
         <SearchInput v-model="search" label="Search" placeholder="Search" />
       </template>
     </p-list-header>
 
-    <p-table v-model:selected="selected" :data="filteredWorkPoolQueues" :columns="columns">
+    <p-table :selected="can.delete.work_queue ? selected : undefined" :data="filteredWorkPoolQueues" :columns="columns" @update:selected="selected = $event">
       <template #priority-heading>
         <WorkPoolQueuePriorityLabel />
       </template>
@@ -85,7 +83,7 @@
     return workPoolQueuesData.value.filter(queue => isRecord(queue) && hasString(queue, search.value))
   })
 
-  const selected = ref<WorkPoolQueue[] | undefined>(can.delete.work_queue ? [] : undefined)
+  const selected = ref<WorkPoolQueue[]>([])
   const columns: TableColumn<WorkPoolQueue>[] = [
     {
       property: 'name',
@@ -110,7 +108,7 @@
 
   const handleDelete = async (): Promise<void> => {
     await workPoolQueuesSubscription.refresh()
-    selected.value = selected.value?.filter(queue => workPoolQueues.value.find(({ id }) => id === queue.id))
+    selected.value = []
   }
 
   function refresh(): void {


### PR DESCRIPTION
These table components implement their own selection behavior despite `<p-table />` having support for multiselect built-in. 

This PR updates all tables with selection behavior to use `<p-table>`'s built-in multiselect behavior.
**There should be close to no functional changes expected from this PR** (with the exception of `<WorkPoolQueueTable />` - see comments)