### PR TITLE
Bugfix: Double success toast when editing a deployment

### DIFF
--- a/src/components/DeploymentFormV2.vue
+++ b/src/components/DeploymentFormV2.vue
@@ -66,7 +66,7 @@
       <p-button @click="cancel">
         Cancel
       </p-button>
-      <p-button primary type="submit" @click="submit">
+      <p-button primary type="submit">
         Save
       </p-button>
     </template>


### PR DESCRIPTION
# Description
Fixes an issue where saving a deployment would cause it to submit twice which resulted in the success toast being shown to the user twice. 