### PR TITLE
Automations: Move "Cancel a flow run" action over from cloud

### DIFF
--- a/src/automations/components/AutomationActionInput.vue
+++ b/src/automations/components/AutomationActionInput.vue
@@ -1,5 +1,7 @@
 <template>
-  <component :is="input.component" v-bind="input.props" class="automation-action-input" />
+  <template v-if="input">
+    <component :is="input.component" v-bind="input.props" class="automation-action-input" />
+  </template>
 </template>
 
 <script lang="ts" setup>
@@ -24,13 +26,19 @@
           action: props.action,
           'onUpdate:action': value => emit('update:action', value),
         })
+
       case 'resume-deployment':
         return withProps(AutomationActionResumeDeploymentInput, {
           action: props.action,
           'onUpdate:action': value => emit('update:action', value),
         })
+
+      case 'cancel-flow-run':
+        return null
+
       case undefined:
         throw new Error('AutomationActionInput.vue action.type is undefined')
+
       default:
         const exhaustive: never = props.action
         throw new Error(`AutomationActionInput.vue missing case for action type: ${(exhaustive as Partial<AutomationAction>).type}`)

--- a/src/automations/maps/actions.ts
+++ b/src/automations/maps/actions.ts
@@ -8,6 +8,8 @@ export const mapAutomationActionResponseToAutomationAction: MapFunction<Automati
     case 'pause-deployment':
     case 'resume-deployment':
       return mapPauseResumeDeploymentResponse(response)
+    case 'cancel-flow-run':
+      return response
     default:
       const exhaustive: never = response
       throw new Error(`Automation action type is missing case for: ${(exhaustive as AutomationActionResponse).type}`)
@@ -19,6 +21,8 @@ export const mapAutomationActionToAutomationActionRequest: MapFunction<Automatio
     case 'pause-deployment':
     case 'resume-deployment':
       return mapPauseResumeDeploymentRequest(response)
+    case 'cancel-flow-run':
+      return response
     default:
       const exhaustive: never = response
       throw new Error(`Automation action type is missing case for: ${(exhaustive as AutomationActionResponse).type}`)

--- a/src/automations/types/actions.ts
+++ b/src/automations/types/actions.ts
@@ -2,7 +2,7 @@ import { Require } from '@/types/utilities'
 import { createTuple, isNullish, isRecord, isString } from '@/utilities'
 
 export const { values: automationActionTypes, isValue: isAutomationActionType } = createTuple([
-  // 'cancel-flow-run',
+  'cancel-flow-run',
   'pause-deployment',
   'resume-deployment',
   // 'pause-work-queue',
@@ -21,6 +21,7 @@ export type AutomationActionType = typeof automationActionTypes[number]
 export const automationActionTypeLabels = {
   'pause-deployment': 'Pause a deployment',
   'resume-deployment': 'Resume a deployment',
+  'cancel-flow-run': 'Cancel a flow run',
 } as const satisfies Record<AutomationActionType, string>
 
 /**
@@ -82,11 +83,11 @@ export function isAutomationActionResumeDeployment(value: unknown): value is Aut
 }
 
 
-// type AutomationActionCancelFlowRun = AutomationActionWithType<'cancel-flow-run'>
+export type AutomationActionCancelFlowRun = AutomationActionWithType<'cancel-flow-run'>
 
-// function isAutomationActionCancelFlowRun(value: unknown): value is AutomationActionCancelFlowRun {
-//   return isAutomationActionTypeRecord(value, 'cancel-flow-run')
-// }
+function isAutomationActionCancelFlowRun(value: unknown): value is AutomationActionCancelFlowRun {
+  return isAutomationActionTypeRecord(value, 'cancel-flow-run')
+}
 
 // type AutomationActionPauseFlowRun = AutomationActionWithType<'suspend-flow-run'>
 
@@ -197,7 +198,7 @@ export function isAutomationActionResumeDeployment(value: unknown): value is Aut
 // }
 
 export type AutomationAction =
-  // | AutomationActionCancelFlowRun
+  | AutomationActionCancelFlowRun
   | AutomationActionPauseDeployment
   | AutomationActionResumeDeployment
   // | AutomationActionResumeWorkQueue
@@ -213,7 +214,7 @@ export type AutomationAction =
 export type AutomationActionFields<T extends AutomationAction> = Require<Partial<T>, 'type'>
 
 const actionTypeGuardMap = {
-  // 'cancel-flow-run': isAutomationActionCancelFlowRun,
+  'cancel-flow-run': isAutomationActionCancelFlowRun,
   'pause-deployment': isAutomationActionPauseDeployment,
   'resume-deployment': isAutomationActionResumeDeployment,
   // 'pause-work-queue': isAutomationActionPauseWorkQueue,

--- a/src/automations/types/api/actions.ts
+++ b/src/automations/types/api/actions.ts
@@ -4,6 +4,7 @@ import { isRecord } from '@/utilities'
 export type AutomationActionResponse =
   | AutomationActionPauseDeploymentResponse
   | AutomationActionResumeDeploymentResponse
+  | AutomationActionCancelFlowRunResponse
 
 export function isAutomationActionResponse(value: unknown): value is AutomationActionResponse {
   return isRecord(value) && isAutomationActionType(value.type)
@@ -32,3 +33,5 @@ export type AutomationActionResumeDeploymentInferredResponse = {
 }
 
 export type AutomationActionResumeDeploymentResponse = AutomationActionWithType<'resume-deployment', AutomationActionResumeDeploymentSelectedResponse | AutomationActionResumeDeploymentInferredResponse>
+
+export type AutomationActionCancelFlowRunResponse = AutomationActionWithType<'cancel-flow-run'>


### PR DESCRIPTION
# Description
Moves all the necessary types and and pieces of the cancel a flow run action over from cloud. 