### PR TITLE
Add the ability for resetting parameters to their default value in the ui when creating a run

### DIFF
--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -4,7 +4,14 @@
       <div class="schema-form-property__header">
         <span class="schema-form-property__label" :class="classes.label">{{ label }}</span>
 
-        <SchemaFormPropertyMenu v-model:kind="kind" class="ml-auto" :property="property" :disabled="omitted" flat>
+        <SchemaFormPropertyMenu
+          v-model:value="value"
+          v-model:kind="kind"
+          class="ml-auto"
+          :property
+          :disabled="omitted"
+          flat
+        >
           <template v-if="!required" #default>
             <p-overflow-menu-item :label="omitLabel" @click="toggleValue" />
           </template>
@@ -12,7 +19,7 @@
       </div>
     </template>
 
-    <slot />
+    <slot :kind />
 
     <template v-if="description" #description>
       <div class="schema-form-property__description">

--- a/src/schemas/components/SchemaFormPropertyAnyOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOf.vue
@@ -66,7 +66,6 @@
   })
 
   async function updateValue(value: unknown): Promise<void> {
-    // if its a prefect kind value like workspace_variable or json we don't need to do anything
     if (isPrefectKindValue(value)) {
       emit('update:value', value)
       return

--- a/src/schemas/components/SchemaFormPropertyAnyOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOf.vue
@@ -67,7 +67,7 @@
 
   async function updateValue(value: unknown): Promise<void> {
     // if its a prefect kind value like workspace_variable or json we don't need to do anything
-    if (!isPrefectKindValue(value, 'none')) {
+    if (isPrefectKindValue(value)) {
       emit('update:value', value)
       return
     }

--- a/src/schemas/components/SchemaFormPropertyAnyOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOf.vue
@@ -1,7 +1,11 @@
 <template>
   <keep-alive>
-    <SchemaFormProperty :key="selectedPropertyIndexValue" v-model:value="value" v-bind="{ property, required, errors }" class="schema-form-property-any-of-input">
-      <p-button-group v-model="selectedPropertyIndex" :options="options" small class="mb-2" />
+    <SchemaFormProperty :key="selectedPropertyIndexValue" :value="internalValue" v-bind="{ property, required, errors }" class="schema-form-property-any-of-input" @update:value="updateValue">
+      <template #default="{ kind }">
+        <template v-if="kind === 'none'">
+          <p-button-group v-model="selectedPropertyIndex" :options="options" small class="mb-2" />
+        </template>
+      </template>
     </SchemaFormProperty>
   </keep-alive>
 </template>
@@ -14,7 +18,7 @@
   import SchemaFormProperty from '@/schemas/components/SchemaFormProperty.vue'
   import { useSchema } from '@/schemas/compositions/useSchema'
   import { SchemaProperty, isPropertyWith } from '@/schemas/types/schema'
-  import { SchemaValue } from '@/schemas/types/schemaValues'
+  import { SchemaValue, isPrefectKindValue } from '@/schemas/types/schemaValues'
   import { SchemaValueError } from '@/schemas/types/schemaValuesValidationResponse'
   import { getSchemaDefinition } from '@/schemas/utilities/definitions'
   import { getInitialIndexForSchemaPropertyAnyOfValue, getSchemaPropertyLabel } from '@/schemas/utilities/properties'
@@ -53,15 +57,33 @@
     'update:value': [SchemaValue],
   }>()
 
-  const value = computed({
-    get() {
-      return propertyValues[selectedPropertyIndex.value]
-    },
-    set(value) {
-      propertyValues[selectedPropertyIndex.value] = value
-      emit('update:value', value)
-    },
+  const internalValue = computed(() => {
+    if (isPrefectKindValue(props.value)) {
+      return props.value
+    }
+
+    return propertyValues[selectedPropertyIndex.value]
   })
+
+  async function updateValue(value: unknown): Promise<void> {
+    // if its a prefect kind value like workspace_variable or json we don't need to do anything
+    if (!isPrefectKindValue(value, 'none')) {
+      emit('update:value', value)
+      return
+    }
+
+    let index = await getInitialIndexForSchemaPropertyAnyOfValue({ value, property: props.property, api, schema })
+
+    if (index === -1) {
+      console.error('Could not determine property index')
+      index = selectedPropertyIndex.value
+    }
+
+    propertyValues[index] = value
+    selectedPropertyIndexValue.value = index
+
+    emit('update:value', value)
+  }
 
   const selectedPropertyIndex = computed({
     get() {

--- a/src/schemas/components/SchemaFormPropertyArrayItem.vue
+++ b/src/schemas/components/SchemaFormPropertyArrayItem.vue
@@ -5,7 +5,7 @@
 
       <component :is="input.component" v-bind="input.props" />
 
-      <SchemaFormPropertyMenu v-model:kind="kind" :property="property">
+      <SchemaFormPropertyMenu v-model:value="value" v-model:kind="kind" :property="property">
         <template v-if="!isFirst">
           <p-overflow-menu-item icon="ArrowSmallUpIcon" label="Move to top" @click="emit('moveToTop')" />
         </template>

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -22,7 +22,7 @@
   import { computed, useSlots } from 'vue'
   import { useSchemaFormKinds } from '@/schemas/compositions/useSchemaFormKinds'
   import { SchemaProperty, isSchemaPropertyType } from '@/schemas/types/schema'
-  import { SchemaValue, PrefectKind, isPrefectKindJson, PrefectKindJson } from '@/schemas/types/schemaValues'
+  import { SchemaValue, PrefectKind, isPrefectKindJson, PrefectKindJson, isPrefectKindWorkspaceVariable, isPrefectKindJinja } from '@/schemas/types/schemaValues'
   import { isNullish, stringify } from '@/utilities'
 
   const kind = defineModel<PrefectKind>('kind', { required: true })
@@ -53,6 +53,10 @@
   const showUseDefault = computed(() => {
     if (!isDefined(props.property.default)) {
       return false
+    }
+
+    if (isPrefectKindWorkspaceVariable(value.value) || isPrefectKindJinja(value.value)) {
+      return true
     }
 
     if (isPrefectKindJson(value.value)) {

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -2,43 +2,41 @@
   <p-icon-button-menu v-if="showMenu" small class="schema-form-property-menu">
     <template v-if="!disabled">
       <template v-if="showNone">
-        <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="emit('update:kind', 'none')" />
+        <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="kind = 'none'" />
       </template>
-      <p-overflow-menu-item v-if="showKind('json')" label="Use JSON input" @click="emit('update:kind', 'json')" />
-      <p-overflow-menu-item v-if="showKind('workspace_variable')" label="Select variable" @click="emit('update:kind', 'workspace_variable')" />
-      <p-overflow-menu-item v-if="showKind('jinja')" label="Use Jinja input" @click="emit('update:kind', 'jinja')" />
+      <p-overflow-menu-item v-if="showKind('json')" label="Use JSON input" @click="kind = 'json'" />
+      <p-overflow-menu-item v-if="showKind('workspace_variable')" label="Select variable" @click="kind = 'workspace_variable'" />
+      <p-overflow-menu-item v-if="showKind('jinja')" label="Use Jinja input" @click="kind = 'jinja'" />
     </template>
 
-    <template v-if="slots.default">
-      <p-divider v-if="showDivider" class="schema-form-property-menu__divider" />
-      <slot />
-    </template>
+    <p-divider class="schema-form-property-menu__divider" />
+
+    <p-overflow-menu-item v-if="showUseDefault" label="Use default value" @click="setDefaultValue" />
+    <slot />
   </p-icon-button-menu>
 </template>
 
 <script lang="ts" setup>
   import { isDefined } from '@prefecthq/prefect-design'
+  import isEqual from 'lodash.isequal'
   import { computed, useSlots } from 'vue'
   import { useSchemaFormKinds } from '@/schemas/compositions/useSchemaFormKinds'
   import { SchemaProperty, isSchemaPropertyType } from '@/schemas/types/schema'
-  import { PrefectKind } from '@/schemas/types/schemaValues'
-  import { isNullish } from '@/utilities'
+  import { SchemaValue, PrefectKind, isPrefectKindJson, PrefectKindJson } from '@/schemas/types/schemaValues'
+  import { isNullish, stringify } from '@/utilities'
+
+  const kind = defineModel<PrefectKind>('kind', { required: true })
+  const value = defineModel<SchemaValue>('value', { required: true })
 
   const props = defineProps<{
-    kind: PrefectKind,
     property: SchemaProperty,
     disabled?: boolean,
-  }>()
-
-  const emit = defineEmits<{
-    'update:kind': [PrefectKind],
   }>()
 
   const slots = useSlots()
   const kinds = useSchemaFormKinds()
 
   const showMenu = computed(() => kinds.length || slots.default)
-  const showDivider = computed(() => !props.disabled && kinds.length)
 
   const showNone = computed(() => {
     if (isSchemaPropertyType(props.property.type, 'object') && isNullish(props.property.properties)) {
@@ -52,13 +50,33 @@
     return props.property.type !== undefined
   })
 
-  function showKind(kind: PrefectKind): boolean {
-    return props.kind !== kind && (kinds.includes(kind) || kind === 'none')
+  const showUseDefault = computed(() => isDefined(props.property.default) && !isEqual(value.value, props.property.default))
+
+  function showKind(value: PrefectKind): boolean {
+    return kind.value !== value && (kinds.includes(value) || value === 'none')
+  }
+
+  function setDefaultValue(): void {
+    if (isPrefectKindJson(value.value)) {
+      value.value = {
+        __prefect_kind: 'json',
+        value: stringify(props.property.default),
+      } satisfies PrefectKindJson
+
+      return
+    }
+
+    value.value = props.property.default
   }
 </script>
 
 <style>
-.schema-form-property-menu__divider .p-divider { @apply
+.schema-form-property-menu__divider .p-divider__line { @apply
   m-0
+}
+
+.schema-form-property-menu__divider:first-child,
+.schema-form-property-menu__divider:last-child { @apply
+  hidden
 }
 </style>

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -50,7 +50,17 @@
     return props.property.type !== undefined
   })
 
-  const showUseDefault = computed(() => isDefined(props.property.default) && !isEqual(value.value, props.property.default))
+  const showUseDefault = computed(() => {
+    if (!isDefined(props.property.default)) {
+      return false
+    }
+
+    if (isPrefectKindJson(value.value)) {
+      return !isEqual(value.value.value, stringify(props.property.default))
+    }
+
+    return !isEqual(value.value, props.property.default)
+  })
 
   function showKind(value: PrefectKind): boolean {
     return kind.value !== value && (kinds.includes(value) || value === 'none')

--- a/src/schemas/types/schemaValues.ts
+++ b/src/schemas/types/schemaValues.ts
@@ -1,3 +1,4 @@
+import { isDefined } from '@prefecthq/prefect-design'
 import { isRecord, isString } from '@/utilities'
 import { createTuple } from '@/utilities/tuples'
 
@@ -49,7 +50,7 @@ export type PrefectKindJson = BasePrefectKindValue<'json', {
 }>
 
 export function isPrefectKindJson(value: unknown): value is PrefectKindJson {
-  return isPrefectKindValue(value, 'json') && isString(value.value)
+  return isPrefectKindValue(value, 'json') && (isString(value.value) || !isDefined(value.value))
 }
 
 export type PrefectKindJinja = BasePrefectKindValue<'jinja', {


### PR DESCRIPTION
# Description
Add an additional menu item to the schema property menu labeled "Use default value". 
<img width="155" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/e46950c5-7f4c-4a9c-a381-8b7b924d06a0">
This menu item only appears if 
1. There is a default value (the default value is not `undefined`)
2. The current value does not match the default value

Selecting this new menu item will
- If the kind is `none` (the default form), `workspace_variable`, or `jinja` it will show the default form with the default value populated
- If the kind is `json` it will update the json to match the default value. 