### PR TITLE
Move send notification action from cloud

### DIFF
--- a/src/automations/components/AutomationActionInput.vue
+++ b/src/automations/components/AutomationActionInput.vue
@@ -16,6 +16,7 @@
   import AutomationActionResumeWorkPoolInput from '@/automations/components/AutomationActionResumeWorkPoolInput.vue'
   import AutomationActionResumeWorkQueueInput from '@/automations/components/AutomationActionResumeWorkQueueInput.vue'
   import AutomationActionRunDeploymentInput from '@/automations/components/AutomationActionRunDeploymentInput.vue'
+  import AutomationActionSendNotificationInput from '@/automations/components/AutomationActionSendNotificationInput.vue'
   import { AutomationAction } from '@/automations/types'
   import { withProps } from '@/utilities'
 
@@ -85,6 +86,12 @@
 
       case 'resume-automation':
         return withProps(AutomationActionResumeAutomationInput, {
+          action: props.action,
+          'onUpdate:action': value => emit('update:action', value),
+        })
+
+      case 'send-notification':
+        return withProps(AutomationActionSendNotificationInput, {
           action: props.action,
           'onUpdate:action': value => emit('update:action', value),
         })

--- a/src/automations/components/AutomationActionSendNotificationInput.vue
+++ b/src/automations/components/AutomationActionSendNotificationInput.vue
@@ -1,0 +1,108 @@
+<template>
+  <p-content class="automation-action-send-notification">
+    <p-label label="Block" :state="blockDocumentState" :message="blockDocumentError">
+      <BlockCapabilityBlockDocumentInput v-model="blockDocumentId" :state="blockDocumentState" capability="notify" required use-modal />
+    </p-label>
+
+    <template v-if="isAnonymousBlock">
+      <p-message info>
+        This notification action is using an anonymous block. This is most likely because it was migrated from an existing notification.
+      </p-message>
+    </template>
+
+    <p-label label="Subject" :state="subjectState" :message="subjectError">
+      <p-code-input v-model="subject" :state="subjectState" lang="jinja" />
+    </p-label>
+
+    <p-label label="Body" :state="bodyState" :message="bodyError">
+      <p-code-input v-model="body" :state="bodyState" rows="5" lang="jinja" />
+    </p-label>
+
+    <p-message info>
+      Event fields and any of the following objects present in the triggering event can be used in notification templates: flow, deployment, flow run, work pool, work queue, metric.
+    </p-message>
+  </p-content>
+</template>
+
+<script lang="ts" setup>
+  import { useValidation, ValidationRule } from '@prefecthq/vue-compositions'
+  import { computed } from 'vue'
+  import { AutomationActionSendNotification } from '@/automations/types/actions'
+  import BlockCapabilityBlockDocumentInput from '@/components/BlockCapabilityBlockDocumentInput.vue'
+  import { useBlockDocument, useWorkspaceApi } from '@/compositions'
+  import { timeout } from '@/utilities/time'
+  import { isRequired } from '@/utilities/validation'
+
+  const props = defineProps<{
+    action: Partial<AutomationActionSendNotification>,
+  }>()
+
+  const emit = defineEmits<{
+    (event: 'update:action', value: Partial<AutomationActionSendNotification>): void,
+  }>()
+
+  const api = useWorkspaceApi()
+
+  const isValidSubject: ValidationRule<string> = async (value, label, options) => {
+    return await isValidTemplate(value, label, options)
+  }
+
+  const isValidBody: ValidationRule<string> = async (value, label, options) => {
+    return await isValidTemplate(value, label, options)
+  }
+
+  const isValidTemplate: ValidationRule<string> = async (value, label, { signal, source, previousValue }) => {
+    if (value === previousValue) {
+      return
+    }
+
+    if (source === 'validator') {
+      await timeout(3000, signal)
+    }
+
+    if (signal.aborted) {
+      return
+    }
+
+    const valid = await api.automations.validateTemplate(value)
+
+    if (valid === true) {
+      return true
+    }
+
+    return valid
+  }
+
+  const blockDocumentId = computed({
+    get() {
+      return props.action.blockDocumentId ?? ''
+    },
+    set(blockDocumentId) {
+      emit('update:action', { ...props.action, blockDocumentId })
+    },
+  })
+  const { state: blockDocumentState, error: blockDocumentError } = useValidation(blockDocumentId, 'Block', isRequired('Block'))
+
+  const { blockDocument } = useBlockDocument(blockDocumentId)
+  const isAnonymousBlock = computed(() => blockDocument.value?.isAnonymous ?? false)
+
+  const subject = computed({
+    get() {
+      return props.action.subject ?? ''
+    },
+    set(subject) {
+      emit('update:action', { ...props.action, subject })
+    },
+  })
+  const { state: subjectState, error: subjectError } = useValidation(subject, 'Subject', [isRequired('Subject'), isValidSubject])
+
+  const body = computed({
+    get() {
+      return props.action.body ?? ''
+    },
+    set(body) {
+      emit('update:action', { ...props.action, body })
+    },
+  })
+  const { state: bodyState, error: bodyError } = useValidation(body, 'Body', [isRequired('Body'), isValidBody])
+</script>

