### PR TITLE
Enhancement: flow run list information density

### DIFF
--- a/src/components/FlowRunBreadCrumbs.vue
+++ b/src/components/FlowRunBreadCrumbs.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flow-run-bread-crumbs">
-    <FlowRouterLink :flow-id="flowRun.flowId" class="flow-run-bread-crumbs__flow-link">
+    <FlowRouterLink v-if="!hideFlowName" :flow-id="flowRun.flowId" class="flow-run-bread-crumbs__flow-link">
       <template #after>
         <p-icon icon="ChevronRightIcon" size="small" />
       </template>
@@ -21,6 +21,7 @@
 
   const props = defineProps<{
     flowRun: FlowRun,
+    hideFlowName?: boolean,
   }>()
 
   const routes = useWorkspaceRoutes()

--- a/src/components/FlowRunFilteredList.vue
+++ b/src/components/FlowRunFilteredList.vue
@@ -19,7 +19,7 @@
       </template>
     </p-list-header>
 
-    <FlowRunList v-model:selected="selected" :flow-runs="flowRuns" :selectable="selectable && can.delete.flow_run" @bottom="next" />
+    <FlowRunList v-model:selected="selected" v-bind="{ hideDetails, hideFlowName }" :flow-runs="flowRuns" :selectable="selectable && can.delete.flow_run" @bottom="next" />
 
     <PEmptyResults v-if="empty">
       <template #message>
@@ -57,6 +57,8 @@
     filter?: FlowRunsFilter,
     selectable?: boolean,
     prefix?: string,
+    hideDetails?: boolean,
+    hideFlowName?: boolean,
   }>()
 
   const can = useCan()

--- a/src/components/FlowRunList.vue
+++ b/src/components/FlowRunList.vue
@@ -1,7 +1,7 @@
 <template>
   <p-virtual-scroller :items="flowRuns" class="flow-run-list">
     <template #default="{ item: flowRun }">
-      <FlowRunListItem v-model:selected="model" v-bind="{ flowRun, selectable }" />
+      <FlowRunListItem v-model:selected="model" v-bind="{ hideFlowName, hideDetails, flowRun, selectable }" />
     </template>
   </p-virtual-scroller>
 </template>
@@ -15,6 +15,8 @@
     selected?: string[] | null,
     flowRuns: FlowRun[],
     selectable?: boolean,
+    hideFlowName?: boolean,
+    hideDetails?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/FlowRunListItem.vue
+++ b/src/components/FlowRunListItem.vue
@@ -2,7 +2,7 @@
   <div ref="el" class="flow-run-list-item">
     <StateListItem v-model:selected="model" v-bind="{ selectable, value, tags, stateType }">
       <template #name>
-        <FlowRunBreadCrumbs :flow-run="flowRun" />
+        <FlowRunBreadCrumbs :hide-flow-name="hideFlowName" :flow-run="flowRun" />
       </template>
       <template #meta>
         <StateBadge :state="flowRun.state" />
@@ -12,7 +12,7 @@
           <IconTextCount icon="Task" :count="taskRunsCount ?? 0" label="Task run" />
         </template>
       </template>
-      <template v-if="visible && (flowRun.deploymentId || flowRun.workQueueName)" #relationships>
+      <template v-if="!hideDetails && visible && (flowRun.deploymentId || flowRun.workQueueName)" #relationships>
         <FlowRunDeployment v-if="flowRun.deploymentId" :deployment-id="flowRun.deploymentId" />
         <FlowRunWorkPool v-if="flowRun.workPoolName" :work-pool-name="flowRun.workPoolName" />
         <FlowRunWorkQueue
@@ -47,6 +47,8 @@
     selectable?: boolean,
     selected?: CheckboxModel | null,
     flowRun: FlowRun,
+    hideFlowName?: boolean,
+    hideDetails?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/FlowRunsAccordionContent.vue
+++ b/src/components/FlowRunsAccordionContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <FlowRunList :flow-runs="flowRuns" :selected="null" class="flow-flow-runs-list" />
+  <FlowRunList :flow-runs="flowRuns" :selected="null" class="flow-flow-runs-list" hide-flow-name hide-details />
   <template v-if="more">
     <div class="flow-flow-runs-list__more">
       <p-button small @click="next">

--- a/src/components/FlowRunsAccordionHeader.vue
+++ b/src/components/FlowRunsAccordionHeader.vue
@@ -92,4 +92,8 @@
 .flow-runs-accordion-header__icon--selected { @apply
   rotate-180
 }
+
+.flow-runs-accordion-header__name { @apply
+  font-semibold
+}
 </style>


### PR DESCRIPTION
This PR introduces a few new props to the flow run list item component set to allow hiding the flow name and ancillary details (like work pool, deployment, work queue)

cc @cicdw 