### PR TITLE
Small tweaks for p-tooltip usages

### DIFF
--- a/src/components/FormattedDate.vue
+++ b/src/components/FormattedDate.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-tooltip class="formatted-date">
+  <p-tooltip>
     <template #content>
       <slot>
         <div class="formatted-date__tooltip">
@@ -8,9 +8,11 @@
       </slot>
     </template>
 
-    <slot name="text" v-bind="{ formattedText }">
-      {{ formattedText }}
-    </slot>
+    <button type="button" class="formatted-date">
+      <slot name="text" v-bind="{ formattedText }">
+        {{ formattedText }}
+      </slot>
+    </button>
   </p-tooltip>
 </template>
 

--- a/src/components/WorkPoolQueueHealthIcon.vue
+++ b/src/components/WorkPoolQueueHealthIcon.vue
@@ -1,17 +1,18 @@
 <template>
   <p-tooltip
     v-if="workPoolQueue && workQueueStatus && !workPool?.isPushPool"
-    class="work-pool-queue-health-icon"
     text="Work queue health is deprecated and will be removed in a future release. Please use work pool status instead."
   >
-    <StatusIcon v-if="status.state === 'healthy'" status="ready" />
-    <p-icon
-      v-if="status.state !== 'healthy'"
-      :icon="status.icon"
-      size="small"
-      class="work-pool-queue-health-icon"
-      :class="classes"
-    />
+    <button type="button" class="work-pool-queue-health-icon">
+      <StatusIcon v-if="status.state === 'healthy'" status="ready" />
+      <p-icon
+        v-if="status.state !== 'healthy'"
+        :icon="status.icon"
+        size="small"
+        class="work-pool-queue-health-icon"
+        :class="classes"
+      />
+    </button>
   </p-tooltip>
 </template>
 

--- a/src/components/WorkPoolQueueStatusIcon.vue
+++ b/src/components/WorkPoolQueueStatusIcon.vue
@@ -1,15 +1,16 @@
 <template>
   <p-tooltip
-    class="work-pool-queue-status-icon"
     :text="status.tooltip"
   >
-    <StatusIcon v-if="status.state === 'ready'" status="ready" />
-    <p-icon
-      v-if="status.state !== 'ready'"
-      :icon="status.icon"
-      size="small"
-      :class="classes"
-    />
+    <button type="button" class="work-pool-queue-status-icon">
+      <StatusIcon v-if="status.state === 'ready'" status="ready" />
+      <p-icon
+        v-if="status.state !== 'ready'"
+        :icon="status.icon"
+        size="small"
+        :class="classes"
+      />
+    </button>
   </p-tooltip>
 </template>
 

--- a/src/components/WorkPoolStatusIcon.vue
+++ b/src/components/WorkPoolStatusIcon.vue
@@ -1,16 +1,17 @@
 <template>
   <p-tooltip
     v-if="status"
-    class="work-pool-status-icon"
     :text="tooltipText"
   >
-    <StatusIcon v-if="status !== 'paused'" :status="status" />
-    <p-icon
-      v-if="status === 'paused'"
-      icon="PauseCircleIcon"
-      size="small"
-      class="work-pool-status-icon--paused"
-    />
+    <button type="button" class="work-pool-status-icon">
+      <StatusIcon v-if="status !== 'paused'" :status="status" />
+      <p-icon
+        v-if="status === 'paused'"
+        icon="PauseCircleIcon"
+        size="small"
+        class="work-pool-status-icon--paused"
+      />
+    </button>
   </p-tooltip>
 </template>
 

--- a/src/components/WorkspaceEventDescription.vue
+++ b/src/components/WorkspaceEventDescription.vue
@@ -1,6 +1,6 @@
 <template>
-  <p-tooltip class="workspace-event-description">
-    <div class="workspace-event-description__content">
+  <p-tooltip>
+    <div class="workspace-event-description">
       <p-link :to="routes.event(event.id, event.occurred)">
         {{ event.eventLabel }}
       </p-link>
@@ -60,9 +60,6 @@
 <style>
 .workspace-event-description { @apply
   w-fit
-}
-
-.workspace-event-description__content { @apply
   inline-flex
   flex-col
   items-start

--- a/src/components/WorkspaceEventListItemDate.vue
+++ b/src/components/WorkspaceEventListItemDate.vue
@@ -1,8 +1,8 @@
 <template>
-  <p-tooltip class="workspace-event-list-item-date">
+  <p-tooltip>
     <div
-      class="workspace-event-list-item-date__occurred"
-      :classes="classes.date"
+      class="workspace-event-list-item-date workspace-event-list-item-date__occurred"
+      :class="classes.date"
       @pointerenter="onPointerEnter"
       @pointerleave="onPointerLeave"
     >


### PR DESCRIPTION
- Prefer classes directly on slotted content when using p-tooltip. There are sometimes issues when passing a class directly to p-tooltip thus going to discourage usage by removing current ones - see https://github.com/PrefectHQ/nebula-ui/issues/4768 for more
- Also prefer a focusable element for tooltip triggers.