### PR TITLE
Chore: Make sure `useFlowRuns` accepts subscription options

### DIFF
--- a/src/compositions/useFlowRuns.ts
+++ b/src/compositions/useFlowRuns.ts
@@ -1,6 +1,6 @@
 import { MaybeReadonly } from '@prefecthq/prefect-design'
-import { UseSubscription, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { ComputedRef, MaybeRefOrGetter, computed, toRef, toValue } from 'vue'
+import { UseSubscription, useSubscriptionWithDependencies, SubscriptionOptions } from '@prefecthq/vue-compositions'
+import { ComputedRef, MaybeRef, MaybeRefOrGetter, computed, toRef, toValue } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
 import { FlowRun, FlowRunsFilter } from '@/models'
@@ -12,7 +12,7 @@ export type UseFlowRuns = {
   flowRuns: ComputedRef<FlowRun[]>,
 }
 
-export function useFlowRuns(filter?: MaybeRefOrGetter<MaybeReadonly<FlowRunsFilter> | null | undefined>): UseFlowRuns {
+export function useFlowRuns(filter?: MaybeRefOrGetter<MaybeReadonly<FlowRunsFilter> | null | undefined>, options?: MaybeRef<SubscriptionOptions>): UseFlowRuns {
   const api = useWorkspaceApi()
   const can = useCan()
 
@@ -31,7 +31,7 @@ export function useFlowRuns(filter?: MaybeRefOrGetter<MaybeReadonly<FlowRunsFilt
   }
 
   const parametersRef = toRef(parameters)
-  const subscription = useSubscriptionWithDependencies(api.flowRuns.getFlowRuns, parametersRef)
+  const subscription = useSubscriptionWithDependencies(api.flowRuns.getFlowRuns, parametersRef, options)
   const flowRuns = computed(() => subscription.response ?? [])
 
   return {

--- a/src/compositions/useLastFlowRun.ts
+++ b/src/compositions/useLastFlowRun.ts
@@ -1,5 +1,6 @@
+import { SubscriptionOptions } from '@prefecthq/vue-compositions'
 import merge from 'lodash.merge'
-import { computed, ComputedRef, MaybeRefOrGetter, toValue } from 'vue'
+import { computed, ComputedRef, MaybeRef, MaybeRefOrGetter, toValue } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { UseFlowRuns, useFlowRuns } from '@/compositions/useFlowRuns'
 import { FlowRun, FlowRunsFilter, UnionFilter } from '@/models'
@@ -8,7 +9,7 @@ export type UseLastFlowRun = Pick<UseFlowRuns, 'subscription'> & {
   flowRun: ComputedRef<FlowRun | undefined>,
 }
 
-export function useLastFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | undefined>): UseLastFlowRun {
+export function useLastFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | undefined>, options?: MaybeRef<SubscriptionOptions>): UseLastFlowRun {
   const can = useCan()
 
   const getter = (): FlowRunsFilter | null => {
@@ -29,7 +30,7 @@ export function useLastFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | und
     return merge({}, filterValue, latestFilter)
   }
 
-  const { flowRuns, subscription } = useFlowRuns(getter)
+  const { flowRuns, subscription } = useFlowRuns(getter, options)
   const flowRun = computed(() => flowRuns.value.at(0))
 
   return {

--- a/src/compositions/useNextFlowRun.ts
+++ b/src/compositions/useNextFlowRun.ts
@@ -1,5 +1,6 @@
+import { SubscriptionOptions } from '@prefecthq/vue-compositions'
 import merge from 'lodash.merge'
-import { computed, ComputedRef, MaybeRefOrGetter, toValue } from 'vue'
+import { computed, ComputedRef, MaybeRef, MaybeRefOrGetter, toValue } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { UseFlowRuns, useFlowRuns } from '@/compositions/useFlowRuns'
 import { FlowRun, FlowRunsFilter, UnionFilter } from '@/models'
@@ -8,7 +9,7 @@ export type UseNextFlowRun = Pick<UseFlowRuns, 'subscription'> & {
   flowRun: ComputedRef<FlowRun | undefined>,
 }
 
-export function useNextFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | undefined>): UseNextFlowRun {
+export function useNextFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | undefined>, options?: MaybeRef<SubscriptionOptions>): UseNextFlowRun {
   const can = useCan()
 
   const getter = (): FlowRunsFilter | null => {
@@ -30,7 +31,7 @@ export function useNextFlowRun(filter: MaybeRefOrGetter<UnionFilter | null | und
     return merge({}, filterValue, nextFlowRunFilter)
   }
 
-  const { flowRuns, subscription } = useFlowRuns(getter)
+  const { flowRuns, subscription } = useFlowRuns(getter, options)
   const flowRun = computed(() => flowRuns.value.at(0))
 
   return {


### PR DESCRIPTION
#2406 changed the behavior of `useFlowRuns` to no longer act as a pagination intermediary. However, I failed to re-introduce subscription options to the composition (something pagination options wrap already) so this PR fixes that for `useFlowRuns`, `useNextFlowRun`, and `useLastFlowRun`.