### PR TITLE
Fix TimezoneSelect defaulting to `UTC`

### DIFF
--- a/src/components/IntervalScheduleForm.vue
+++ b/src/components/IntervalScheduleForm.vue
@@ -48,7 +48,7 @@
   import { computed, ref, watch, onMounted } from 'vue'
   import TimezoneSelect from '@/components/TimezoneSelect.vue'
   import { IntervalSchedule } from '@/models'
-  import { setTimezone, toPluralString, unsetTimezone } from '@/utilities'
+  import { toPluralString, unsetTimezone } from '@/utilities'
   import { IntervalOption, secondsToClosestIntervalOption, secondsToClosestIntervalValue, intervalOptionsToSecondsMap } from '@/utilities/timeIntervals'
   import { fieldRules, isGreaterThanOrEqual, isRequired } from '@/utilities/validation'
 

--- a/src/components/TimezoneSelect.vue
+++ b/src/components/TimezoneSelect.vue
@@ -25,7 +25,7 @@
 
   const internalValue = computed({
     get() {
-      return props.modelValue ?? 'UTC'
+      return props.modelValue
     },
     set(val) {
       emit('update:modelValue', val)

--- a/src/components/TimezoneSelect.vue
+++ b/src/components/TimezoneSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-combobox v-model="internalValue" :options="timezoneOptions" :append="timestamp">
+  <p-combobox v-model="modelValue" :options="timezoneOptions" :append="timestamp">
     <template v-for="(index, name) in $slots" #[name]="data">
       <slot :name="name" v-bind="data" />
     </template>
@@ -13,27 +13,15 @@
   import { titleCase } from '@/utilities/strings'
   import { formatDateInTimezone, utcTimezone } from '@/utilities/timezone'
 
+  const modelValue = defineModel<string | null>({ required: true })
+
   const props = defineProps<{
-    modelValue: string | null,
     showTimestamp?: boolean,
     hideUnset?: boolean,
   }>()
 
-  const emit = defineEmits<{
-    (event: 'update:modelValue', value: string | null): void,
-  }>()
-
-  const internalValue = computed({
-    get() {
-      return props.modelValue
-    },
-    set(val) {
-      emit('update:modelValue', val)
-    },
-  })
-
   const currentTime = ref(new Date())
-  const timestamp = computed(() => props.showTimestamp ? formatDateInTimezone(currentTime.value, 'hh:mm a', props.modelValue) : undefined)
+  const timestamp = computed(() => props.showTimestamp ? formatDateInTimezone(currentTime.value, 'hh:mm a', modelValue.value) : undefined)
 
   function updateCurrentTime(): void {
     currentTime.value = new Date()


### PR DESCRIPTION
# Description
Different implementations can have different logic for what `null` means for a timezone. For example user preferences in cloud use `null` for "Local" time (the browser's default timezone). But because of this component defaulting to `UTC` even when the user had no value for timezone in their settings (and it would say "Local" when viewing preferences) it would say `UTC` when editing (even though that is not what was saved in their profile). 

Removing the null coalesce fixes this. And other implementations of this component specify `UTC` as the default and continue to work as intended. 

**Preferences**
<img width="1076" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/9a791ac2-02b2-4ff2-8f09-cf1ca905361c">

**Editing Before**
<img width="1083" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/1392f2ba-1f87-4a29-a5a4-e2224d996414">

**Editing After**
<img width="1078" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/b090e242-2bb5-46c8-9355-8001cca3bc63">
