### PR TITLE
Add pause-deployment and resume-deployment actions from nebula-ui

### DIFF
--- a/src/automations/components/AutomationActionInput.vue
+++ b/src/automations/components/AutomationActionInput.vue
@@ -1,0 +1,39 @@
+<template>
+  <component :is="input.component" v-bind="input.props" class="automation-action-input" />
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import AutomationActionPauseDeploymentInput from '@/automations/components/AutomationActionPauseDeploymentInput.vue'
+  import AutomationActionResumeDeploymentInput from '@/automations/components/AutomationActionResumeDeploymentInput.vue'
+  import { AutomationAction } from '@/automations/types'
+  import { withProps } from '@/utilities'
+
+  const props = defineProps<{
+    action: Partial<AutomationAction>,
+  }>()
+
+  const emit = defineEmits<{
+    'update:action': [Partial<AutomationAction>],
+  }>()
+
+  const input = computed(() => {
+    switch (props.action.type) {
+      case 'pause-deployment':
+        return withProps(AutomationActionPauseDeploymentInput, {
+          action: props.action,
+          'onUpdate:action': value => emit('update:action', value),
+        })
+      case 'resume-deployment':
+        return withProps(AutomationActionResumeDeploymentInput, {
+          action: props.action,
+          'onUpdate:action': value => emit('update:action', value),
+        })
+      case undefined:
+        throw new Error('AutomationActionInput.vue action.type is undefined')
+      default:
+        const exhaustive: never = props.action
+        throw new Error(`AutomationActionInput.vue missing case for action type: ${(exhaustive as Partial<AutomationAction>).type}`)
+    }
+  })
+</script>

--- a/src/automations/components/AutomationActionPauseDeploymentInput.vue
+++ b/src/automations/components/AutomationActionPauseDeploymentInput.vue
@@ -1,0 +1,32 @@
+<template>
+  <p-content class="automation-action-pause-deployment">
+    <p-label label="Deployment To Pause">
+      <template #default="{ id }">
+        <AutomationDeploymentCombobox :id="id" v-model:selected="deploymentId" allow-unset />
+      </template>
+    </p-label>
+  </p-content>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import AutomationDeploymentCombobox from '@/automations/components/AutomationDeploymentCombobox.vue'
+  import { AutomationActionPauseDeployment } from '@/automations/types/actions'
+
+  const props = defineProps<{
+    action: Partial<AutomationActionPauseDeployment>,
+  }>()
+
+  const emit = defineEmits<{
+    (event: 'update:action', value: Partial<AutomationActionPauseDeployment>): void,
+  }>()
+
+  const deploymentId = computed({
+    get() {
+      return props.action.deploymentId ?? null
+    },
+    set(deploymentId) {
+      emit('update:action', { ...props.action, deploymentId })
+    },
+  })
+</script>

--- a/src/automations/components/AutomationActionResumeDeploymentInput.vue
+++ b/src/automations/components/AutomationActionResumeDeploymentInput.vue
@@ -1,0 +1,32 @@
+<template>
+  <p-content class="automation-action-resume-deployment">
+    <p-label label="Deployment To Resume">
+      <template #default="{ id }">
+        <AutomationDeploymentCombobox :id="id" v-model:selected="deploymentId" />
+      </template>
+    </p-label>
+  </p-content>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import AutomationDeploymentCombobox from '@/automations/components/AutomationDeploymentCombobox.vue'
+  import { AutomationActionResumeDeployment } from '@/automations/types/actions'
+
+  const props = defineProps<{
+    action: Partial<AutomationActionResumeDeployment>,
+  }>()
+
+  const emit = defineEmits<{
+    (event: 'update:action', value: Partial<AutomationActionResumeDeployment>): void,
+  }>()
+
+  const deploymentId = computed({
+    get() {
+      return props.action.deploymentId ?? null
+    },
+    set(deploymentId) {
+      emit('update:action', { ...props.action, deploymentId })
+    },
+  })
+</script>

