### PR TITLE
swapping stringifyunknown for stringify

### DIFF
--- a/src/models/VariableV2.ts
+++ b/src/models/VariableV2.ts
@@ -1,5 +1,3 @@
-import { stringifyUnknownJson } from '@/utilities'
-
 export interface IVariableV2 {
   id: string,
   created: Date,
@@ -18,7 +16,7 @@ export class VariableV2 implements IVariableV2 {
   public tags: string[]
 
   public get valueString(): string {
-    return stringifyUnknownJson(this.value) ?? ''
+    return JSON.stringify(this.value)
   }
 
   public constructor(


### PR DESCRIPTION
Previously, string variables when viewed in the edit modal were coming back without quotes, i.e invalid.

![image](https://github.com/PrefectHQ/prefect-ui-library/assets/26799928/59f74997-0b76-43c2-92c2-41e874e05c4c)


Now they are coming back accurately.

<img width="476" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/26799928/06bf5b09-5c53-484f-a96a-18e8d0b8617a">
