### PR TITLE
Enhancement: Update DEBUG-level log badge colors

### DIFF
--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -2,7 +2,7 @@
   --p-color-log-info-bg: #304A76;
   --p-color-log-info-text: var(--p-color-text-default);
 
-  --p-color-log-debug-bg: #DB6900;
+  --p-color-log-debug-bg: #1e293b;
   --p-color-log-debug-text: var(--p-color-text-default);
 
   --p-color-log-warning-bg: #F79008;
@@ -22,7 +22,7 @@
   --p-color-log-info-bg: #304A76;
   --p-color-log-info-text: var(--p-color-text-inverse);
 
-  --p-color-log-debug-bg: #DB6900;
+  --p-color-log-debug-bg: #1e293b;
   --p-color-log-debug-text: var(--p-color-text-inverse);
 
   --p-color-log-warning-bg: #F79008;


### PR DESCRIPTION
As pointed out in [this thread](https://prefect-community.slack.com/archives/CM28LL405/p1712702403049459), `DEBUG` and `WARNING`-level logs look somewhat-alarmingly similar. This update should bring `DEBUG`-level logs more in line with their intended level of attention. 

Before:

<img width="1497" alt="Screenshot 2024-04-09 at 7 19 59 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/a22abc22-cb2b-41fe-ba1f-9ba6e555d1ec">

<img width="1497" alt="Screenshot 2024-04-09 at 7 19 51 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/1fbb0cc3-4849-4dca-b15e-99349bcd725a">


After:

<img width="1497" alt="Screenshot 2024-04-09 at 7 20 05 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/ebcd4264-0256-477a-896a-757d700730c5">

<img width="1497" alt="Screenshot 2024-04-09 at 7 20 09 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/ec8a0b89-3094-4f4d-94d5-f318981855df">
