### PR TITLE
Enhancement: Show pagination even if there's just 1 page

### DIFF
--- a/src/components/BlockDocumentsTable.vue
+++ b/src/components/BlockDocumentsTable.vue
@@ -58,7 +58,7 @@
       </template>
     </p-table>
 
-    <p-pager v-if="pages > 1" v-model:limit="limit" v-model:page="page" :pages="pages" />
+    <p-pager v-model:limit="limit" v-model:page="page" :pages="pages" />
   </div>
 </template>
 

--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -114,7 +114,7 @@
       </template>
     </p-table>
 
-    <p-pager v-if="pages > 1" v-model:limit="limit" v-model:page="page" :pages="pages" />
+    <p-pager v-model:limit="limit" v-model:page="page" :pages="pages" />
   </p-content>
 </template>
 

--- a/src/components/DeploymentsList.vue
+++ b/src/components/DeploymentsList.vue
@@ -108,7 +108,7 @@
       </template>
     </p-table>
 
-    <p-pager v-if="pages > 1" v-model:page="page" :pages="pages" />
+    <p-pager v-model:page="page" :pages="pages" />
   </p-content>
 </template>
 

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -81,7 +81,7 @@
       </template>
     </p-table>
 
-    <p-pager v-if="pages > 1" v-model:page="page" v-model:limit="limit" :pages="pages" />
+    <p-pager v-model:page="page" v-model:limit="limit" :pages="pages" />
   </p-content>
 </template>
 


### PR DESCRIPTION
This PR removes the constraint that we only show pagination info when tables contain more than 1 page. This was a confusing constraint generally. 