### PR TITLE
Prune dangerous trash icons. 

### DIFF
--- a/src/components/BlocksDeleteButton.vue
+++ b/src/components/BlocksDeleteButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-button v-if="selected.length > 0" v-bind="attrs" dangerous icon="TrashIcon" @click="open" />
+  <p-button v-if="selected.length > 0" v-bind="attrs" icon="TrashIcon" @click="open" />
   <ConfirmDeleteModal
     v-model:showModal="showModal"
     name="selected blocks"

--- a/src/components/DeploymentsDeleteButton.vue
+++ b/src/components/DeploymentsDeleteButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-button v-if="selected.length > 0" v-bind="attrs" dangerous icon="TrashIcon" @click="open" />
+  <p-button v-if="selected.length > 0" v-bind="attrs" icon="TrashIcon" @click="open" />
   <ConfirmDeleteModal
     v-model:showModal="showModal"
     name="selected deployments"

--- a/src/components/FlowRunsDeleteButton.vue
+++ b/src/components/FlowRunsDeleteButton.vue
@@ -1,6 +1,6 @@
 <template>
   <Transition name="flow-runs-delete-button-transition">
-    <p-button v-if="selected.length > 0" dangerous icon="TrashIcon" @click="open" />
+    <p-button v-if="selected.length > 0" icon="TrashIcon" @click="open" />
   </Transition>
   <ConfirmDeleteModal
     v-model:showModal="showModal"

--- a/src/components/FlowsDeleteButton.vue
+++ b/src/components/FlowsDeleteButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-button v-if="selected.length > 0" v-bind="attrs" dangerous icon="TrashIcon" @click="open" />
+  <p-button v-if="selected.length > 0" v-bind="attrs" icon="TrashIcon" @click="open" />
   <ConfirmDeleteModal
     v-model:showModal="showModal"
     name="selected flows"

--- a/src/components/VariablesDeleteButton.vue
+++ b/src/components/VariablesDeleteButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-button v-if="variableIds.length > 0" small dangerous icon="TrashIcon" @click="open" />
+  <p-button v-if="variableIds.length > 0" small icon="TrashIcon" @click="open" />
   <ConfirmDeleteModal
     v-model:showModal="showModal"
     :name="modalName"

--- a/src/components/WorkPoolQueuesDeleteButton.vue
+++ b/src/components/WorkPoolQueuesDeleteButton.vue
@@ -1,6 +1,6 @@
 <template>
   <Transition name="work-pool-queues-delete-button-transition">
-    <p-button v-if="workPoolQueues.length > 0" dangerous icon="TrashIcon" @click="open" />
+    <p-button v-if="workPoolQueues.length > 0" icon="TrashIcon" @click="open" />
   </Transition>
   <ConfirmDeleteModal
     v-model:showModal="showModal"

--- a/src/components/WorkQueuesDeleteButton.vue
+++ b/src/components/WorkQueuesDeleteButton.vue
@@ -1,6 +1,6 @@
 <template>
   <Transition name="work-queues-delete-button-transition">
-    <p-button v-if="selected.length > 0" dangerous icon="TrashIcon" @click="open" />
+    <p-button v-if="selected.length > 0" icon="TrashIcon" @click="open" />
   </Transition>
   <ConfirmDeleteModal
     v-model:showModal="showModal"


### PR DESCRIPTION
In prefect-ui-library we accidentally use destructive (i.e. red) colors for non-destructive actions. 

e.g. we use a destructive trash icon button to launch a modal, and separately that modal has a button to confirm delete. 

- the button to launch the modal is _not_ a destructive action - so it shouldn't be red (changed).
- the button to confirm deletion _is_ a destructive action, so it should continue to be red (unchanged).

separately this choice pays dividends in our design library so that we don't need to worry about outline&destructive vs filled&destructive buttons