### PR TITLE
Remove transparent background from format button - add transparent on hover

### DIFF
--- a/src/components/JsonInput.vue
+++ b/src/components/JsonInput.vue
@@ -62,9 +62,14 @@
 }
 
 .json-input__prettify-button { @apply
+  bg-code
   absolute
   right-2
   top-2;
   z-index: 1;
+}
+
+.json-input__prettify-button:hover { @apply
+  bg-transparent
 }
 </style>


### PR DESCRIPTION
This PR addresses overlay/transparency issues with the format button on the `<JSONInput>` component. 

| Problem | Before | After |
| ---- | ---- | ---- |
| It blurs with validation state of the input | <img width="475" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/6361d809-cbc8-4cbe-b207-64aa664aec2b"> | <img width="444" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/504fb1d1-86d1-4ded-8457-b31c76842f5c"> |
| It blurs with overlapped content | <img width="253" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/34f6a6b3-6aa9-4069-837d-38f5ccd575a6"> | <img width="250" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/eef7d90c-093a-4f04-a92b-6b0874edda1b"> |


> [!Important]
> Since the background is no longer transparent, content can get hidden underneath. To solve that issue, this PR makes the background transparent again on hover. Considered adding a button to show/hide but thought this to be the most straight-forward.

