### PR TITLE
Add richer descriptions for automation actions

### DIFF
--- a/src/automations/components/AutomationActionDescription.vue
+++ b/src/automations/components/AutomationActionDescription.vue
@@ -1,0 +1,60 @@
+<template>
+  <component :is="description.component" v-bind="description.props" class="automation-action-description" />
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import AutomationActionDescriptionChangeFlowRunState from '@/automations/components/AutomationActionDescriptionChangeFlowRunState.vue'
+  import AutomationActionDescriptionDefault from '@/automations/components/AutomationActionDescriptionDefault.vue'
+  import AutomationActionDescriptionPauseResumeDeployment from '@/automations/components/AutomationActionDescriptionPauseResumeDeployment.vue'
+  import AutomationActionDescriptionPauseResumeWorkPool from '@/automations/components/AutomationActionDescriptionPauseResumeWorkPool.vue'
+  import AutomationActionDescriptionPauseResumeWorkQueue from '@/automations/components/AutomationActionDescriptionPauseResumeWorkQueue.vue'
+  import { AutomationAction } from '@/automations/types/actions'
+  import { withProps } from '@/utilities'
+
+  const props = defineProps<{
+    action: AutomationAction,
+  }>()
+
+  const description = computed(() => {
+    switch (props.action.type) {
+      case 'pause-deployment':
+      case 'resume-deployment':
+        return withProps(AutomationActionDescriptionPauseResumeDeployment, {
+          action: props.action,
+        })
+      case 'pause-work-queue':
+      case 'resume-work-queue':
+        return withProps(AutomationActionDescriptionPauseResumeWorkQueue, {
+          action: props.action,
+        })
+      case 'change-flow-run-state':
+        return withProps(AutomationActionDescriptionChangeFlowRunState, {
+          action: props.action,
+        })
+      case 'pause-work-pool':
+      case 'resume-work-pool':
+        return withProps(AutomationActionDescriptionPauseResumeWorkPool, {
+          action: props.action,
+        })
+      case 'suspend-flow-run':
+      case 'cancel-flow-run':
+      case 'run-deployment':
+      case 'pause-automation':
+      case 'resume-automation':
+      case 'send-notification':
+        return withProps(AutomationActionDescriptionDefault, {
+          action: props.action,
+        })
+      default:
+        const exhaustive: never = props.action
+        throw new Error(`AutomationActionDescription has no case for type: ${(exhaustive as AutomationAction).type}`)
+    }
+  })
+</script>
+
+<style>
+.automation-action-description { @apply
+  text-sm
+}
+</style>

--- a/src/automations/components/AutomationActionDescription.vue
+++ b/src/automations/components/AutomationActionDescription.vue
@@ -6,9 +6,12 @@
   import { computed } from 'vue'
   import AutomationActionDescriptionChangeFlowRunState from '@/automations/components/AutomationActionDescriptionChangeFlowRunState.vue'
   import AutomationActionDescriptionDefault from '@/automations/components/AutomationActionDescriptionDefault.vue'
+  import AutomationActionDescriptionPauseResumeAutomation from '@/automations/components/AutomationActionDescriptionPauseResumeAutomation.vue'
   import AutomationActionDescriptionPauseResumeDeployment from '@/automations/components/AutomationActionDescriptionPauseResumeDeployment.vue'
   import AutomationActionDescriptionPauseResumeWorkPool from '@/automations/components/AutomationActionDescriptionPauseResumeWorkPool.vue'
   import AutomationActionDescriptionPauseResumeWorkQueue from '@/automations/components/AutomationActionDescriptionPauseResumeWorkQueue.vue'
+  import AutomationActionDescriptionRunDeployment from '@/automations/components/AutomationActionDescriptionRunDeployment.vue'
+  import AutomationActionDescriptionSuspendCancelFlowRun from '@/automations/components/AutomationActionDescriptionSuspendCancelFlowRun.vue'
   import { AutomationAction } from '@/automations/types/actions'
   import { withProps } from '@/utilities'
 
@@ -37,11 +40,20 @@
         return withProps(AutomationActionDescriptionPauseResumeWorkPool, {
           action: props.action,
         })
-      case 'suspend-flow-run':
-      case 'cancel-flow-run':
-      case 'run-deployment':
       case 'pause-automation':
       case 'resume-automation':
