### PR TITLE
Schemas: Set default value for json inputs

### DIFF
--- a/src/schemas/components/SchemaFormPropertyKindJson.vue
+++ b/src/schemas/components/SchemaFormPropertyKindJson.vue
@@ -6,14 +6,19 @@
 </template>
 
 <script lang="ts" setup>
-  import { State } from '@prefecthq/prefect-design'
+  import { State, isDefined } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import SchemaFormPropertyErrors from '@/schemas/components/SchemaFormPropertyErrors.vue'
+  import { useSchemaProperty } from '@/schemas/compositions/useSchemaProperty'
+  import { SchemaProperty } from '@/schemas/types/schema'
   import { PrefectKindJson } from '@/schemas/types/schemaValues'
   import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
   import { getAllChildSchemaPropertyErrors } from '@/schemas/utilities/errors'
+  import { getSchemaPropertyDefaultValue } from '@/schemas/utilities/properties'
+  import { stringify } from '@/utilities/json'
 
   const props = defineProps<{
+    property: SchemaProperty,
     value: PrefectKindJson,
     errors: SchemaValueError[],
     state: State,
@@ -22,6 +27,10 @@
   const emit = defineEmits<{
     'update:value': [PrefectKindJson],
   }>()
+
+  const { property } = useSchemaProperty(() => props.property)
+  const defaultValue = getSchemaPropertyDefaultValue(property.value)
+  const childErrors = computed(() => getAllChildSchemaPropertyErrors(props.errors))
 
   const value = computed({
     get() {
@@ -43,5 +52,7 @@
     },
   })
 
-  const childErrors = computed(() => getAllChildSchemaPropertyErrors(props.errors))
+  if (!isDefined(value.value) && isDefined(defaultValue)) {
+    value.value = stringify(defaultValue)
+  }
 </script>

--- a/src/schemas/compositions/useSchemaPropertyInput.ts
+++ b/src/schemas/compositions/useSchemaPropertyInput.ts
@@ -20,7 +20,7 @@ export function useSchemaPropertyInput(schemaProperty: MaybeRefOrGetter<SchemaPr
 
     if (!isPrefectKindValue(propertyValue.value)) {
       return withProps(SchemaFormPropertyInput, {
-        property: property,
+        property,
         value: propertyValue.value,
         errors,
         state,
@@ -30,6 +30,7 @@ export function useSchemaPropertyInput(schemaProperty: MaybeRefOrGetter<SchemaPr
 
     if (isPrefectKindValue(propertyValue.value, 'json')) {
       return withProps(SchemaFormPropertyKindJson, {
+        property,
         value: propertyValue.value,
         errors,
         state,
@@ -53,7 +54,7 @@ export function useSchemaPropertyInput(schemaProperty: MaybeRefOrGetter<SchemaPr
 
     if (isPrefectKindValue(propertyValue.value, 'none')) {
       return withProps(SchemaFormPropertyInput, {
-        property: property,
+        property,
         value: propertyValue.value,
         errors,
         state,


### PR DESCRIPTION
# Description
When switching to json we can fill in the default values so that the user has something to work from rather than just showing them an empty json input. 

<img width="811" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/9823bbf7-4837-45cc-885d-5cb83d4227c7">

closes https://github.com/PrefectHQ/prefect-ui-library/issues/2244