### PR TITLE
Fix generated deployment parameter not respecting `None` as a default value

### DIFF
--- a/src/schemas/components/SchemaFormProperties.vue
+++ b/src/schemas/components/SchemaFormProperties.vue
@@ -79,7 +79,7 @@
   }
 
   function getValue(propertyKey: string): unknown {
-    return props.values?.[propertyKey] ?? undefined
+    return props.values?.[propertyKey]
   }
 
   function setValue(propertyKey: string, value: unknown): void {

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { isNotNullish } from '@prefecthq/prefect-design'
+  import { isDefined, isNotNullish } from '@prefecthq/prefect-design'
   import { computed, ref, onMounted } from 'vue'
   import SchemaFormPropertyMenu from '@/schemas/components/SchemaFormPropertyMenu.vue'
   import { usePrefectKind } from '@/schemas/compositions/usePrefectKind'
@@ -96,11 +96,11 @@
         return omittedValue.value
       }
 
-      if (isNotNullish(props.value)) {
+      if (isDefined(props.value)) {
         return props.value
       }
 
-      if (!initialized.value && isNotNullish(property.value.default)) {
+      if (!initialized.value && isDefined(property.value.default)) {
         return property.value.default
       }
 
@@ -111,7 +111,7 @@
     },
   })
 
-  if (isNullish(props.value) && isNotNullish(property.value.default)) {
+  if (!isDefined(props.value) && isDefined(property.value.default)) {
     emit('update:value', property.value.default)
   }
 

--- a/src/schemas/components/SchemaFormPropertyAnyOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOf.vue
@@ -96,12 +96,14 @@
 
   const property = computed(() => {
     const selectedProperty = props.property.anyOf[selectedPropertyIndex.value]
+    // eslint-disable-next-line no-unused-vars
+    const { anyOf, ...property } = props.property
 
     if (isPropertyWith(selectedProperty, '$ref')) {
-      return merge({}, getSchemaDefinition(schema, selectedProperty.$ref), props.property)
+      return merge({}, getSchemaDefinition(schema, selectedProperty.$ref), property)
     }
 
-    return merge({}, selectedProperty, props.property)
+    return merge({}, selectedProperty, property)
   })
 
   const options = computed<ButtonGroupOption[]>(() => props.property.anyOf.map((property, index) => ({


### PR DESCRIPTION
# Description
Found a couple places where we were checking for nullish values when we should be only checking for undefined. This would mean that `None` values were not treated as real values. 