### PR TITLE
Fix "Show more" button on the flow runs widget

### DIFF
--- a/src/components/FlowRunsAccordionContent.vue
+++ b/src/components/FlowRunsAccordionContent.vue
@@ -18,10 +18,7 @@
   const props = defineProps<{
     flowId: string,
     filter?: FlowRunsFilter,
-    flowRunLimit?: number,
   }>()
-
-  const limit = computed(() => props.flowRunLimit ?? 3)
 
   const filter = (): FlowRunsFilter => ({
     ...props.filter,
@@ -36,7 +33,7 @@
     mode: 'infinite',
   })
 
-  const more = computed(() => total.value > limit.value)
+  const more = computed(() => total.value > flowRuns.value.length)
 
   next()
 </script>


### PR DESCRIPTION
# Description
The "Show more" button is supposed to go away once a user has loaded all of the available runs. But the logic was broken and this would never happen. Which meant users would end up clicking a button that doesn't do anything. 

Fixed by fixing the logic for showing the button. 