### PR TITLE
Bugfix/Chore: Bump prefect-design peer dep, fix issue with negative lookup of activity in flows table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "vue-tsc": "^2.0.14"
             },
             "peerDependencies": {
-                "@prefecthq/prefect-design": "^2.7.14",
+                "@prefecthq/prefect-design": "^2.7.15",
                 "@prefecthq/vue-charts": "^2.0.3",
                 "@prefecthq/vue-compositions": "^1.11.4",
                 "vee-validate": "^4.7.0",
@@ -1110,13 +1110,10 @@
             }
         },
         "node_modules/@prefecthq/prefect-design": {
-            "version": "2.7.14",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.7.14.tgz",
-            "integrity": "sha512-jMPXxPohIvsapHHFOfbdlia2JsWaTb4xWBbY8/07x+ozRmqSam9MugGTHxSvDRAt8W4cbq8HXGvNcu1vGo3Lsw==",
+            "version": "2.7.15",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.7.15.tgz",
+            "integrity": "sha512-pnIKQtA+K/quX9pm6JP9Q/Mkqotk9Ny5BFw1SFWIszxG0vqkij4pBdFcnPod+CLgz49PXG8dOBFAuexP3nOuug==",
             "peer": true,
-            "workspaces": [
-                "./demo"
-            ],
             "dependencies": {
                 "@heroicons/vue": "2.0.17",
                 "@tailwindcss/aspect-ratio": "^0.4.0",
@@ -8309,9 +8306,9 @@
             }
         },
         "@prefecthq/prefect-design": {
-            "version": "2.7.14",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.7.14.tgz",
-            "integrity": "sha512-jMPXxPohIvsapHHFOfbdlia2JsWaTb4xWBbY8/07x+ozRmqSam9MugGTHxSvDRAt8W4cbq8HXGvNcu1vGo3Lsw==",
+            "version": "2.7.15",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.7.15.tgz",
+            "integrity": "sha512-pnIKQtA+K/quX9pm6JP9Q/Mkqotk9Ny5BFw1SFWIszxG0vqkij4pBdFcnPod+CLgz49PXG8dOBFAuexP3nOuug==",
             "peer": true,
             "requires": {
                 "@heroicons/vue": "2.0.17",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "vue-tsc": "^2.0.14"
     },
     "peerDependencies": {
-        "@prefecthq/prefect-design": "^2.7.14",
+        "@prefecthq/prefect-design": "^2.7.15",
         "@prefecthq/vue-charts": "^2.0.3",
         "@prefecthq/vue-compositions": "^1.11.4",
         "vee-validate": "^4.7.0",

--- a/src/components/DeploymentsList.vue
+++ b/src/components/DeploymentsList.vue
@@ -67,7 +67,7 @@
         <MiniDeploymentHistory
           class="deployment-list__activity-chart"
           :deployment-id="row.id"
-          :time-span-in-seconds="secondsInDay"
+          :time-span-in-seconds="secondsInWeek"
         />
       </template>
 
@@ -115,7 +115,7 @@
 <script lang="ts" setup>
   import { ColumnClassesMethod, TableColumn, media } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
-  import { secondsInDay } from 'date-fns/constants'
+  import { secondsInWeek } from 'date-fns/constants'
   import merge from 'lodash.merge'
   import { ref } from 'vue'
   import {

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -48,7 +48,7 @@
         <MiniFlowHistory
           class="flow-list__activity-chart"
           :flow-id="row.id"
-          :time-span-in-seconds="secondsInDay"
+          :time-span-in-seconds="-secondsInWeek"
         />
       </template>
 
@@ -88,7 +88,7 @@
 <script lang="ts" setup>
   import { ColumnClassesMethod, TableColumn } from '@prefecthq/prefect-design'
   import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
-  import { secondsInDay } from 'date-fns/constants'
+  import { secondsInWeek } from 'date-fns/constants'
   import merge from 'lodash.merge'
   import { ref } from 'vue'
   import {


### PR DESCRIPTION
This PR fixes an inconsistency with the flows table where the timespan that gets mapped was always looking forward; this resulted in no runs ever being displayed. It also updates the timespan for both the deployment and flows lists to match the defaults on other pages of 1 week. Last it bumps the prefect-design peer dep cause that's just helpful.