### PR TITLE
Fix deployment parameters merging with parameters passed in

### DIFF
--- a/src/components/FlowRunCreateFormV2.vue
+++ b/src/components/FlowRunCreateFormV2.vue
@@ -117,7 +117,7 @@
   const name = ref(props.name)
   const { state: nameState, error: nameError } = useValidation(name, isRequired('name'))
 
-  const parameters = ref<SchemaValuesV2>(merge({}, props.deployment.parametersV2, props.parameters ?? {}))
+  const parameters = ref<SchemaValuesV2>({ ...props.deployment.parametersV2, ...props.parameters ?? {} })
   const { kind } = usePrefectKind(parameters)
   const scheduledTime = ref<Date | null>(null)
   const stateMessage = ref<string>('')


### PR DESCRIPTION
# Description
Closes https://github.com/PrefectHQ/prefect/issues/12756

Cause:
lodash.merge will merge arrays together. So
```
merge({}, { params: [1, 2, 3, 4, 5] }, { params: [6, 7, 8] })
```
returns
```
{ params: [6, 7, 8, 4, 5] }
```
which isn't what we want here. If any top level key is provided as a value we don't need to recursively merge. So spreading here should be just fine. 