--- a/src/automations/components/AutomationActionSendNotificationInput.vue
+++ b/src/automations/components/AutomationActionSendNotificationInput.vue
@@ -19,7 +19,7 @@
     </p-label>
 
     <p-message info>
-      Event fields and any of the following objects present in the triggering event can be used in notification templates: flow, deployment, flow run, work pool, work queue, metric.
+      In addition to any fields present on the triggering event, the following objects can be used in notification templates: <p-code inline>flow</p-code>, <p-code inline>deployment</p-code>, <p-code inline>flow_run</p-code>, <p-code inline>work_pool</p-code>, <p-code inline>work_queue</p-code>, and <p-code inline>metric</p-code>.
     </p-message>
   </p-content>
 </template>

--- a/src/automations/maps/actions.ts
+++ b/src/automations/maps/actions.ts
@@ -9,7 +9,8 @@ import {
   AutomationActionResumeDeployment,
   AutomationActionResumeWorkPool,
   AutomationActionResumeWorkQueue,
-  AutomationActionRunDeployment
+  AutomationActionRunDeployment,
+  AutomationActionSendNotification
 } from '@/automations/types/actions'
 import {
   AutomationActionPauseAutomationResponse,
@@ -22,7 +23,8 @@ import {
   AutomationActionResumeDeploymentResponse,
   AutomationActionResumeWorkPoolResponse,
   AutomationActionResumeWorkQueueResponse,
-  AutomationActionRunDeploymentResponse
+  AutomationActionRunDeploymentResponse,
+  AutomationActionSendNotificationResponse
 } from '@/automations/types/api/actions'
 import { MapFunction } from '@/services/Mapper'
 
@@ -42,6 +44,8 @@ export const mapAutomationActionResponseToAutomationAction: MapFunction<Automati
     case 'pause-automation':
     case 'resume-automation':
       return mapPauseResumeAutomationRequest(response)
+    case 'send-notification':
+      return mapSendNotificationResponse(response)
     case 'cancel-flow-run':
     case 'suspend-flow-run':
     case 'change-flow-run-state':
@@ -68,6 +72,8 @@ export const mapAutomationActionToAutomationActionRequest: MapFunction<Automatio
     case 'pause-automation':
     case 'resume-automation':
       return mapPauseResumeAutomationRequest(request)
+    case 'send-notification':
+      return mapSendNotificationRequest(request)
     case 'cancel-flow-run':
     case 'suspend-flow-run':
     case 'change-flow-run-state':
@@ -213,5 +219,23 @@ function mapPauseResumeAutomationRequest(action: AutomationActionPauseAutomation
     type: action.type,
     source: 'selected',
     automation_id: action.automationId,
+  }
+}
+
+function mapSendNotificationRequest({ type, blockDocumentId, subject, body }: AutomationActionSendNotification): AutomationActionSendNotificationResponse {
+  return {
+    type,
+    block_document_id: blockDocumentId,
+    subject,
+    body,
+  }
+}
+
+function mapSendNotificationResponse({ type, block_document_id, subject, body }: AutomationActionSendNotificationResponse): AutomationActionSendNotification {
+  return {
+    type,
+    blockDocumentId: block_document_id,
+    subject,
+    body,
   }
 }

