### PR TITLE
Chore: Improve truncated deployment name/flow column styles.

### DIFF
--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -47,7 +47,7 @@
 
       <template #deployment="{ row }">
         <div class="deployment-list__deployment">
-          <router-link :to="routes.deployment(row.id)" class="deployment-list__name">
+          <router-link :to="routes.deployment(row.id)" class="deployment-list__name" :title="row.name">
             {{ row.name }}
           </router-link>
 

--- a/src/components/FlowPopover.vue
+++ b/src/components/FlowPopover.vue
@@ -6,7 +6,7 @@
         <FlowRouterLink :flow-id="flowId">
           <div v-if="flow" class="flow-popover__link" v-bind="$attrs">
             <p-icon icon="PFlow" small class="flow-popover__link-icon" />
-            <span class="flow-popover__link-name">{{ flow.name }}</span>
+            <span class="flow-popover__link-name" :title="flow.name">{{ flow.name }}</span>
           </div>
         </FlowRouterLink>
       </slot>
@@ -17,7 +17,7 @@
         <FlowRouterLink :flow-id="flowId">
           <div v-if="flow" class="flow-popover__link">
             <p-icon icon="PFlow" small class="flow-popover__link-icon" />
-            <span class="flow-popover__link-name">{{ flow.name }}</span>
+            <span class="flow-popover__link-name" :title="flow.name">{{ flow.name }}</span>
           </div>
         </FlowRouterLink>
 
@@ -63,11 +63,11 @@
 }
 
 .flow-popover__link-name { @apply
-  shrink
   truncate
 }
 
 .flow-popover__link-icon { @apply
+  shrink-0
   h-3
   w-3
 }


### PR DESCRIPTION
Follow-up to https://github.com/PrefectHQ/prefect-design/pull/1301 which removes titles at the `p-table` level. This PR _adds_ `title` attributes to the truncated text in this table. 