### PR TITLE
Bugfix: Fix run deployment automation action now showing parameters on edit

### DIFF
--- a/src/automations/components/AutomationActionRunDeploymentInput.vue
+++ b/src/automations/components/AutomationActionRunDeploymentInput.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed, ref, watch } from 'vue'
+  import { computed, onMounted, ref, watch } from 'vue'
   import AutomationActionRunDeploymentParameters from '@/automations/components/AutomationActionRunDeploymentParameters.vue'
   import AutomationDeploymentCombobox from '@/automations/components/AutomationDeploymentCombobox.vue'
   import { AutomationActionRunDeployment } from '@/automations/types/actions'
@@ -94,4 +94,14 @@
       // validation for this field is handled by the FlowRunJobVariableOverridesLabeledInput component
     }
   }
+
+  onMounted(() => {
+    if (deploymentId.value) {
+      setDeploymentId(deploymentId.value)
+
+      if (props.action.parameters) {
+        setParametersForDeployment(deploymentId.value, props.action.parameters)
+      }
+    }
+  })
 </script>


### PR DESCRIPTION
This an issue where the `AutomationActionRunDeploymentInput` component was initializing deployment/parameters state when the deployment id changed. This meant that when returning to the form, prior values were ignored and the deployment needed to be re-selected. 


Resolves https://github.com/PrefectHQ/nebula-ui/issues/4723