### PR TITLE
Fix schema form properties with no default value from defaulting to `null` (`None`)

### DIFF
--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -97,7 +97,7 @@
         return property.value.default
       }
 
-      return null
+      return undefined
     },
     set(value) {
       emit('update:value', value)

--- a/src/schemas/maps/schema.ts
+++ b/src/schemas/maps/schema.ts
@@ -6,7 +6,7 @@ import { mapValues } from '@/utilities/object'
 
 export const mapSchemaResponseToSchema: MapFunction<SchemaResponse, Schema> = function(source) {
   return {
-    definitions: source.definitions,
+    definitions: this.map('SchemaPropertiesResponse', source.definitions, 'SchemaProperties'),
     position: source.position,
     blockTypeSlug: source.block_type_slug,
     $ref: source.$ref,
@@ -59,7 +59,7 @@ export const mapSchemaPropertyResponseToSchemaProperty: MapFunction<SchemaProper
 
 export const mapSchemaToSchemaResponse: MapFunction<Schema, SchemaResponse> = function(source) {
   return {
-    definitions: source.definitions,
+    definitions: this.map('SchemaProperties', source.definitions, 'SchemaPropertiesResponse'),
     position: source.position,
     block_type_slug: source.blockTypeSlug,
     $ref: source.$ref,


### PR DESCRIPTION
# Description
For most form components `null | undefined` is treated the same. But for something like a json input `null` is actually a valid value. So we need to make sure we always use `undefined` for an empty value and not null. 

Also noticed that definitions were not getting mapped so added the mapper to those properties. 