+        return withProps(AutomationActionDescriptionPauseResumeAutomation, {
+          action: props.action,
+        })
+      case 'suspend-flow-run':
+      case 'cancel-flow-run':
+        return withProps(AutomationActionDescriptionSuspendCancelFlowRun, {
+          action: props.action,
+        })
+      case 'run-deployment':
+        return withProps(AutomationActionDescriptionRunDeployment, {
+          action: props.action,
+        })
       case 'send-notification':
         return withProps(AutomationActionDescriptionDefault, {
           action: props.action,

--- a/src/automations/components/AutomationActionDescriptionChangeFlowRunState.vue
+++ b/src/automations/components/AutomationActionDescriptionChangeFlowRunState.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="automation-action-description-change-flow-run-state">
-    <span>Change the state of the flow run inferred from the triggering event to <StateBadge :state /> </span>
+    Change the state of the flow run inferred from the triggering event to <StateBadge :state />
   </div>
 </template>
 
@@ -27,5 +27,10 @@
 </script>
 
 <style>
-
+.automation-action-description-change-flow-run-state { @apply
+  flex
+  flex-wrap
+  gap-1
+  items-center
+}
 </style>

--- a/src/automations/components/AutomationActionDescriptionChangeFlowRunState.vue
+++ b/src/automations/components/AutomationActionDescriptionChangeFlowRunState.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="automation-action-description-change-flow-run-state">
-    <span>Change the flow run's state to <StateBadge :state /> </span>
+    <span>Change the state of the flow run inferred from the triggering event to <StateBadge :state /> </span>
   </div>
 </template>
 

--- a/src/automations/components/AutomationActionDescriptionChangeFlowRunState.vue
+++ b/src/automations/components/AutomationActionDescriptionChangeFlowRunState.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="automation-action-description-change-flow-run-state">
+    <span>Change the flow run's state to <StateBadge :state /> </span>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { AutomationActionChangeFlowRunState } from '@/automations/types/actions'
+  import StateBadge from '@/components/StateBadge.vue'
+  import { mapper } from '@/services/Mapper'
+  import { StateBadgeState } from '@/types/stateBadge'
+  import { mapStateTypeOrNameToStateName } from '@/utilities/state'
+
+  const props = defineProps<{
+    action: AutomationActionChangeFlowRunState,
+  }>()
+
+  const state = computed<StateBadgeState>(() => {
+    const test: StateBadgeState = {
+      type: mapper.map('ServerStateType', props.action.state, 'StateType'),
+      name: mapStateTypeOrNameToStateName(props.action.name ?? props.action.state),
+    }
+
+    return test
+  })
+</script>
+
+<style>
+
+</style>

--- a/src/automations/components/AutomationActionDescriptionDefault.vue
+++ b/src/automations/components/AutomationActionDescriptionDefault.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="automation-action-description-default">
+    {{ automationActionTypeLabels[action.type] }}
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { AutomationAction, automationActionTypeLabels } from '@/automations/types/actions'
+
+  defineProps<{
+    action: AutomationAction,
+  }>()
+</script>

--- a/src/automations/components/AutomationActionDescriptionPauseResumeAutomation.vue
+++ b/src/automations/components/AutomationActionDescriptionPauseResumeAutomation.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="automation-action-description-pause-resume-automation">
+    <template v-if="action.automationId">
+      {{ pauseOrResume }} automation: <AutomationIconText :automation-id="action.automationId" />
+    </template>
+
+    <template v-else>
+      <span>{{ pauseOrResume }} automation inferred from the trigger</span>
+    </template>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import AutomationIconText from '@/automations/components/AutomationIconText.vue'
+  import { AutomationActionPauseAutomation, AutomationActionResumeAutomation } from '@/automations/types/actions'
+
+  const props = defineProps<{
+    action: AutomationActionResumeAutomation | AutomationActionPauseAutomation,
+  }>()
+
+  const pauseOrResume = computed(() => props.action.type === 'pause-automation' ? 'Pause' : 'Resume')
+</script>
+
+<style>
+.automation-action-description-pause-resume-automation { @apply
+  flex
+  flex-wrap
+  gap-1
+  items-center
+}
+</style>

--- a/src/automations/components/AutomationActionDescriptionPauseResumeAutomation.vue
+++ b/src/automations/components/AutomationActionDescriptionPauseResumeAutomation.vue
@@ -5,7 +5,7 @@
     </template>
 
     <template v-else>
-      <span>{{ pauseOrResume }} automation inferred from the trigger</span>
+      <span>{{ pauseOrResume }} automation inferred from the triggering event</span>
     </template>
   </div>
 </template>

--- a/src/automations/components/AutomationActionDescriptionPauseResumeDeployment.vue
+++ b/src/automations/components/AutomationActionDescriptionPauseResumeDeployment.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="automation-action-description-pause-resume-deployment">
+    <template v-if="action.deploymentId">
+      {{ pauseOrResume }} deployment: <DeploymentIconText :deployment-id="action.deploymentId" />
+    </template>
+
+    <template v-else>
+      <span>{{ pauseOrResume }} deployment inferred from the trigger</span>
+    </template>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { AutomationActionPauseDeployment, AutomationActionResumeDeployment } from '@/automations/types/actions'
+  import DeploymentIconText from '@/components/DeploymentIconText.vue'
+
+  const props = defineProps<{
+    action: AutomationActionResumeDeployment | AutomationActionPauseDeployment,
+  }>()
+
+  const pauseOrResume = computed(() => props.action.type === 'pause-deployment' ? 'Pause' : 'Resume')
+</script>
+
+<style>
+.automation-action-description-pause-resume-deployment { @apply
+  flex
+  flex-wrap
+  gap-1
+  items-center
+}
+</style>

--- a/src/automations/components/AutomationActionDescriptionPauseResumeDeployment.vue
+++ b/src/automations/components/AutomationActionDescriptionPauseResumeDeployment.vue
@@ -5,7 +5,7 @@
     </template>
 
     <template v-else>
-      <span>{{ pauseOrResume }} deployment inferred from the trigger</span>
+      <span>{{ pauseOrResume }} deployment inferred from the triggering event</span>
     </template>
   </div>
 </template>

--- a/src/automations/components/AutomationActionDescriptionPauseResumeWorkPool.vue
+++ b/src/automations/components/AutomationActionDescriptionPauseResumeWorkPool.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="automation-action-description-pause-resume-work-pool">
+    <template v-if="action.workPoolId">
+      <template v-if="workPool">
+        {{ pauseOrResume }} work pool: <WorkPoolIconText :work-pool-name="workPool.name" />
+      </template>
+    </template>
+
+    <template v-else>
+      <span>{{ pauseOrResume }} work pool inferred from the trigger</span>
+    </template>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { AutomationActionPauseWorkPool, AutomationActionResumeWorkPool } from '@/automations/types/actions'
+  import WorkPoolIconText from '@/components/WorkPoolIconText.vue'
+  import { useWorkPoolById } from '@/compositions'
+
+  const props = defineProps<{
+    action: AutomationActionResumeWorkPool | AutomationActionPauseWorkPool,
+  }>()
+
+  const { workPool } = useWorkPoolById(() => props.action.workPoolId)
+
+  const pauseOrResume = computed(() => props.action.type === 'pause-work-pool' ? 'Pause' : 'Resume')
+</script>
+
+<style>
+.automation-action-description-pause-resume-work-pool { @apply
+  flex
+  flex-wrap
+  gap-1
+  items-center
+}
+</style>

--- a/src/automations/components/AutomationActionDescriptionPauseResumeWorkPool.vue
+++ b/src/automations/components/AutomationActionDescriptionPauseResumeWorkPool.vue
@@ -7,7 +7,7 @@
     </template>
 
     <template v-else>
-      <span>{{ pauseOrResume }} work pool inferred from the trigger</span>
+      <span>{{ pauseOrResume }} work pool inferred from the triggering event</span>
     </template>
   </div>
 </template>

--- a/src/automations/components/AutomationActionDescriptionPauseResumeWorkQueue.vue
+++ b/src/automations/components/AutomationActionDescriptionPauseResumeWorkQueue.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="automation-action-description-pause-resume-work-queue">
+    <template v-if="action.workQueueId">
+      <template v-if="workPoolQueue">
+        {{ pauseOrResume }} work queue: <WorkQueueIconText :work-queue-name="workPoolQueue.name" :work-pool-name="workPoolQueue.workPoolName" />
+      </template>
+    </template>
+
+    <template v-else>
+      <span>{{ pauseOrResume }} work queue inferred from the trigger</span>
+    </template>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { AutomationActionPauseWorkQueue, AutomationActionResumeWorkQueue } from '@/automations/types/actions'
+  import WorkQueueIconText from '@/components/WorkQueueIconText.vue'
+  import { useWorkPoolQueue } from '@/compositions'
+
+  const props = defineProps<{
+    action: AutomationActionResumeWorkQueue | AutomationActionPauseWorkQueue,
+  }>()
+
+  const { workPoolQueue } = useWorkPoolQueue(() => props.action.workQueueId)
+  const pauseOrResume = computed(() => props.action.type === 'pause-work-queue' ? 'Pause' : 'Resume')
+</script>
+
+<style>
+.automation-action-description-pause-resume-work-queue { @apply
+  flex
+  flex-wrap
+  gap-1
+  items-center
+}
+</style>

--- a/src/automations/components/AutomationActionDescriptionPauseResumeWorkQueue.vue
+++ b/src/automations/components/AutomationActionDescriptionPauseResumeWorkQueue.vue
@@ -7,7 +7,7 @@
     </template>
 
     <template v-else>
-      <span>{{ pauseOrResume }} work queue inferred from the trigger</span>
+      <span>{{ pauseOrResume }} work queue inferred from the triggering event</span>
     </template>
   </div>
 </template>

--- a/src/automations/components/AutomationActionDescriptionRunDeployment.vue
+++ b/src/automations/components/AutomationActionDescriptionRunDeployment.vue
@@ -1,9 +1,7 @@
 <template>
-  <p-content class="automation-action-description-run-deployment" v-bind="$attrs">
+  <div class="automation-action-description-run-deployment" v-bind="$attrs">
     <template v-if="action.deploymentId">
-      <template v-if="deployment">
-        <span>Run <p-link :to="routes.deployment(deployment.id)">{{ deployment.name }}</p-link> deployment</span>
-      </template>
+      <span class="automation_action-description-run-deployment__deployment">Run deployment: <DeploymentIconText :deployment-id="action.deploymentId" /></span>
 
       <p-button small @click="openParametersModal">
         Show parameters
@@ -19,7 +17,7 @@
     <template v-else>
       <span>Run deployment inferred from the triggering event</span>
     </template>
-  </p-content>
+  </div>
 
   <p-modal v-model:show-modal="showParametersModal" title="Parameters">
     <p-code-highlight :text="stringify(action.parameters)" lang="json" />
@@ -33,19 +31,17 @@
 <script lang="ts" setup>
   import { useBoolean } from '@prefecthq/vue-compositions'
   import { AutomationActionRunDeployment } from '@/automations/types/actions'
-  import { useDeployment, useWorkspaceRoutes } from '@/compositions'
+  import DeploymentIconText from '@/components/DeploymentIconText.vue'
   import { stringify } from '@/utilities'
 
   defineOptions({
     inheritAttrs: false,
   })
 
-  const props = defineProps<{
+  defineProps<{
     action: AutomationActionRunDeployment,
   }>()
 
-  const routes = useWorkspaceRoutes()
-  const { deployment } = useDeployment(() => props.action.deploymentId)
   const { value: showParametersModal, setTrue: openParametersModal } = useBoolean()
   const { value: showJobVariablesModal, setTrue: openJobVariablesModal } = useBoolean()
 </script>
@@ -55,6 +51,13 @@
   flex
   flex-wrap
   gap-2
+  items-center
+}
+
+.automation_action-description-run-deployment__deployment { @apply
+  flex
+  flex-wrap
+  gap-1
   items-center
 }
 </style>

--- a/src/automations/components/AutomationActionDescriptionRunDeployment.vue
+++ b/src/automations/components/AutomationActionDescriptionRunDeployment.vue
@@ -1,0 +1,60 @@
+<template>
+  <p-content class="automation-action-description-run-deployment" v-bind="$attrs">
+    <template v-if="action.deploymentId">
+      <template v-if="deployment">
+        <span>Run <p-link :to="routes.deployment(deployment.id)">{{ deployment.name }}</p-link> deployment</span>
+      </template>
+
+      <p-button small @click="openParametersModal">
+        Show parameters
+      </p-button>
+
+      <template v-if="action.jobVariables">
+        <p-button small @click="openJobVariablesModal">
+          Show job variables
+        </p-button>
+      </template>
+    </template>
+
+    <template v-else>
+      <span>Run deployment inferred from the triggering event</span>
+    </template>
+  </p-content>
+
+  <p-modal v-model:show-modal="showParametersModal" title="Parameters">
+    <p-code-highlight :text="stringify(action.parameters)" lang="json" />
+  </p-modal>
+
+  <p-modal v-model:show-modal="showJobVariablesModal" title="Job Variables">
+    <p-code-highlight :text="stringify(action.jobVariables)" lang="json" />
+  </p-modal>
+</template>
+
+<script lang="ts" setup>
+  import { useBoolean } from '@prefecthq/vue-compositions'
+  import { AutomationActionRunDeployment } from '@/automations/types/actions'
+  import { useDeployment, useWorkspaceRoutes } from '@/compositions'
+  import { stringify } from '@/utilities'
+
+  defineOptions({
+    inheritAttrs: false,
+  })
+
+  const props = defineProps<{
+    action: AutomationActionRunDeployment,
+  }>()
+
+  const routes = useWorkspaceRoutes()
+  const { deployment } = useDeployment(() => props.action.deploymentId)
+  const { value: showParametersModal, setTrue: openParametersModal } = useBoolean()
+  const { value: showJobVariablesModal, setTrue: openJobVariablesModal } = useBoolean()
+</script>
+
+<style>
+.automation-action-description-run-deployment { @apply
+  flex
+  flex-wrap
+  gap-2
+  items-center
+}
+</style>

--- a/src/automations/components/AutomationActionDescriptionSuspendCancelFlowRun.vue
+++ b/src/automations/components/AutomationActionDescriptionSuspendCancelFlowRun.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="automation-action-description-suspend-cancel-flow-run">
+    <span>{{ suspendOrCancel }} flow run inferred from the triggering event</span>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { AutomationActionCancelFlowRun, AutomationActionSuspendFlowRun } from '@/automations/types/actions'
+
+  const props = defineProps<{
+    action: AutomationActionSuspendFlowRun | AutomationActionCancelFlowRun,
+  }>()
+
+  const suspendOrCancel = computed(() => props.action.type === 'suspend-flow-run' ? 'Suspend' : 'Cancel')
+</script>

--- a/src/automations/components/AutomationIconText.vue
+++ b/src/automations/components/AutomationIconText.vue
@@ -1,0 +1,22 @@
+<template>
+  <p-link :to="routes.automation(automationId)" class="automation-icon-text">
+    <p-icon-text icon="Automation">
+      <span>{{ automationName }}</span>
+    </p-icon-text>
+  </p-link>
+</template>
+
+<script lang="ts" setup>
+  import { useSubscription } from '@prefecthq/vue-compositions'
+  import { computed } from 'vue'
+  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+
+  const props = defineProps<{
+    automationId: string,
+  }>()
+
+  const api = useWorkspaceApi()
+  const routes = useWorkspaceRoutes()
+  const flowRunSubscription = useSubscription(api.automations.getAutomation, [props.automationId])
+  const automationName = computed(() => flowRunSubscription.response?.name)
+</script>

--- a/src/automations/index.ts
+++ b/src/automations/index.ts
@@ -3,3 +3,7 @@ export * from './types'
 export {
   default as AutomationActionInput
 } from './components/AutomationActionInput.vue'
+
+export {
+  default as AutomationActionDescription
+} from './components/AutomationActionDescription.vue'

--- a/src/types/stateBadge.ts
+++ b/src/types/stateBadge.ts
@@ -1,3 +1,3 @@
 import { StateType } from '@/models/StateType'
 
-export type StateBadgeState = { name: string, type: StateType | null }
+export type StateBadgeState = { name: string, type: StateType | null | undefined }


### PR DESCRIPTION
# Description
This PR attempts to make the description of an automations actions richer and more descriptive by adding the ability for each action to define a component that displays information about a specific instance of that action. 

This PR adds the pattern by enforcing each action type has a description component associated with it. Which could be as simple as choosing the "default" description component which just uses the action's label. Or a custom component that adds more rich information. 

Description components are added for all of the automation actions defined here in ui-library. And allows for extending in nebula-ui. 

<img width="784" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/aefa3500-f997-412b-bdb7-05c7b1864693">

<img width="797" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/ecf2dba6-6c0c-4e46-9f55-13fa2f0a7b03">
<img width="819" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/af16a19a-61f3-4925-a4af-2ecb21fc7dde">

<img width="788" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/a95fb2e1-8234-4aaf-bc0a-a24de2f31def">
