### PR TITLE
Migrate from deployment.infra_overrides -> deployment.job_variables

### DIFF
--- a/src/components/DeploymentConfiguration.vue
+++ b/src/components/DeploymentConfiguration.vue
@@ -26,7 +26,7 @@
     deployment: Deployment,
   }>()
 
-  const overrides = computed(() => props.deployment.infrastructureOverrides ? stringify(props.deployment.infrastructureOverrides) : '{}')
+  const overrides = computed(() => props.deployment.jobVariables ? stringify(props.deployment.jobVariables) : '{}')
 
   const pullSteps = computed(() => props.deployment.pullSteps ? stringify(props.deployment.pullSteps) : '[]')
 </script>

--- a/src/components/DeploymentFormV2.vue
+++ b/src/components/DeploymentFormV2.vue
@@ -58,10 +58,10 @@
     <p-divider />
 
     <h3 class="deployment-form__heading">
-      {{ localization.info.infraOverrides }}
+      {{ localization.info.jobVariables }}
     </h3>
-    <p-label label="Infrastructure Overrides (Optional)" :message="overrideError" :state="overrideState">
-      <JobVariableOverridesInput v-model="infrastructureOverrides" :state="overrideState" />
+    <p-label label="Job Variables (Optional)" :message="overrideError" :state="overrideState">
+      <JobVariableOverridesInput v-model="jobVariables" :state="overrideState" />
     </p-label>
 
     <template #footer>
@@ -97,7 +97,7 @@
   const workQueueName = ref(props.deployment.workQueueName)
   const parameters = ref(props.deployment.parameters)
   const tags = ref(props.deployment.tags)
-  const infrastructureOverrides = ref(stringify(props.deployment.infrastructureOverrides))
+  const jobVariables = ref(stringify(props.deployment.jobVariables))
   const enforceParameterSchema = ref(props.deployment.enforceParameterSchema)
   const shouldValidateParameters = ref(true)
 
@@ -109,7 +109,7 @@
 
   const { validate } = useValidationObserver()
   const { errors, validate: validateParameters } = useSchemaValidation(schema, parameters)
-  const { state: overrideState, error: overrideError } = useValidation(infrastructureOverrides, isJson('Infrastructure overrides'))
+  const { state: overrideState, error: overrideError } = useValidation(jobVariables, isJson('Job variables'))
 
   const emit = defineEmits<{
     (event: 'submit', value: DeploymentUpdateV2): void,
@@ -144,7 +144,7 @@
       parameters: parameters.value,
       tags: tags.value,
       enforceParameterSchema: enforceParameterSchema.value,
-      infrastructureOverrides: JSON.parse(infrastructureOverrides.value),
+      jobVariables: JSON.parse(jobVariables.value),
     }
 
     emit('submit', deploymentUpdate)

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -188,7 +188,7 @@ export const en = {
     dashboardWorkPoolCardEmpty: 'There are no active work pools to show. Any work pools you do have are paused.',
     dashboardWorkPoolCardViewAll: 'View all work pools',
     percentChangeOverTimePeriod: (percent: string | number) => `${percent}% change compared to the previous time period.`,
-    infraOverrides: 'Infrastructure Overrides',
+    jobVariables: 'Job Variables',
     terminalTaskRunNoArtifacts: 'This task run did not produce any artifacts; for more information on creating artifacts, see the [documentation](https://docs.prefect.io/concepts/artifacts).',
     nonTerminalTaskRunNoArtifacts: 'This task run has not yet produced artifacts; for more information on creating artifacts, see the [documentation](https://docs.prefect.io/concepts/artifacts).',
     terminalFlowRunNoArtifacts: 'This run did not produce any artifacts; for more information on creating artifacts, see the [documentation](https://docs.prefect.io/concepts/artifacts).',

--- a/src/maps/deployment.ts
+++ b/src/maps/deployment.ts
@@ -27,7 +27,7 @@ export const mapDeploymentResponseToDeployment: MapFunction<DeploymentResponse, 
     entrypoint: source.entrypoint,
     storageDocumentId: source.storage_document_id,
     infrastructureDocumentId: source.infrastructure_document_id,
-    infrastructureOverrides: source.infra_overrides,
+    jobVariables: source.job_variables,
     workQueueName: source.work_queue_name,
     workPoolName: source.work_pool_name,
     enforceParameterSchema: source.enforce_parameter_schema,
@@ -45,7 +45,7 @@ export const mapDeploymentUpdateV2ToDeploymentUpdateRequest: MapFunction<Deploym
     tags: source.tags,
     work_queue_name: source.workQueueName,
     work_pool_name: source.workPoolName,
-    infra_overrides: source.infrastructureOverrides,
+    job_variables: source.jobVariables,
     enforce_parameter_schema: source.enforceParameterSchema,
   }
 }