--- a/src/automations/types/actions.ts
+++ b/src/automations/types/actions.ts
@@ -16,7 +16,7 @@ export const { values: automationActionTypes, isValue: isAutomationActionType } 
   'resume-work-pool',
   'pause-automation',
   'resume-automation',
-  // 'send-notification',
+  'send-notification',
 ])
 
 export type AutomationActionType = typeof automationActionTypes[number]
@@ -34,6 +34,7 @@ export const automationActionTypeLabels = {
   'resume-work-pool': 'Resume a work pool',
   'pause-automation': 'Pause an automation',
   'resume-automation': 'Resume an automation',
+  'send-notification': 'Send a notification',
 } as const satisfies Record<AutomationActionType, string>
 
 /**
@@ -243,30 +244,26 @@ function isAutomationActionResumeAutomation(value: unknown): value is Automation
   return isValidAutomationId
 }
 
-// type AutomationActionSendNotification = AutomationActionWithType<'send-notification', {
-//   blockDocumentId: string,
-//   subject: string,
-//   body: string,
-// }>
+/*
+ * Send a notification
+ */
+export type AutomationActionSendNotification = AutomationActionWithType<'send-notification', {
+  blockDocumentId: string,
+  subject: string,
+  body: string,
+}>
 
-// function isAutomationActionSendNotification(value: unknown): value is AutomationActionSendNotification {
-//   if (!isAutomationActionTypeRecord(value, 'send-notification')) {
-//     return false
-//   }
+function isAutomationActionSendNotification(value: unknown): value is AutomationActionSendNotification {
+  if (!isAutomationActionTypeRecord(value, 'send-notification')) {
+    return false
+  }
 
-//   const isValidBlockDocumentId = isString(value.blockDocumentId) || isNullish(value.blockDocumentId)
-//   const isValidSubject = isString(value.subject)
-//   const isValidBody = isString(value.body)
+  const isValidBlockDocumentId = isString(value.blockDocumentId) || isNullish(value.blockDocumentId)
+  const isValidSubject = isString(value.subject)
+  const isValidBody = isString(value.body)
 
-//   return isValidBlockDocumentId && isValidSubject && isValidBody
-// }
-
-
-// type AutomationActionPauseFlowRun = AutomationActionWithType<'suspend-flow-run'>
-
-// function isAutomationActionPauseFlowRun(value: unknown): value is AutomationActionPauseFlowRun {
-//   return isAutomationActionTypeRecord(value, 'suspend-flow-run')
-// }
+  return isValidBlockDocumentId && isValidSubject && isValidBody
+}
 
 export type AutomationAction =
   | AutomationActionCancelFlowRun
@@ -281,11 +278,10 @@ export type AutomationAction =
   | AutomationActionResumeWorkPool
   | AutomationActionPauseAutomation
   | AutomationActionResumeAutomation
