### PR TITLE
Fix parameters that are unions with default values that are unresponsive and disappear

### DIFF
--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -60,6 +60,8 @@
     value: SchemaValue,
     required: boolean,
     errors: SchemaValueError[],
+    // For an anyOf property we don't want to keep initializing the default value each time the type is changed
+    // https://github.com/PrefectHQ/prefect-ui-library/pull/2355
     skipDefaultValueInitialization?: boolean,
     // In cases like SchemaFormPropertyAnyOf or SchemaPropertyAllOf the property is modified before being passed into this component
     // But in order to do proper validation of the value we want to use the full unmodified property.

--- a/src/schemas/components/SchemaFormProperty.vue
+++ b/src/schemas/components/SchemaFormProperty.vue
@@ -60,6 +60,7 @@
     value: SchemaValue,
     required: boolean,
     errors: SchemaValueError[],
+    skipDefaultValueInitialization?: boolean,
     // In cases like SchemaFormPropertyAnyOf or SchemaPropertyAllOf the property is modified before being passed into this component
     // But in order to do proper validation of the value we want to use the full unmodified property.
     propertyForValidation?: SchemaProperty,
@@ -111,7 +112,7 @@
     },
   })
 
-  if (!isDefined(props.value) && isDefined(property.value.default)) {
+  if (!props.skipDefaultValueInitialization && !isDefined(props.value) && isDefined(property.value.default)) {
     emit('update:value', property.value.default)
 
     const unwatch = watch(() => props.value, () => {

--- a/src/schemas/components/SchemaFormPropertyAnyOf.vue
+++ b/src/schemas/components/SchemaFormPropertyAnyOf.vue
@@ -7,8 +7,10 @@
       :property-for-validation="property"
       :required
       :errors
+      :skip-default-value-initialization
       class="schema-form-property-any-of-input"
       @update:value="updateValue"
+      @vnode-mounted="() => skipDefaultValueInitialization = true"
     >
       <template #default="{ kind }">
         <template v-if="kind === 'none'">
@@ -44,6 +46,7 @@
   const schema = useSchema()
   const propertyValues = reactive<SchemaValue[]>([])
   const selectedPropertyIndexValue = ref<number>(0)
+  const skipDefaultValueInitialization = ref(false)
 
   // we need to await this during setup so that the initial default value gets populated correctly
   // if we wait until mount when onActivated is called the child will override the value with its default value
@@ -76,7 +79,7 @@
     let index = await getInitialIndexForSchemaPropertyAnyOfValue({ value, property: props.property, api, schema })
 
     if (index === -1) {
-      console.error('Could not determine property index')
+      console.warn('SchemaFormPropertyAnyOf could not determine the initial index for property value')
       index = selectedPropertyIndex.value
     }
 
@@ -132,7 +135,8 @@
     })
 
     if (index === -1) {
-      throw 'not implemented'
+      console.warn('SchemaFormPropertyAnyOf could not determine the initial index for property value')
+      return
     }
 
     selectedPropertyIndexValue.value = index


### PR DESCRIPTION
# Description
Closes: https://github.com/PrefectHQ/prefect/issues/13219

Caused by https://github.com/PrefectHQ/prefect-ui-library/pull/2344 and https://github.com/PrefectHQ/prefect-ui-library/pull/2342 which when combined caused parameters that are a union and have a default value to be unable to be edited. And then the parameter could just disappear from the form altogether. 

This is because `SchemaFormPropertyAny` resets the value back to `undefined` when switching parameter types. Then `SchemaFormProperty` would detect that the default value had not been initialized and reset its value. 

Unsure why the parameter would disappear after attempting this twice, but I'm unable to reproduce either issue now. 