--- a/src/automations/components/AutomationDeploymentCombobox.vue
+++ b/src/automations/components/AutomationDeploymentCombobox.vue
@@ -1,0 +1,31 @@
+<template>
+  <DeploymentCombobox v-model:selected="internalSelected" allow-unset empty-message="Infer Deployment" class="automation-deployment-combobox">
+    <template #option="{ option }">
+      <template v-if="option.value === null">
+        Infer Deployment
+      </template>
+    </template>
+  </DeploymentCombobox>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import DeploymentCombobox from '@/components/DeploymentCombobox.vue'
+
+  const props = defineProps<{
+    selected: string | string[] | null | undefined,
+  }>()
+
+  const emit = defineEmits<{
+    (event: 'update:selected', value: string | string[] | null): void,
+  }>()
+
+  const internalSelected = computed({
+    get() {
+      return props.selected ?? null
+    },
+    set(selected: string | string[] | null) {
+      emit('update:selected', selected)
+    },
+  })
+</script>

--- a/src/automations/index.ts
+++ b/src/automations/index.ts
@@ -1,0 +1,5 @@
+export * from './types'
+
+export {
+  default as AutomationActionInput
+} from './components/AutomationActionInput.vue'

--- a/src/automations/maps/actions.ts
+++ b/src/automations/maps/actions.ts
@@ -1,0 +1,55 @@
+/* eslint-disable camelcase */
+import { AutomationAction, AutomationActionPauseDeployment, AutomationActionResumeDeployment } from '@/automations/types/actions'
+import { AutomationActionPauseDeploymentResponse, AutomationActionRequest, AutomationActionResponse, AutomationActionResumeDeploymentResponse } from '@/automations/types/api/actions'
+import { MapFunction } from '@/services/Mapper'
+
+export const mapAutomationActionResponseToAutomationAction: MapFunction<AutomationActionResponse, AutomationAction> = function(response) {
+  switch (response.type) {
+    case 'pause-deployment':
+    case 'resume-deployment':
+      return mapPauseResumeDeploymentResponse(response)
+    default:
+      const exhaustive: never = response
+      throw new Error(`Automation action type is missing case for: ${(exhaustive as AutomationActionResponse).type}`)
+  }
+}
+
+export const mapAutomationActionToAutomationActionRequest: MapFunction<AutomationAction, AutomationActionRequest> = function(response) {
+  switch (response.type) {
+    case 'pause-deployment':
+    case 'resume-deployment':
+      return mapPauseResumeDeploymentRequest(response)
+    default:
+      const exhaustive: never = response
+      throw new Error(`Automation action type is missing case for: ${(exhaustive as AutomationActionResponse).type}`)
+  }
+}
+
+function mapPauseResumeDeploymentRequest(action: AutomationActionPauseDeployment | AutomationActionResumeDeployment): AutomationActionPauseDeploymentResponse | AutomationActionResumeDeploymentResponse {
+  if (!action.deploymentId) {
+    return {
+      type: action.type,
+      source: 'inferred',
+    }
+  }
+
+  return {
+    type: action.type,
+    source: 'selected',
+    deployment_id: action.deploymentId,
+  }
+}
+
+function mapPauseResumeDeploymentResponse(action: AutomationActionPauseDeploymentResponse | AutomationActionResumeDeploymentResponse): AutomationActionPauseDeployment | AutomationActionResumeDeployment {
+  if (action.source === 'inferred') {
+    return {
+      type: action.type,
+      deploymentId: null,
+    }
+  }
+
+  return {
+    type: action.type,
+    deploymentId: action.deployment_id,
+  }
+}

