### PR TITLE
Fix: Add missing copy to clipboard buttons to blocks in deployment configuration tabs

### DIFF
--- a/src/components/DeploymentConfiguration.vue
+++ b/src/components/DeploymentConfiguration.vue
@@ -18,13 +18,13 @@
 
 <script lang="ts" setup>
   import { computed } from 'vue'
+  import CopyableWrapper from '@/components/CopyableWrapper.vue'
   import { Deployment } from '@/models/Deployment'
   import { stringify } from '@/utilities/json'
 
   const props = defineProps<{
     deployment: Deployment,
   }>()
-
 
   const overrides = computed(() => props.deployment.infrastructureOverrides ? stringify(props.deployment.infrastructureOverrides) : '{}')
 


### PR DESCRIPTION
| Before | After |
| ---- | ---- |
| <img width="673" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/cbdc6110-b18c-4e19-836d-3ab8027e49da"> | <img width="675" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/38c09c75-8f6e-42a9-b9e3-75aa21698c85"> |

And yeah I've noticed the copy button alignment is off on small code blocks... something else to be fixed another time. 