-  // | AutomationActionPauseFlowRun
-  // | AutomationActionSendNotification
+  | AutomationActionSendNotification
 
 /*
- * if this is giving you a type error you forgot to add a response type for your action to the AutomationAction
+ * if this is giving you a type error you forgot to add a type for your action to the AutomationAction type
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
 const automationActionHasAllActionTypes: Equals<AutomationAction['type'], AutomationActionType> = true
@@ -305,7 +301,7 @@ const actionTypeGuardMap = {
   'resume-work-pool': isAutomationActionResumeWorkPool,
   'pause-automation': isAutomationActionPauseAutomation,
   'resume-automation': isAutomationActionResumeAutomation,
-  // 'send-notification': isAutomationActionSendNotification,
+  'send-notification': isAutomationActionSendNotification,
 } satisfies Record<AutomationActionType, (value: unknown) => boolean>
 
 export function isAutomationAction(value: unknown): value is AutomationAction {

--- a/src/automations/types/api/actions.ts
+++ b/src/automations/types/api/actions.ts
@@ -17,11 +17,12 @@ export type AutomationActionResponse =
 | AutomationActionResumeWorkPoolResponse
 | AutomationActionPauseAutomationResponse
 | AutomationActionResumeAutomationResponse
+| AutomationActionSendNotificationResponse
 
 export type AutomationActionRequest = AutomationActionResponse
 
 /*
- * if this is giving you a type error you forgot to add a response type for your action to the AutomationActionResponseType
+ * if this is giving you a type error you forgot to add a response type for your action to the AutomationActionResponse type
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
 const automationActionResponseHasAllActionTypes: Equals<AutomationActionResponse['type'], AutomationActionType> = true
@@ -176,3 +177,12 @@ export type AutomationActionResumeAutomationInferredResponse = {
 }
 
 export type AutomationActionResumeAutomationResponse = AutomationActionWithType<'resume-automation', AutomationActionResumeAutomationSelectedResponse | AutomationActionResumeAutomationInferredResponse>
+
+/*
+ * Send a notification
+ */
+export type AutomationActionSendNotificationResponse = AutomationActionWithType<'send-notification', {
+  block_document_id: string,
+  subject: string,
+  body: string,
+}>

--- a/src/services/WorkspaceAutomationsApi.ts
+++ b/src/services/WorkspaceAutomationsApi.ts
@@ -1,8 +1,11 @@
+import { isAxiosError, AxiosError } from 'axios'
 import { AutomationResponse } from '@/automations/types/api/automation'
 import { Automation } from '@/automations/types/automation'
 import { AutomationsFilter } from '@/automations/types/filter'
 import { mapper } from '@/services/Mapper'
 import { WorkspaceApi } from '@/services/WorkspaceApi'
+import { Require } from '@/types/utilities'
+import { httpStatus } from '@/utilities/httpStatus'
 
 export class WorkspaceAutomationsApi extends WorkspaceApi {
 
@@ -14,4 +17,36 @@ export class WorkspaceAutomationsApi extends WorkspaceApi {
     return mapper.map('AutomationResponse', data, 'Automation')
   }
 
+  public async validateTemplate(template: string): Promise<string | true> {
+    try {
+      await this.post('/templates/validate', template)
+
+      return true
+    } catch (error) {
+      if (isInvalidAutomationTemplateError(error)) {
+        const { line, message } = error.response.data.error
+
+        return `Error on line ${line}: ${message} `
+      }
+
+      throw error
+    }
+  }
+
+}
+
+type InvalidAutomationTemplateError = {
+  error: {
+    line: number,
+    message: string,
+    source: string,
+  },
+}
+
+function isInvalidAutomationTemplateError(error: unknown): error is Require<AxiosError<InvalidAutomationTemplateError>, 'response'> {
+  if (!isAxiosError(error)) {
+    return false
+  }
+
+  return httpStatus(error).is('UnprocessableEntity')
 }


### PR DESCRIPTION
# Description
Moves all the pieces of the "Send a notification" action from cloud. Noteworthy changes

- The AutomationActionSendNotificationInput component no longer requires passing in the automation. It used to use the automation's trigger to determine the default subject and body. There is now a separate utility in nebula-ui that determines the default value for any action. That way actions can be completely agnostic of the rest of the automation. 
- The template validation endpoint was also moved into the WorkspaceAutomationsApi service. This endpoint has not been implemented in the oss api yet. 