### PR TITLE
Bugfix: Route to work pools page from work pool on delete

### DIFF
--- a/src/components/PageHeadingWorkPool.vue
+++ b/src/components/PageHeadingWorkPool.vue
@@ -34,6 +34,6 @@
   ])
 
   const handleDelete = (): void => {
-    router.back()
+    router.push(routes.workPools())
   }
 </script>


### PR DESCRIPTION
Previously this was using `router.back()` which would lead to some weird situations where we'd attempt to route back to the work pool page that no longer existed.