### PR TITLE
Show run parameters in flow run list

### DIFF
--- a/src/components/DurationIconText.vue
+++ b/src/components/DurationIconText.vue
@@ -1,6 +1,6 @@
 <template>
   <p-icon-text icon="ClockIcon" class="duration-icon-text">
-    <span>{{ label }}</span>
+    <span class="duration-icon-text__label" :class="classes.label">{{ label }}</span>
   </p-icon-text>
 </template>
 
@@ -13,4 +13,16 @@
   }>()
 
   const label = computed(() => props.duration == 0 ? 'None' : secondsToApproximateString(props.duration))
+
+  const classes = computed(() => ({
+    label: {
+      'duration-icon-text__label--none': props.duration === 0,
+    },
+  }))
 </script>
+
+<style>
+.duration-icon-text__label--none { @apply
+  text-subdued
+}
+</style>

--- a/src/components/DurationIconText.vue
+++ b/src/components/DurationIconText.vue
@@ -12,7 +12,7 @@
     duration: number,
   }>()
 
-  const label = computed(() => props.duration == 0 ? 'None' : secondsToApproximateString(props.duration))
+  const label = computed(() => secondsToApproximateString(props.duration))
 
   const classes = computed(() => ({
     label: {

--- a/src/components/FlowRunListItem.vue
+++ b/src/components/FlowRunListItem.vue
@@ -2,16 +2,19 @@
   <div ref="el" class="flow-run-list-item">
     <StateListItem v-model:selected="model" v-bind="{ selectable, value, tags, stateType }">
       <template #name>
-        <FlowRunBreadCrumbs :hide-flow-name="hideFlowName" :flow-run="flowRun" />
+        <FlowRunBreadCrumbs :hide-flow-name="hideFlowName" :flow-run />
       </template>
       <template #meta>
         <StateBadge :state="flowRun.state" />
-        <FlowRunStartTime :flow-run="flowRun" />
-        <DurationIconText :duration="flowRun.duration" />
+        <FlowRunStartTime :flow-run />
+        <FlowRunParametersIconText :flow-run />
+
         <template v-if="visible && flowRun.stateType !== 'scheduled'">
-          <IconTextCount icon="Task" :count="taskRunsCount ?? 0" label="Task run" />
+          <DurationIconText :duration="flowRun.duration" />
+          <FlowRunTasksIconText :flow-run />
         </template>
       </template>
+
       <template v-if="!hideDetails && visible && (flowRun.deploymentId || flowRun.workQueueName)" #relationships>
         <FlowRunDeployment v-if="flowRun.deploymentId" :deployment-id="flowRun.deploymentId" />
         <FlowRunWorkPool v-if="flowRun.workPoolName" :work-pool-name="flowRun.workPoolName" />
@@ -22,7 +25,8 @@
           :flow-run-state="flowRun.stateType"
         />
       </template>
-      <slot name="after" :flow-run="flowRun" />
+
+      <slot name="after" :flow-run />
     </StateListItem>
   </div>
 </template>
@@ -34,13 +38,13 @@
   import DurationIconText from '@/components/DurationIconText.vue'
   import FlowRunBreadCrumbs from '@/components/FlowRunBreadCrumbs.vue'
   import FlowRunDeployment from '@/components/FlowRunDeployment.vue'
+  import FlowRunParametersIconText from '@/components/FlowRunParametersIconText.vue'
   import FlowRunStartTime from '@/components/FlowRunStartTime.vue'
+  import FlowRunTasksIconText from '@/components/FlowRunTasksIconText.vue'
   import FlowRunWorkPool from '@/components/FlowRunWorkPool.vue'
   import FlowRunWorkQueue from '@/components/FlowRunWorkQueue.vue'
-  import IconTextCount from '@/components/IconTextCount.vue'
   import StateBadge from '@/components/StateBadge.vue'
   import StateListItem from '@/components/StateListItem.vue'
-  import { useTaskRunsCount } from '@/compositions'
   import { FlowRun } from '@/models/FlowRun'
 
   const props = defineProps<{
@@ -67,12 +71,6 @@
   const stateType = computed(() => props.flowRun.state?.type)
   const tags = computed(() => props.flowRun.tags)
   const value = computed(() => props.flowRun.id)
-
-  const { count: taskRunsCount } = useTaskRunsCount(() => ({
-    flowRuns: {
-      id: [props.flowRun.id],
-    },
-  }))
 
   const visible = ref(false)
   const el = ref<HTMLDivElement>()

--- a/src/components/FlowRunParametersIconText.vue
+++ b/src/components/FlowRunParametersIconText.vue
@@ -1,0 +1,46 @@
+<template>
+  <p-icon-text v-bind="$attrs" icon="AdjustmentsVerticalIcon" class="flow-run-parameters-icon-text">
+    <template v-if="hasParameters">
+      <button type="button" class="flow-run-parameters-icon-text__button" @click="open">
+        {{ parametersCount }} {{ toPluralString('parameter', parametersCount) }}
+      </button>
+    </template>
+    <template v-else>
+      <span class="flow-run-parameters-icon-text__none">0 parameters</span>
+    </template>
+  </p-icon-text>
+
+  <p-modal v-model:show-modal="showModal" :title="`Flow run parameters for ${flowRun.name}`" auto-close>
+    <p-code-highlight lang="json" :text="stringify(flowRun.parameters)" />
+  </p-modal>
+</template>
+
+<script lang="ts" setup>
+  import { toPluralString } from '@prefecthq/prefect-design'
+  import { computed } from 'vue'
+  import { useShowModal } from '@/compositions/useShowModal'
+  import { FlowRun } from '@/models/FlowRun'
+  import { stringify } from '@/utilities/json'
+
+  defineOptions({
+    inheritAttrs: false,
+  })
+
+  const props = defineProps<{
+    flowRun: FlowRun,
+  }>()
+
+  const parametersCount = computed(() => Object.keys(props.flowRun.parameters).length)
+  const hasParameters = computed(() => parametersCount.value > 0)
+  const { showModal, open } = useShowModal()
+</script>
+
+<style>
+.flow-run-parameters-icon-text__none { @apply
+  text-subdued
+}
+
+.flow-run-parameters-icon-text__button { @apply
+  text-link
+}
+</style>

--- a/src/components/FlowRunParametersIconText.vue
+++ b/src/components/FlowRunParametersIconText.vue
@@ -2,11 +2,11 @@
   <p-icon-text v-bind="$attrs" icon="AdjustmentsVerticalIcon" class="flow-run-parameters-icon-text">
     <template v-if="hasParameters">
       <button type="button" class="flow-run-parameters-icon-text__button" @click="open">
-        {{ parametersCount }} {{ toPluralString('parameter', parametersCount) }}
+        {{ parametersCount }} {{ toPluralString('Parameter', parametersCount) }}
       </button>
     </template>
     <template v-else>
-      <span class="flow-run-parameters-icon-text__none">0 parameters</span>
+      <span class="flow-run-parameters-icon-text__none">0 Parameters</span>
     </template>
   </p-icon-text>
 

--- a/src/components/FlowRunTasksIconText.vue
+++ b/src/components/FlowRunTasksIconText.vue
@@ -1,0 +1,38 @@
+<template>
+  <p-icon-text icon="Task" class="flow-run-tasks-icon-text">
+    <template v-if="hasTasks">
+      <span class="flow-run-parameters-icon-text__button">
+        {{ tasksCount }} {{ toPluralString('Task run', tasksCount) }}
+      </span>
+    </template>
+    <template v-else>
+      <span class="flow-run-tasks-icon-text__none">0 Task runs</span>
+    </template>
+  </p-icon-text>
+</template>
+
+<script lang="ts" setup>
+  import { toPluralString } from '@prefecthq/prefect-design'
+  import { computed } from 'vue'
+  import { useTaskRunsCount } from '@/compositions/useTaskRunsCount'
+  import { FlowRun } from '@/models/FlowRun'
+
+  const props = defineProps<{
+    flowRun: FlowRun,
+  }>()
+
+  const { count: taskRunsCount } = useTaskRunsCount(() => ({
+    flowRuns: {
+      id: [props.flowRun.id],
+    },
+  }))
+
+  const tasksCount = computed(() => taskRunsCount.value ?? 0)
+  const hasTasks = computed(() => tasksCount.value > 0)
+</script>
+
+<style>
+.flow-run-tasks-icon-text__none { @apply
+  text-subdued
+}
+</style>


### PR DESCRIPTION
# Description
Adds the ability to quickly see how many parameters were passed to a specific run and for previewing those parameters via a modal. This provides a quick way for users to parameters for runs being viewed in a list without navigating to each individual run. 

Also cleans up the duration and task run counts. 
- Hides duration for scheduled runs (because it will always be 0). 
- Show `0s` rather than `None` for any runs that exited immediately.
- Update task runs label to  `X Task runs`  rather than just the number.
- Make sure all stats (parameters, duration, and task runs) use the subdued text color when the value is 0

**Before**
<img width="690" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/a4e46099-203c-41b4-a0e5-2d6b6baa4bba">

**After**
<img width="642" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/b7968104-2ca2-441f-8d0e-830f2b01a7f8">

**Parameters modal**
<img width="591" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/559142a8-705f-4c3b-9f6e-0497b2489961">
