### PR TITLE
Remove default open accordion in Dashboard

### DIFF
--- a/src/components/FlowRunsAccordion.vue
+++ b/src/components/FlowRunsAccordion.vue
@@ -1,6 +1,6 @@
 <template>
   <template v-if="flowIds">
-    <p-accordion v-model:selected="selectedAccordionItem" :sections="flowIds" class="flow-runs-accordion">
+    <p-accordion :sections="flowIds" class="flow-runs-accordion">
       <template #header="{ section: flowId, id, toggle, content, selected }">
         <FlowRunsAccordionHeader :flow="getFlow(flowId)" :filter="flowRunsFilter" v-bind="{ id, content, toggle, selected }" />
       </template>
@@ -50,12 +50,6 @@
   const { flows } = useFlows(flowsFilter, options)
   const flowIds = computed(() => flows.value.map(flow => flow.id))
   const flowsLookup = computed(() => toMap(flows.value, 'id'))
-
-  const selectedAccordionItem: Ref<string | null> = ref(null)
-
-  watch(flowIds, () => {
-    selectedAccordionItem.value = flowIds.value[0] ?? null
-  })
 
   function getFlow(id: string): Flow {
     const flow = flowsLookup.value.get(id)


### PR DESCRIPTION
The dashboard uses a PAccordion component to collapse groups of flow runs.

Today's behavior is to render the first accorrdion item open by default, which can cause stuttery load times since it fetches all of the subsequent flow runs underneath it. Relatedly, this is the only component which would break under the new PAccordion API so I'm going to remove this behavior for now. 