--- a/src/automations/types/actions.ts
+++ b/src/automations/types/actions.ts
@@ -1,0 +1,234 @@
+import { Require } from '@/types/utilities'
+import { createTuple, isNullish, isRecord, isString } from '@/utilities'
+
+export const { values: automationActionTypes, isValue: isAutomationActionType } = createTuple([
+  // 'cancel-flow-run',
+  'pause-deployment',
+  'resume-deployment',
+  // 'pause-work-queue',
+  // 'resume-work-queue',
+  // 'run-deployment',
+  // 'send-notification',
+  // 'suspend-flow-run',
+  // 'pause-automation',
+  // 'resume-automation',
+  // 'pause-work-pool',
+  // 'resume-work-pool',
+])
+
+export type AutomationActionType = typeof automationActionTypes[number]
+
+export const automationActionTypeLabels = {
+  'pause-deployment': 'Pause a deployment',
+  'resume-deployment': 'Resume a deployment',
+} as const satisfies Record<AutomationActionType, string>
+
+/**
+ * Utility type for creating individual automation action types.
+ * Enforces `type` is of type `AutomationActionType`.
+ */
+export type AutomationActionWithType<
+  TType extends AutomationActionType,
+  TRest extends Record<string, unknown> = Record<never, never>
+> = { type: TType } & TRest
+
+function isAutomationActionTypeRecord<T extends AutomationActionType>(value: unknown, type: T): value is ({ type: T } & Record<string, unknown>) {
+  return isRecord(value) && 'type' in value && value.type === type
+}
+
+// type AutomationActionRunDeployment = AutomationActionWithType<'run-deployment', {
+//   deploymentId?: string | null,
+//   parameters: SchemaValues | null,
+//   jobVariables?: Record<string, unknown>,
+// }>
+
+// function isAutomationActionRunDeployment(value: unknown): value is AutomationActionRunDeployment {
+//   if (!isAutomationActionTypeRecord(value, 'run-deployment')) {
+//     return false
+//   }
+
+//   const isValidDeploymentId = isString(value.deploymentId) || isNullish(value.deploymentId)
+//   const isValidParameters = isRecord(value.parameters) || value.parameters === null
+
+//   return isValidDeploymentId && isValidParameters
+// }
+
+export type AutomationActionPauseDeployment = AutomationActionWithType<'pause-deployment', {
+  deploymentId?: string | null,
+}>
+
+export function isAutomationActionPauseDeployment(value: unknown): value is AutomationActionPauseDeployment {
+  if (!isAutomationActionTypeRecord(value, 'pause-deployment')) {
+    return false
+  }
+
+  const isValidDeploymentId = isString(value.deploymentId) || isNullish(value.deploymentId)
+
+  return isValidDeploymentId
+}
+
+export type AutomationActionResumeDeployment = AutomationActionWithType<'resume-deployment', {
+  deploymentId?: string | null,
+}>
+
+export function isAutomationActionResumeDeployment(value: unknown): value is AutomationActionResumeDeployment {
+  if (!isAutomationActionTypeRecord(value, 'resume-deployment')) {
+    return false
+  }
+
+  const isValidDeploymentId = isString(value.deploymentId) || isNullish(value.deploymentId)
+
+  return isValidDeploymentId
+}
+
+
+// type AutomationActionCancelFlowRun = AutomationActionWithType<'cancel-flow-run'>
+
+// function isAutomationActionCancelFlowRun(value: unknown): value is AutomationActionCancelFlowRun {
+//   return isAutomationActionTypeRecord(value, 'cancel-flow-run')
+// }
+
+// type AutomationActionPauseFlowRun = AutomationActionWithType<'suspend-flow-run'>
+
+// function isAutomationActionPauseFlowRun(value: unknown): value is AutomationActionPauseFlowRun {
+//   return isAutomationActionTypeRecord(value, 'suspend-flow-run')
+// }
+
+// type AutomationActionSendNotification = AutomationActionWithType<'send-notification', {
+//   blockDocumentId: string,
+//   subject: string,
+//   body: string,
+// }>
+
+// function isAutomationActionSendNotification(value: unknown): value is AutomationActionSendNotification {
+//   if (!isAutomationActionTypeRecord(value, 'send-notification')) {
+//     return false
+//   }
+
+//   const isValidBlockDocumentId = isString(value.blockDocumentId) || isNullish(value.blockDocumentId)
+//   const isValidSubject = isString(value.subject)
+//   const isValidBody = isString(value.body)
+
+//   return isValidBlockDocumentId && isValidSubject && isValidBody
+// }
+
+// type AutomationActionPauseWorkQueue = AutomationActionWithType<'pause-work-queue', {
+//   workQueueId?: string | null,
+// }>
+
+// function isAutomationActionPauseWorkQueue(value: unknown): value is AutomationActionPauseWorkQueue {
+//   if (!isAutomationActionTypeRecord(value, 'pause-work-queue')) {
+//     return false
+//   }
+
+//   const isValidWorkQueueId = isString(value.workQueueId) || isNullish(value.workQueueId)
+
+//   return isValidWorkQueueId
+// }
+
+// type AutomationActionResumeWorkQueue = AutomationActionWithType<'resume-work-queue', {
+//   workQueueId?: string | null,
+// }>
+
+// function isAutomationActionResumeWorkQueue(value: unknown): value is AutomationActionResumeWorkQueue {
+//   if (!isAutomationActionTypeRecord(value, 'resume-work-queue')) {
+//     return false
+//   }
+
+//   const isValidWorkQueueId = isString(value.workQueueId) || isNullish(value.workQueueId)
+
+//   return isValidWorkQueueId
+// }
+
+// type AutomationActionPauseAutomation = AutomationActionWithType<'pause-automation', {
+//   automationId?: string | null,
+// }>
+
+// function isAutomationActionPauseAutomation(value: unknown): value is AutomationActionPauseAutomation {
+//   if (!isAutomationActionTypeRecord(value, 'pause-automation')) {
+//     return false
+//   }
+
+//   const isValidAutomationId = isString(value.automationId) || isNullish(value.automationId)
+
+//   return isValidAutomationId
+// }
+
+// type AutomationActionResumeAutomation = AutomationActionWithType<'resume-automation', {
+//   automationId?: string | null,
+// }>
+
+// function isAutomationActionResumeAutomation(value: unknown): value is AutomationActionResumeAutomation {
+//   if (!isAutomationActionTypeRecord(value, 'resume-automation')) {
+//     return false
+//   }
+
+//   const isValidAutomationId = isString(value.automationId) || isNullish(value.automationId)
+
+//   return isValidAutomationId
+// }
+
+// type AutomationActionPauseWorkPool = AutomationActionWithType<'pause-work-pool', {
+//   workPoolId?: string | null,
+// }>
+
+// function isAutomationActionPauseWorkPool(value: unknown): value is AutomationActionPauseWorkPool {
+//   if (!isAutomationActionTypeRecord(value, 'pause-work-pool')) {
+//     return false
+//   }
+
+//   const isValidWorkPoolId = isString(value.workPoolId) || isNullish(value.workPoolId)
+
+//   return isValidWorkPoolId
+// }
+
+// type AutomationActionResumeWorkPool = AutomationActionWithType<'resume-work-pool', {
+//   workPoolId?: string | null,
+// }>
+
+// function isAutomationActionResumeWorkPool(value: unknown): value is AutomationActionResumeWorkPool {
+//   if (!isAutomationActionTypeRecord(value, 'resume-work-pool')) {
+//     return false
+//   }
+
+//   const isValidWorkPoolId = isString(value.workPoolId) || isNullish(value.workPoolId)
+
+//   return isValidWorkPoolId
+// }
+
+export type AutomationAction =
+  // | AutomationActionCancelFlowRun
+  | AutomationActionPauseDeployment
+  | AutomationActionResumeDeployment
+  // | AutomationActionResumeWorkQueue
+  // | AutomationActionPauseFlowRun
+  // | AutomationActionPauseWorkQueue
+  // | AutomationActionRunDeployment
+  // | AutomationActionSendNotification
+  // | AutomationActionPauseAutomation
+  // | AutomationActionResumeAutomation
+  // | AutomationActionPauseWorkPool
+  // | AutomationActionResumeWorkPool
+
+export type AutomationActionFields<T extends AutomationAction> = Require<Partial<T>, 'type'>
+
+const actionTypeGuardMap = {
+  // 'cancel-flow-run': isAutomationActionCancelFlowRun,
+  'pause-deployment': isAutomationActionPauseDeployment,
+  'resume-deployment': isAutomationActionResumeDeployment,
+  // 'pause-work-queue': isAutomationActionPauseWorkQueue,
+  // 'resume-work-queue': isAutomationActionResumeWorkQueue,
+  // 'run-deployment': isAutomationActionRunDeployment,
+  // 'send-notification': isAutomationActionSendNotification,
+  // 'suspend-flow-run': isAutomationActionPauseFlowRun,
+  // 'pause-automation': isAutomationActionPauseAutomation,
+  // 'resume-automation': isAutomationActionResumeAutomation,
+  // 'pause-work-pool': isAutomationActionPauseWorkPool,
+  // 'resume-work-pool': isAutomationActionResumeWorkPool,
+} satisfies Record<AutomationActionType, (value: unknown) => boolean>
+
+export function isAutomationAction(value: unknown): value is AutomationAction {
+  const guards = Object.values(actionTypeGuardMap)
+
+  return guards.some(guard => guard(value))
+}

