### PR TITLE
Chore: Redirect old flow-runs child routes as well

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,7 +9,8 @@ type WorkspaceRoutes = ReturnType<typeof createWorkspaceRoutes>
 type WorkspaceRouteKey = keyof WorkspaceRoutes
 type WorkspaceRoute = ReturnType<WorkspaceRoutes[WorkspaceRouteKey]>
 
-export type WorkspaceNamedRoute = WorkspaceRoute['name']
+export type DeprecatedNamedRoutes = 'workspace.flow-runs' | 'workspace.flow-runs.flow-run' | 'workspace.flow-runs.task-run'
+export type WorkspaceNamedRoute = WorkspaceRoute['name'] | DeprecatedNamedRoutes
 
 type WorkspaceRouteRecordParent = { name?: WorkspaceNamedRoute, children: WorkspaceRouteRecord[] }
 type WorkspaceRouteRecordChild = { name: WorkspaceNamedRoute }
@@ -54,7 +55,19 @@ export function createWorkspaceRouteRecords(components: Partial<WorkspaceRouteCo
     {
       path: 'flow-runs',
       name: 'workspace.flow-runs',
-      redirect: { name: 'workspace.runs' },
+      redirect: to => ({ name: 'workspace.runs', query: to.query, params: to.params }),
+      children: [
+        {
+          name: 'workspace.flow-runs.flow-run',
+          path: 'flow-run/:flowRunId',
+          redirect: to => ({ name: 'workspace.runs.flow-run', query: to.query, params: to.params }),
+        },
+        {
+          name: 'workspace.flow-runs.task-run',
+          path: 'task-run/:taskRunId',
+          redirect: to => ({ name: 'workspace.runs.task-run', query: to.query, params: to.params }),
+        },
+      ],
     },
     {
       path: 'flows',

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -26,6 +26,7 @@ export function createWorkspaceRoutes(config?: CreateWorkspaceRoutesConfig) {
     artifacts: () => ({ name: 'workspace.artifacts', params: { ...config } }) as const,
     dashboard: () => ({ name: 'workspace.dashboard', params: { ...config } }) as const,
     runs: (query?: { tab?: string }) => ({ name: 'workspace.runs', params: { ...config }, query }) as const,
+    /** @deprecated use workspace.runs instead */
     flowRuns: () => ({ name: 'workspace.flow-runs', params: { ...config } }) as const,
     flowRun: (flowRunId: string) => ({ name: 'workspace.runs.flow-run', params: { flowRunId, ...config } }) as const,
     taskRun: (taskRunId: string) => ({ name: 'workspace.runs.task-run', params: { taskRunId, ...config } }) as const,


### PR DESCRIPTION
Unfortunately vue doesn't match on the top level route when following links from the CLI. This update adds a deprecation notice to the `flowRuns` route, child routes with their own redirects, and ensures query and route params are included during redirects to make sure existing perm links are respected.