### PR TITLE
Chore: make the props simpler and remove the counter

### DIFF
--- a/src/components/PageHeadingWorkPools.vue
+++ b/src/components/PageHeadingWorkPools.vue
@@ -20,8 +20,3 @@
   const routes = useWorkspaceRoutes()
 </script>
 
-<style>
-.page-heading-work-pools__total-counter { @apply
-  text-subdued
-}
-</style>

--- a/src/components/PageHeadingWorkPools.vue
+++ b/src/components/PageHeadingWorkPools.vue
@@ -1,37 +1,23 @@
 <template>
   <page-heading class="page-heading-work-pools" :crumbs="crumbs">
     <template #after-crumbs>
-      <p-button v-if="can.create.work_pool && displayCreateButton" small icon="PlusIcon" :to="routes.workPoolCreate()" />
-    </template>
-    <template v-if="workPoolsLimit && currentWorkPools" #actions>
-      <span class="page-heading-work-pools__total-counter">
-        {{ currentWorkPools }} / {{ workPoolsLimit }} Work Pools
-      </span>
+      <p-button v-if="can.create.work_pool && !hideCreatebutton" small icon="PlusIcon" :to="routes.workPoolCreate()" />
     </template>
   </page-heading>
 </template>
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
   import { PageHeading } from '@/components'
   import { useWorkspaceRoutes, useCan } from '@/compositions'
 
   const crumbs = [{ text: 'Work Pools' }]
 
-  const props = defineProps<{
-    workPoolsLimit?: number | null,
-    currentWorkPools?: number | null,
+  defineProps<{
+    hideCreatebutton?: boolean,
   }>()
 
   const can = useCan()
   const routes = useWorkspaceRoutes()
-
-  const displayCreateButton = computed(() => {
-    if (!props.workPoolsLimit || !props.currentWorkPools) {
-      return true
-    }
-    return props.currentWorkPools < props.workPoolsLimit
-  })
 </script>
 
 <style>

--- a/src/components/PageHeadingWorkPools.vue
+++ b/src/components/PageHeadingWorkPools.vue
@@ -1,7 +1,7 @@
 <template>
   <page-heading class="page-heading-work-pools" :crumbs="crumbs">
     <template #after-crumbs>
-      <p-button v-if="can.create.work_pool && !hideCreatebutton" small icon="PlusIcon" :to="routes.workPoolCreate()" />
+      <p-button v-if="can.create.work_pool && !hideCreateButton" small icon="PlusIcon" :to="routes.workPoolCreate()" />
     </template>
   </page-heading>
 </template>
@@ -13,7 +13,7 @@
   const crumbs = [{ text: 'Work Pools' }]
 
   defineProps<{
-    hideCreatebutton?: boolean,
+    hideCreateButton?: boolean,
   }>()
 
   const can = useCan()


### PR DESCRIPTION
After working with @collincchoy to place the usage counter for automations, I've decided to move the counter for work pools in Nebula so that the placement is similar. The `PageHeadingWorkPools` still needs a prop to help it hide the create WorkPool button but it's now much simpler.