--- a/src/automations/types/api/actions.ts
+++ b/src/automations/types/api/actions.ts
@@ -1,0 +1,34 @@
+import { AutomationActionWithType, isAutomationActionType } from '@/automations/types/actions'
+import { isRecord } from '@/utilities'
+
+export type AutomationActionResponse =
+  | AutomationActionPauseDeploymentResponse
+  | AutomationActionResumeDeploymentResponse
+
+export function isAutomationActionResponse(value: unknown): value is AutomationActionResponse {
+  return isRecord(value) && isAutomationActionType(value.type)
+}
+
+export type AutomationActionRequest = AutomationActionResponse
+
+export type AutomationActionPauseDeploymentSelectedResponse = {
+  source: 'selected',
+  deployment_id: string,
+}
+
+export type AutomationActionPauseDeploymentInferredResponse = {
+  source: 'inferred',
+}
+
+export type AutomationActionPauseDeploymentResponse = AutomationActionWithType<'pause-deployment', AutomationActionPauseDeploymentSelectedResponse | AutomationActionPauseDeploymentInferredResponse>
+
+export type AutomationActionResumeDeploymentSelectedResponse = {
+  source: 'selected',
+  deployment_id: string,
+}
+
+export type AutomationActionResumeDeploymentInferredResponse = {
+  source: 'inferred',
+}
+
+export type AutomationActionResumeDeploymentResponse = AutomationActionWithType<'resume-deployment', AutomationActionResumeDeploymentSelectedResponse | AutomationActionResumeDeploymentInferredResponse>

