### PR TITLE
Add the do nothing option for automation actions

### DIFF
--- a/src/automations/components/AutomationActionDescription.vue
+++ b/src/automations/components/AutomationActionDescription.vue
@@ -1,5 +1,7 @@
 <template>
-  <component :is="description.component" v-bind="description.props" class="automation-action-description" />
+  <template v-if="description">
+    <component :is="description.component" v-bind="description.props" class="automation-action-description" />
+  </template>
 </template>
 
 <script lang="ts" setup>
@@ -58,6 +60,10 @@
         return withProps(AutomationActionDescriptionDefault, {
           action: props.action,
         })
+
+      case 'do-nothing':
+        return null
+
       default:
         const exhaustive: never = props.action
         throw new Error(`AutomationActionDescription has no case for type: ${(exhaustive as AutomationAction).type}`)

--- a/src/automations/components/AutomationActionInput.vue
+++ b/src/automations/components/AutomationActionInput.vue
@@ -98,6 +98,7 @@
 
       case 'cancel-flow-run':
       case 'suspend-flow-run':
+      case 'do-nothing':
         return null
 
       case undefined:

--- a/src/automations/maps/actions.ts
+++ b/src/automations/maps/actions.ts
@@ -49,6 +49,7 @@ export const mapAutomationActionResponseToAutomationAction: MapFunction<Automati
     case 'cancel-flow-run':
     case 'suspend-flow-run':
     case 'change-flow-run-state':
+    case 'do-nothing':
       return response
     default:
       const exhaustive: never = response
@@ -77,6 +78,7 @@ export const mapAutomationActionToAutomationActionRequest: MapFunction<Automatio
     case 'cancel-flow-run':
     case 'suspend-flow-run':
     case 'change-flow-run-state':
+    case 'do-nothing':
       return request
     default:
       const exhaustive: never = request

--- a/src/automations/types/actions.ts
+++ b/src/automations/types/actions.ts
@@ -17,6 +17,7 @@ export const { values: automationActionTypes, isValue: isAutomationActionType } 
   'pause-automation',
   'resume-automation',
   'send-notification',
+  'do-nothing',
 ])
 
 export type AutomationActionType = typeof automationActionTypes[number]
@@ -35,6 +36,7 @@ export const automationActionTypeLabels = {
   'pause-automation': 'Pause an automation',
   'resume-automation': 'Resume an automation',
   'send-notification': 'Send a notification',
+  'do-nothing': 'Do nothing',
 } as const satisfies Record<AutomationActionType, string>
 
 /**
@@ -265,6 +267,16 @@ function isAutomationActionSendNotification(value: unknown): value is Automation
   return isValidBlockDocumentId && isValidSubject && isValidBody
 }
 
+/*
+ * Do nothing
+ */
+
+export type AutomationActionDoNothing = AutomationActionWithType<'do-nothing'>
+
+function isAutomationActionDoNothing(value: unknown): value is AutomationActionDoNothing {
+  return isAutomationActionTypeRecord(value, 'do-nothing')
+}
+
 export type AutomationAction =
   | AutomationActionCancelFlowRun
   | AutomationActionSuspendFlowRun
@@ -279,6 +291,7 @@ export type AutomationAction =
   | AutomationActionPauseAutomation
   | AutomationActionResumeAutomation
   | AutomationActionSendNotification
+  | AutomationActionDoNothing
 
 /*
  * if this is giving you a type error you forgot to add a type for your action to the AutomationAction type
@@ -302,6 +315,7 @@ const actionTypeGuardMap = {
   'pause-automation': isAutomationActionPauseAutomation,
   'resume-automation': isAutomationActionResumeAutomation,
   'send-notification': isAutomationActionSendNotification,
+  'do-nothing': isAutomationActionDoNothing,
 } satisfies Record<AutomationActionType, (value: unknown) => boolean>
 
 export function isAutomationAction(value: unknown): value is AutomationAction {

--- a/src/automations/types/api/actions.ts
+++ b/src/automations/types/api/actions.ts
@@ -18,6 +18,7 @@ export type AutomationActionResponse =
 | AutomationActionPauseAutomationResponse
 | AutomationActionResumeAutomationResponse
 | AutomationActionSendNotificationResponse
+| AutomationActionDoNothingResponse
 
 export type AutomationActionRequest = AutomationActionResponse
 
@@ -186,3 +187,8 @@ export type AutomationActionSendNotificationResponse = AutomationActionWithType<
   subject: string,
   body: string,
 }>
+
+/**
+ * Do nothing
+ */
+export type AutomationActionDoNothingResponse = AutomationActionWithType<'do-nothing'>


### PR DESCRIPTION
# Description
This action is used internally and we'd like it to show up in the ui if used. This will be filtered out upstream so it doesn't show in the drop down unless it was already selected. 