### PR TITLE
Chore: Map state timestamps from string => date

### DIFF
--- a/src/maps/state.ts
+++ b/src/maps/state.ts
@@ -10,7 +10,7 @@ export const mapStateResponseToState: MapFunction<StateResponse, State> = functi
     message: source.message,
     stateDetails: this.map('StateDetailsResponse', source.state_details, 'StateDetails'),
     data: source.data,
-    timestamp: source.timestamp,
+    timestamp: this.map('string', source.timestamp, 'Date'),
     name: source.name,
   }
 }
@@ -22,7 +22,7 @@ export const mapStateToStateResponse: MapFunction<State, StateResponse> = functi
     message: source.message,
     state_details: this.map('StateDetails', source.stateDetails, 'StateDetailsResponse'),
     data: source.data,
-    timestamp: source.timestamp,
+    timestamp: this.map('Date', source.timestamp, 'string'),
     name: source.name,
   }
 }
@@ -33,7 +33,7 @@ export const mapStateCreateToStateRequest: MapFunction<StateCreate, StateRequest
     message: source.message,
     state_details: source.stateDetails ? this.map('StateDetailsCreate', source.stateDetails, 'StateDetailsRequest') : {},
     data: source.data,
-    timestamp: source.timestamp,
+    timestamp: this.map('Date', source.timestamp, 'string'),
     name: source.name,
   }
 }

--- a/src/mocks/state.ts
+++ b/src/mocks/state.ts
@@ -23,7 +23,7 @@ export const randomState: MockFunction<State, [Partial<State>?]> = function(over
       encoding: this.create('string'),
       blob: this.create('string'),
     },
-    timestamp: this.create('string'),
+    timestamp: this.create('date'),
     name: name,
     ...overrides,
   }

--- a/src/models/State.ts
+++ b/src/models/State.ts
@@ -7,6 +7,6 @@ export type State = {
   message: string,
   stateDetails: StateDetails | null,
   data: Record<string, unknown>,
-  timestamp: string,
+  timestamp: Date,
   name: string,
 }

--- a/src/models/StateCreate.ts
+++ b/src/models/StateCreate.ts
@@ -5,6 +5,6 @@ export type StateCreate = {
   message?: string,
   stateDetails?: StateDetailsCreate,
   data?: Record<string, unknown>,
-  timestamp?: string,
+  timestamp?: Date,
   name?: string,
 }


### PR DESCRIPTION
This was inconsistent with other timestamps and meant we couldn't operate on them in components without doing a conversion there; this seemed better.