### PR TITLE
Move "delete" action out of menu on parameter list items

### DIFF
--- a/src/schemas/components/SchemaFormPropertyArrayItem.vue
+++ b/src/schemas/components/SchemaFormPropertyArrayItem.vue
@@ -5,6 +5,8 @@
 
       <component :is="input.component" v-bind="input.props" />
 
+      <p-button icon="TrashIcon" size="sm" @click="emit('deleteItem')" />
+
       <SchemaFormPropertyMenu v-model:value="value" :kind :property @update:kind="setKind">
         <template v-if="!isFirst">
           <p-overflow-menu-item icon="ArrowSmallUpIcon" label="Move to top" @click="emit('moveToTop')" />
@@ -12,8 +14,6 @@
         <template v-if="!isLast">
           <p-overflow-menu-item icon="ArrowSmallDownIcon" label="Move to bottom" @click="emit('moveToBottom')" />
         </template>
-
-        <p-overflow-menu-item icon="TrashIcon" label="Delete" @click="emit('deleteItem')" />
       </SchemaFormPropertyMenu>
     </div>
     <p v-if="errorMessage" class="schema-form-property-array-item__error">
@@ -77,7 +77,7 @@
   grid
   gap-2
   items-start;
-  grid-template-columns: min-content 1fr min-content;
+  grid-template-columns: min-content 1fr min-content min-content;
 }
 
 .schema-form-property-array-item__error { @apply

--- a/src/schemas/components/SchemaFormPropertyMenu.vue
+++ b/src/schemas/components/SchemaFormPropertyMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-icon-button-menu v-if="showMenu" small class="schema-form-property-menu">
+  <p-icon-button-menu v-if="showMenu" size="sm" class="schema-form-property-menu">
     <template v-if="!disabled">
       <template v-if="showNone">
         <p-overflow-menu-item v-if="showKind('none')" label="Use form input" @click="kind = 'none'" />


### PR DESCRIPTION
# Description
Since removing an item is frequently used and there is plenty of space for an additional button we can move the "delete" action out of the menu. This has been requested by a few users and I think it makes sense. 

**Before**
<img width="874" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/7c854e61-bd54-48f5-aa3d-0220d62f2c2f">


**After**
<img width="865" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/e358f1eb-ea3b-4e79-8848-4f114507b93b">
