### PR TITLE
Bugfix: Add a redirect for flow runs to the new runs route

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -52,6 +52,11 @@ export function createWorkspaceRouteRecords(components: Partial<WorkspaceRouteCo
       ],
     },
     {
+      path: 'flow-runs',
+      name: 'workspace.flow-runs',
+      redirect: { name: 'workspace.runs' },
+    },
+    {
       path: 'flows',
       meta: {
         can: 'read:flow',

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -26,6 +26,7 @@ export function createWorkspaceRoutes(config?: CreateWorkspaceRoutesConfig) {
     artifacts: () => ({ name: 'workspace.artifacts', params: { ...config } }) as const,
     dashboard: () => ({ name: 'workspace.dashboard', params: { ...config } }) as const,
     runs: (query?: { tab?: string }) => ({ name: 'workspace.runs', params: { ...config }, query }) as const,
+    flowRuns: () => ({ name: 'workspace.flow-runs', params: { ...config } }) as const,
     flowRun: (flowRunId: string) => ({ name: 'workspace.runs.flow-run', params: { flowRunId, ...config } }) as const,
     taskRun: (taskRunId: string) => ({ name: 'workspace.runs.task-run', params: { taskRunId, ...config } }) as const,
     flows: () => ({ name: 'workspace.flows', params: { ...config } }) as const,


### PR DESCRIPTION
We need to maintain this redirect for backwards compatibility with core clients. 