### PR TITLE
Remove last dangerous buttons

### DIFF
--- a/src/components/ConfirmDeleteModal.vue
+++ b/src/components/ConfirmDeleteModal.vue
@@ -17,7 +17,7 @@
     </span>
     <template #actions>
       <slot name="actions">
-        <p-button dangerous primary @click="handleDeleteClick">
+        <p-button variant="destructive" @click="handleDeleteClick">
           {{ action }}
         </p-button>
       </slot>

--- a/src/components/FlowRunCancelModal.vue
+++ b/src/components/FlowRunCancelModal.vue
@@ -11,7 +11,7 @@
     </div>
 
     <template #actions>
-      <p-button dangerous primary @click="cancel">
+      <p-button variant="destructive" @click="cancel">
         Confirm
       </p-button>
     </template>


### PR DESCRIPTION
Finishes (🤞) a series of PRs to remove `<p-button dangerous...` from our ui libraries. 