### PR TITLE
Enhancement: variable names tooltip

### DIFF
--- a/src/components/VariablesTable.vue
+++ b/src/components/VariablesTable.vue
@@ -3,10 +3,18 @@
     <p-list-header sticky>
       <ResultsCount v-if="selectedVariables.length == 0" :label="localization.info.variable" :count="variablesCount" />
       <SelectedCount v-else :count="selectedVariables.length" />
-      <VariablesDeleteButton v-if="can.delete.variable" :variable-ids="selectedVariables.map(variable => variable.id)" @delete="deleteVariables" />
+      <VariablesDeleteButton
+        v-if="can.delete.variable"
+        :variable-ids="selectedVariables.map(variable => variable.id)"
+        @delete="deleteVariables"
+      />
 
       <template #controls>
-        <SearchInput v-model="variableLike" :placeholder="localization.info.variablesSearch" :label="localization.info.variablesSearch" />
+        <SearchInput
+          v-model="variableLike"
+          :placeholder="localization.info.variablesSearch"
+          :label="localization.info.variablesSearch"
+        />
         <VariableTagsInput v-model:selected="filter.variables.tags.name" class="variables-table__tags-input" />
       </template>
 
@@ -15,12 +23,16 @@
       </template>
     </p-list-header>
 
-    <p-table :selected="can.delete.variable ? selectedVariables : undefined" :data="variables" :columns="columns" :column-classes="columnClass" @update:selected="selectedVariables = $event">
+    <p-table
+      :selected="can.delete.variable ? selectedVariables : undefined"
+      :data="variables"
+      :columns="columns"
+      :column-classes="columnClass"
+      @update:selected="selectedVariables = $event"
+    >
       <template #name="{ row }">
-        <div class="variables-table__name">
-          <p-tooltip :text="row.name">
-            {{ row.name }}
-          </p-tooltip>
+        <div class="variables-table__name" :title="row.name">
+          {{ row.name }}
         </div>
       </template>
 
@@ -186,6 +198,6 @@
 }
 
 .variables-table__name { @apply
-  max-w-[124px]
+  max-w-[192px]
 }
 </style>

--- a/src/components/VariablesTable.vue
+++ b/src/components/VariablesTable.vue
@@ -18,7 +18,9 @@
     <p-table :selected="can.delete.variable ? selectedVariables : undefined" :data="variables" :columns="columns" :column-classes="columnClass" @update:selected="selectedVariables = $event">
       <template #name="{ row }">
         <div class="variables-table__name">
-          {{ row.name }}
+          <p-tooltip :text="row.name">
+            {{ row.name }}
+          </p-tooltip>
         </div>
       </template>
 
@@ -100,7 +102,7 @@
     {
       property: 'name',
       label: 'Name',
-      width: '124px',
+      width: '192px',
     },
     {
       property: 'value',


### PR DESCRIPTION
This PR gives variable names a little more space and adds a title attr to the wrapping element to make sure even truncated values are always visible

Before:
<img width="1256" alt="Screenshot 2024-04-02 at 3 03 02 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/42fe6dc3-1252-4c05-acd5-47462ace9c10">

After:
<img width="1259" alt="Screenshot 2024-04-02 at 3 10 23 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/8b775e46-0268-4bd8-9d7c-5de3558b0f50">
