### PR TITLE
Chore: Standardize on p-loading-icon for table loading states.

### DIFF
--- a/src/components/BlockDocumentsTable.vue
+++ b/src/components/BlockDocumentsTable.vue
@@ -52,7 +52,7 @@
         </PEmptyResults>
         <PEmptyResults v-else>
           <template #message>
-            Loading...
+            <p-loading-icon />
           </template>
         </PEmptyResults>
       </template>

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -75,7 +75,7 @@
         </PEmptyResults>
         <PEmptyResults v-else>
           <template #message>
-            Loading...
+            <p-loading-icon />
           </template>
         </PEmptyResults>
       </template>

--- a/src/components/VariablesTable.vue
+++ b/src/components/VariablesTable.vue
@@ -55,7 +55,7 @@
       </template>
 
       <template #empty-state>
-        <PEmptyResults>
+        <PEmptyResults v-if="variablesSubscription.executed">
           <template #message>
             {{ localization.info.noVariables }}
           </template>
@@ -63,6 +63,11 @@
             <p-button size="sm" @click="clear">
               Clear Filters
             </p-button>
+          </template>
+        </PEmptyResults>
+        <PEmptyResults v-else>
+          <template #message>
+            <p-loading-icon />
           </template>
         </PEmptyResults>
       </template>


### PR DESCRIPTION
At the moment, `<DeploymentsList />` using `<p-loading-icon>` (a spinner).

BlockDocumentsTable and FlowList both use `Loading...` and Variables falls back to its empty state. 

This PR makes all 4 use `<p-loading-icon/>`