--- a/src/mocks/deployment.ts
+++ b/src/mocks/deployment.ts
@@ -28,7 +28,7 @@ export const randomDeployment: MockFunction<Deployment, [Partial<Deployment>?]> 
     entrypoint: this.create('id'),
     storageDocumentId: this.create('id'),
     infrastructureDocumentId: this.create('id'),
-    infrastructureOverrides: {},
+    jobVariables: {},
     deprecated: false,
     workQueueName: null,
     workPoolName: random() > 0.05 ? this.create('noun') : null,

--- a/src/models/Deployment.ts
+++ b/src/models/Deployment.ts
@@ -24,7 +24,7 @@ export interface IDeployment {
   entrypoint: string | null,
   storageDocumentId: string | null,
   infrastructureDocumentId: string | null,
-  infrastructureOverrides: Record<string, unknown> | null,
+  jobVariables: Record<string, unknown> | null,
   workQueueName: string | null,
   workPoolName: string | null,
   enforceParameterSchema: boolean,
@@ -53,7 +53,7 @@ export class Deployment implements IDeployment {
   public entrypoint: string | null
   public storageDocumentId: string | null
   public infrastructureDocumentId: string | null
-  public infrastructureOverrides: Record<string, unknown> | null
+  public jobVariables: Record<string, unknown> | null
   public workQueueName: string | null
   public workPoolName: string | null
   public enforceParameterSchema: boolean
@@ -81,7 +81,7 @@ export class Deployment implements IDeployment {
     this.entrypoint = deployment.entrypoint
     this.storageDocumentId = deployment.storageDocumentId
     this.infrastructureDocumentId = deployment.infrastructureDocumentId
-    this.infrastructureOverrides = deployment.infrastructureOverrides
+    this.jobVariables = deployment.jobVariables
     this.workQueueName = deployment.workQueueName
     this.workPoolName = deployment.workPoolName
     this.enforceParameterSchema = deployment.enforceParameterSchema

--- a/src/models/DeploymentUpdate.ts
+++ b/src/models/DeploymentUpdate.ts
@@ -6,7 +6,7 @@ type Base = {
   tags?: string[] | null,
   workQueueName?: string | null,
   workPoolName?: string | null,
-  infrastructureOverrides?: Record<string, unknown> | null,
+  jobVariables?: Record<string, unknown> | null,
   enforceParameterSchema?: boolean,
 }
 

--- a/src/models/api/DeploymentResponse.ts
+++ b/src/models/api/DeploymentResponse.ts
@@ -27,7 +27,8 @@ export type DeploymentResponse = {
   parameter_openapi_schema: SchemaResponseV2,
   storage_document_id: string | null,
   infrastructure_document_id: string | null,
-  infra_overrides: Record<string, unknown> | null,
+  /** Formerly known as infra_overrides in prefect<3 */
+  job_variables: Record<string, unknown> | null,
   work_queue_name: string | null,
   work_pool_name: string | null,
   enforce_parameter_schema: boolean,

--- a/src/models/api/DeploymentUpdateRequest.ts
+++ b/src/models/api/DeploymentUpdateRequest.ts
@@ -13,6 +13,6 @@ export type DeploymentUpdateRequest = Partial<{
   infrastructure_document_id: string | null,
   work_queue_name: string | null,
   work_pool_name: string | null,
-  infra_overrides: Record<string, unknown> | null,
+  job_variables: Record<string, unknown> | null,
   enforce_parameter_schema: boolean,
 }>


### PR DESCRIPTION
This PR updates deployment models to remove usage of the deprecated `deployment.infra_overrides` field in favor of its successor `deployment.job_variables`. 

> [!Important]
> This is a breaking change from Prefect==2.x -> Prefect==3.x.
> However Prefect Cloud maintains a compatibility layer to support both. This means that this change will be breaking and newer versions of prefect-ui-library will no longer be compatible with prefect servers using prefect<3. 

I've tested these changes by successfully editing a deployment in both a 3.xrc prefect server (oss) and also against Cloud (beware Cloud is pending [some compat changes](https://github.com/PrefectHQ/nebula/pull/7900) to handle this)

Fixes this issue - https://github.com/orgs/PrefectHQ/projects/147/views/1?pane=issue&itemId=66037538