### PR TITLE
Enhancement: List limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "vue-tsc": "^2.0.17"
             },
             "peerDependencies": {
-                "@prefecthq/prefect-design": "^2.10.4",
+                "@prefecthq/prefect-design": "^2.10.5",
                 "@prefecthq/vue-charts": "^2.0.3",
                 "@prefecthq/vue-compositions": "^1.11.4",
                 "vee-validate": "^4.7.0",
@@ -1181,9 +1181,9 @@
             }
         },
         "node_modules/@prefecthq/prefect-design": {
-            "version": "2.10.4",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.10.4.tgz",
-            "integrity": "sha512-W+hoSEs+AKlFsQBvL+YGqkLrBabwsn+lPjUrorLNrB8pywIHVaPcpnraFEoVU63q0K3m1TZ6516E3YtHAbiRJw==",
+            "version": "2.10.5",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.10.5.tgz",
+            "integrity": "sha512-99tBsXAdFTDAgMUdjcNxNHIVxGW87dfUny9oepboLP3IUbUYQEIoQEucXk039TXBN0sYwoDZrMXFZLczpAPqgw==",
             "peer": true,
             "dependencies": {
                 "@heroicons/vue": "2.0.17",
@@ -8645,9 +8645,9 @@
             }
         },
         "@prefecthq/prefect-design": {
-            "version": "2.10.4",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.10.4.tgz",
-            "integrity": "sha512-W+hoSEs+AKlFsQBvL+YGqkLrBabwsn+lPjUrorLNrB8pywIHVaPcpnraFEoVU63q0K3m1TZ6516E3YtHAbiRJw==",
+            "version": "2.10.5",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.10.5.tgz",
+            "integrity": "sha512-99tBsXAdFTDAgMUdjcNxNHIVxGW87dfUny9oepboLP3IUbUYQEIoQEucXk039TXBN0sYwoDZrMXFZLczpAPqgw==",
             "peer": true,
             "requires": {
                 "@heroicons/vue": "2.0.17",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "vue-tsc": "^2.0.17"
     },
     "peerDependencies": {
-        "@prefecthq/prefect-design": "^2.10.4",
+        "@prefecthq/prefect-design": "^2.10.5",
         "@prefecthq/vue-charts": "^2.0.3",
         "@prefecthq/vue-compositions": "^1.11.4",
         "vee-validate": "^4.7.0",

--- a/src/components/BlockDocumentsTable.vue
+++ b/src/components/BlockDocumentsTable.vue
@@ -58,13 +58,13 @@
       </template>
     </p-table>
 
-    <p-pager v-if="pages > 1" v-model:page="page" :pages="pages" />
+    <p-pager v-if="pages > 1" v-model:limit="limit" v-model:page="page" :pages="pages" />
   </div>
 </template>
 
 <script lang="ts" setup>
   import { media, TableColumn, PEmptyResults } from '@prefecthq/prefect-design'
-  import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
+  import { NumberRouteParam, useDebouncedRef, useLocalStorage, useRouteQueryParam } from '@prefecthq/vue-compositions'
   import merge from 'lodash.merge'
   import { computed, ref, ComputedRef } from 'vue'
   import BlockSchemaCapabilities from '@/components/BlockSchemaCapabilities.vue'
@@ -113,7 +113,9 @@
   const searchTerm = ref('')
   const searchTermDebounced = useDebouncedRef(searchTerm, 500)
 
-  const { filter } = useBlockDocumentsFilterFromRoute({
+  const { value: limit } = useLocalStorage('block-documents-table-limit', 10)
+
+  const { filter: routeFilter } = useBlockDocumentsFilterFromRoute({
     blockSchemas: {
       blockCapabilities: capabilities,
     },
@@ -123,11 +125,11 @@
     blockTypes: {
       slug: blockTypes,
     },
-    limit: 50,
+    limit,
     sort: 'BLOCK_TYPE_AND_NAME_ASC',
   })
 
-  const { blockDocuments, total, pages, subscriptions } = useBlockDocuments(() => merge({}, props.filter, filter), {
+  const { blockDocuments, total, pages, subscriptions } = useBlockDocuments(() => merge({}, props.filter, routeFilter), {
     page,
   })
 

--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -114,13 +114,13 @@
       </template>
     </p-table>
 
-    <p-pager v-if="pages > 1" v-model:page="page" :pages="pages" />
+    <p-pager v-if="pages > 1" v-model:limit="limit" v-model:page="page" :pages="pages" />
   </p-content>
 </template>
 
 <script lang="ts" setup>
   import { TableColumn, media } from '@prefecthq/prefect-design'
-  import { NumberRouteParam, useDebouncedRef, useRouteQueryParam } from '@prefecthq/vue-compositions'
+  import { NumberRouteParam, useDebouncedRef, useLocalStorage, useRouteQueryParam } from '@prefecthq/vue-compositions'
   import { secondsInWeek } from 'date-fns/constants'
   import { snakeCase } from 'lodash'
   import merge from 'lodash.merge'
@@ -160,12 +160,13 @@
 
   const nameLike = ref<string>()
   const nameLikeDebounced = useDebouncedRef(nameLike, 1200)
+  const { value: limit } = useLocalStorage('deployment-list-limit', 10)
 
   const { filter, clear, isCustomFilter } = useDeploymentsFilterFromRoute(merge({}, props.filter, {
     deployments: {
       flowOrDeploymentNameLike: nameLikeDebounced,
     },
-    limit: 50,
+    limit,
   }), props.prefix)
 
   const page = useRouteQueryParam('page', NumberRouteParam, 1)

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -81,13 +81,13 @@
       </template>
     </p-table>
 
-    <p-pager v-if="pages > 1" v-model:page="page" :pages="pages" />
+    <p-pager v-if="pages > 1" v-model:page="page" v-model:limit="limit" :pages="pages" />
   </p-content>
 </template>
 
 <script lang="ts" setup>
   import { ColumnClassesMethod, TableColumn } from '@prefecthq/prefect-design'
-  import { NumberRouteParam, useDebouncedRef, useRouteQueryParam, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
+  import { NumberRouteParam, useDebouncedRef, useLocalStorage, useRouteQueryParam, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
   import { secondsInWeek } from 'date-fns/constants'
   import merge from 'lodash.merge'
   import { computed, ref, toRef } from 'vue'
@@ -121,13 +121,14 @@
   const can = useCan()
   const routes = useWorkspaceRoutes()
 
+  const { value: limit } = useLocalStorage('list-limit', 10)
   const flowNameLike = ref<string>()
   const flowNameLikeDebounced = useDebouncedRef(flowNameLike, 1200)
   const { filter, clear, isCustomFilter } = useFlowsFilterFromRoute(merge({}, props.filter, {
     flows: {
       nameLike: flowNameLikeDebounced,
     },
-    limit: 50,
+    limit,
   }))
 
   const page = useRouteQueryParam('page', NumberRouteParam, 1)

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -121,7 +121,7 @@
   const can = useCan()
   const routes = useWorkspaceRoutes()
 
-  const { value: limit } = useLocalStorage('list-limit', 10)
+  const { value: limit } = useLocalStorage('flow-list-limit', 10)
   const flowNameLike = ref<string>()
   const flowNameLikeDebounced = useDebouncedRef(flowNameLike, 1200)
   const { filter, clear, isCustomFilter } = useFlowsFilterFromRoute(merge({}, props.filter, {

--- a/src/components/VariablesTable.vue
+++ b/src/components/VariablesTable.vue
@@ -68,13 +68,13 @@
       </template>
     </p-table>
 
-    <p-pager v-if="variables.length" v-model:page="page" :pages="pages" />
+    <p-pager v-if="variables.length" v-model:limit="limit" v-model:page="page" :pages="pages" />
   </p-content>
 </template>
 
 <script lang="ts" setup>
   import { PTable, PEmptyResults, TableColumn, ClassValue } from '@prefecthq/prefect-design'
-  import { useDebouncedRef, useSubscription } from '@prefecthq/vue-compositions'
+  import { useDebouncedRef, useLocalStorage, useSubscription } from '@prefecthq/vue-compositions'
   import merge from 'lodash.merge'
   import { computed, ref } from 'vue'
   import { VariablesDeleteButton, VariableMenu, ResultsCount, SearchInput, SelectedCount, VariableTagsInput } from '@/components'
@@ -101,6 +101,7 @@
     return (page.value - 1) * DEFAULT_LIMIT
   })
   const pages = computed(() => Math.ceil((variablesCount.value ?? DEFAULT_LIMIT) / DEFAULT_LIMIT))
+  const { value: limit } = useLocalStorage('variables-table-limit', 10)
 
   const { filter, isCustomFilter, clear } = useVariablesFilter(merge({}, props.filter, {
     variables: {


### PR DESCRIPTION
This PR updates the deployment, block documents, variables, and flows list components to take advantage of the new p-pager limit functionality. Each table now has a default items per page limit of 10 with the ability to change the default up to the previous max of 50.
 
There are several reasons to lower the default limit on these:
1. Improved performance; many of these tables make calls on a per-row basis or to more expensive endpoints; each item in the list adds to the overall load time and increases the potential number of times that a user might experience content shifting on the page as data is hydrated
2. There's [research/guidance](https://catsy.com/blog/how-many-products-should-i-show-per-page) to suggest that the ideal number of items to display in a list is somewhere in the 5-50 range, skewing lower depending on the complexity of the objects being shown. Following this guidance lowers the amount of cognitive overhead required to scan these lists and helps users better learn and navigate the product.
