### PR TITLE
Fix: Flow Run Accordion

### DIFF
--- a/src/components/FlowRunsAccordion.vue
+++ b/src/components/FlowRunsAccordion.vue
@@ -1,8 +1,8 @@
 <template>
   <template v-if="flowIds">
     <p-accordion :sections="flowIds" class="flow-runs-accordion">
-      <template #header="{ section: flowId, id, toggle, content, selected }">
-        <FlowRunsAccordionHeader :flow="getFlow(flowId)" :filter="flowRunsFilter" v-bind="{ id, content, toggle, selected }" />
+      <template #heading="{ section: flowId, selected }">
+        <FlowRunsAccordionHeader :flow="getFlow(flowId)" :filter="flowRunsFilter" v-bind="{ selected }" />
       </template>
       <template #content="{ section: flowId }">
         <FlowRunsAccordionContent :flow-id="flowId" :filter="flowRunsFilter" />
@@ -63,7 +63,7 @@
 </script>
 
 <style>
-.p-accordion__section:first-child .flow-runs-accordion-header:first-of-type { @apply
-  border-0
+.flow-runs-accordion *:last-child {@apply
+  border-b-0
 }
 </style>

--- a/src/components/FlowRunsAccordionHeader.vue
+++ b/src/components/FlowRunsAccordionHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :id="id" class="flow-runs-accordion-header">
+  <div :id="flow.id" class="flow-runs-accordion-header">
     <div class="flow-runs-accordion-header__content">
       <p-link :to="routes.flow(flow.id)" class="flow-runs-accordion-header__name">
         {{ flow.name }}
@@ -8,10 +8,10 @@
         {{ lastRunTime }}
       </span>
     </div>
-    <p-button size="sm" :aria-controls="content" @click="toggle">
+
+    <span class="flow-runs-accordion-header__count">
       {{ count }}
-      <p-icon size="small" icon="ChevronDownIcon" class="flow-runs-accordion-header__icon" :class="classes.icon" />
-    </p-button>
+    </span>
   </div>
 </template>
 
@@ -27,21 +27,11 @@
 
   const props = defineProps<{
     flow: Flow,
-    id: string,
-    selected: boolean,
-    content: string,
-    toggle: () => void,
     filter?: FlowRunsFilter,
   }>()
 
   const routes = useWorkspaceRoutes()
   const { now } = useNow({ interval: 1000 })
-
-  const classes = computed(() => ({
-    icon: {
-      'flow-runs-accordion-header__icon--selected': props.selected,
-    },
-  }))
 
   const filter = computed<FlowRunsFilter>(() => ({
     ...props.filter,
@@ -66,12 +56,11 @@
 <style>
 .flow-runs-accordion-header { @apply
   flex
-  items-start
+  flex-1
   gap-2
   justify-between
-  border-t
-  border-divider
   py-2
+  items-center
 }
 
 .flow-runs-accordion-header__content { @apply
@@ -83,6 +72,11 @@
 .flow-runs-accordion-header__time { @apply
   text-xs
   text-subdued
+  text-left
+}
+
+.flow-runs-accordion-header__count { @apply
+  text-sm mr-2
 }
 
 .flow-runs-accordion-header__icon { @apply


### PR DESCRIPTION
A visual regression was introduced as the result of an upstream change in
 https://github.com/PrefectHQ/prefect-design/pull/1255.

The name of the slot changed, so the rendering for the accordion header was falling back onto the section name, which was simply the flow id. This PR corrects the use of the updated slot name, and also accounts for the fact that the new accordion renders borders on the top bottom of each element by default (instead of top). 
<img width="731" alt="Screenshot 2024-05-06 at 6 55 55 AM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/33043305/59239184-9f39-4e0d-90d2-786a634e5f91">