--- a/src/automations/types/index.ts
+++ b/src/automations/types/index.ts
@@ -1,0 +1,19 @@
+export type {
+  AutomationActionResponse
+} from './api/actions'
+
+export {
+  isAutomationActionResponse
+} from './api/actions'
+
+export type {
+  AutomationAction,
+  AutomationActionType
+} from './actions'
+
+export {
+  isAutomationAction,
+  automationActionTypes,
+  isAutomationActionType,
+  automationActionTypeLabels
+} from './actions'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import '@prefecthq/graphs/dist/style.css'
 
+// core functionality
 export * from './components'
 export * from './compositions'
 export * from './formatters'
@@ -11,7 +12,10 @@ export * from './router'
 export * from './services'
 export * from './types'
 export * from './utilities'
+
+// feature specific
 export * from './schemas'
+export * from './automations'
 
 import '@/styles/style.css'
 

--- a/src/maps/index.ts
+++ b/src/maps/index.ts
@@ -1,3 +1,4 @@
+import { mapAutomationActionResponseToAutomationAction, mapAutomationActionToAutomationActionRequest } from '@/automations/maps/actions'
 import { mapArtifactCollectionResponseToArtifactCollection, mapArtifactResponseToArtifact } from '@/maps/artifact'
 import { mapBlockDocumentResponseToBlockDocument, mapBlockDocumentToSelectOption } from '@/maps/blockDocument'
 import { mapBlockDocumentCreateToBlockDocumentCreateRequest } from '@/maps/blockDocumentCreate'
@@ -78,6 +79,8 @@ export const maps = {
   ArtifactResponse: { Artifact: mapArtifactResponseToArtifact },
   ArtifactCollectionResponse: { ArtifactCollection: mapArtifactCollectionResponseToArtifactCollection },
   ArtifactsFilter: { ArtifactsFilterRequest: mapArtifactsFilter },
+  AutomationActionResponse: { AutomationAction: mapAutomationActionResponseToAutomationAction },
+  AutomationAction: { AutomationActionRequest: mapAutomationActionToAutomationActionRequest },
   BlockDocument: { SelectOption: mapBlockDocumentToSelectOption },
   BlockDocumentCreate: { BlockDocumentCreateRequest: mapBlockDocumentCreateToBlockDocumentCreateRequest },
   BlockDocumentFilter: { BlockDocumentFilterRequest: mapBlockDocumentFilter },


### PR DESCRIPTION
# Description
First piece of ui work in the broader goal of bringing automations to oss. Sets up the ability for automation actions to be defined in ui-library that can be shared with oss and cloud. 

Starting by bringing over the `pause-deployment` and `resume-deployment` actions into ui-library. Creating exports that nebula-ui can import and extend. 