### PR TITLE
Enhancement: Update modal buttons and add auto-close to the parameters and job variable modals

### DIFF
--- a/src/automations/components/AutomationActionDescriptionRunDeployment.vue
+++ b/src/automations/components/AutomationActionDescriptionRunDeployment.vue
@@ -19,12 +19,22 @@
     </template>
   </div>
 
-  <p-modal v-model:show-modal="showParametersModal" title="Parameters">
+  <p-modal v-model:show-modal="showParametersModal" title="Parameters" auto-close>
     <p-code-highlight :text="stringify(action.parameters)" lang="json" />
+    <template #cancel>
+      <p-button @click="closeParametersModal">
+        Close
+      </p-button>
+    </template>
   </p-modal>
 
-  <p-modal v-model:show-modal="showJobVariablesModal" title="Job Variables">
+  <p-modal v-model:show-modal="showJobVariablesModal" title="Job Variables" auto-close>
     <p-code-highlight :text="stringify(action.jobVariables)" lang="json" />
+    <template #cancel>
+      <p-button @click="closeJobVariablesModal">
+        Close
+      </p-button>
+    </template>
   </p-modal>
 </template>
 
@@ -42,8 +52,8 @@
     action: AutomationActionRunDeployment,
   }>()
 
-  const { value: showParametersModal, setTrue: openParametersModal } = useBoolean()
-  const { value: showJobVariablesModal, setTrue: openJobVariablesModal } = useBoolean()
+  const { value: showParametersModal, setTrue: openParametersModal, setFalse: closeParametersModal } = useBoolean()
+  const { value: showJobVariablesModal, setTrue: openJobVariablesModal, setFalse: closeJobVariablesModal } = useBoolean()
 </script>
 
 <style>

--- a/src/automations/components/AutomationActionDescriptionRunDeployment.vue
+++ b/src/automations/components/AutomationActionDescriptionRunDeployment.vue
@@ -39,9 +39,9 @@
 </template>
 
 <script lang="ts" setup>
-  import { useBoolean } from '@prefecthq/vue-compositions'
   import { AutomationActionRunDeployment } from '@/automations/types/actions'
   import DeploymentIconText from '@/components/DeploymentIconText.vue'
+  import { useShowModal } from '@/compositions'
   import { stringify } from '@/utilities'
 
   defineOptions({
@@ -52,8 +52,8 @@
     action: AutomationActionRunDeployment,
   }>()
 
-  const { value: showParametersModal, setTrue: openParametersModal, setFalse: closeParametersModal } = useBoolean()
-  const { value: showJobVariablesModal, setTrue: openJobVariablesModal, setFalse: closeJobVariablesModal } = useBoolean()
+  const { showModal: showParametersModal, open: openParametersModal, close: closeParametersModal } = useShowModal()
+  const { showModal: showJobVariablesModal, open: openJobVariablesModal, close: closeJobVariablesModal } = useShowModal()
 </script>
 
 <style>


### PR DESCRIPTION
# Description
When viewing a run deployment action there are two modals that are basically the same for viewing parameters and job variables. Update them to use `auto-close` so users can click on the mask to close the modal and changing the button from the default cancel button to a primary "Close" button like we've done on the ExtraInfoModal. 