### PR TITLE
Update pagination for flow runs

### DIFF
--- a/src/components/FlowRunsAccordionContent.vue
+++ b/src/components/FlowRunsAccordionContent.vue
@@ -1,18 +1,17 @@
 <template>
-  <FlowRunList :flow-runs="flowRuns" :selected="null" class="flow-flow-runs-list" hide-flow-name hide-details />
-  <template v-if="more">
-    <div class="flow-flow-runs-list__more">
-      <p-button size="sm" @click="next">
-        Show more
-      </p-button>
-    </div>
-  </template>
+  <p-content>
+    <FlowRunList :flow-runs="flowRuns" :selected="null" class="flow-flow-runs-list" hide-flow-name hide-details />
+
+    <template v-if="pages > 1">
+      <p-pager v-model:page="filter.page" :pages="pages" />
+    </template>
+  </p-content>
 </template>
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
+  import merge from 'lodash.merge'
   import FlowRunList from '@/components/FlowRunList.vue'
-  import { usePaginatedFlowRuns } from '@/compositions'
+  import { useFlowRunsPaginationFilterFromRoute, usePaginatedFlowRuns } from '@/compositions'
   import { FlowRunsFilter } from '@/models/Filters'
 
   const props = defineProps<{
@@ -20,27 +19,13 @@
     filter?: FlowRunsFilter,
   }>()
 
-  const filter = (): FlowRunsFilter => ({
-    ...props.filter,
+  const { filter } = useFlowRunsPaginationFilterFromRoute(merge({}, props.filter, {
     flows: {
       ...props.filter?.flows,
       id: [props.flowId],
     },
     limit: 3,
-  })
+  }))
 
-  const { flowRuns, total, next } = usePaginatedFlowRuns(filter, {
-    mode: 'infinite',
-  })
-
-  const more = computed(() => total.value > flowRuns.value.length)
-
-  next()
+  const { flowRuns, pages } = usePaginatedFlowRuns(filter)
 </script>
-
-<style>
-.flow-flow-runs-list__more { @apply
-  flex
-  justify-center
-}
-</style>

--- a/src/compositions/usePaginatedFlowRuns.ts
+++ b/src/compositions/usePaginatedFlowRuns.ts
@@ -1,23 +1,25 @@
-import { MaybeReadonly } from '@prefecthq/prefect-design'
-import { MaybeRefOrGetter, toValue } from 'vue'
+import { SubscriptionOptions, UseSubscription, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
+import { ComputedRef, MaybeRefOrGetter, computed, toRef, toValue } from 'vue'
 import { useCan } from '@/compositions/useCan'
-import { PaginationOptions, UsePaginationEntity, usePagination } from '@/compositions/usePagination'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { FlowRunsFilter } from '@/models'
+import { FlowRun, FlowRunsPaginationFilter } from '@/models'
 import { WorkspaceFlowRunsApi } from '@/services'
 import { Getter } from '@/types/reactivity'
 
-export type UsePaginatedFlowRuns = UsePaginationEntity<
-WorkspaceFlowRunsApi['getFlowRuns'],
-WorkspaceFlowRunsApi['getFlowRunsCount'],
-'flowRuns'
->
+type UsePaginatedFlowRuns = {
+  subscription: UseSubscription<WorkspaceFlowRunsApi['getFlowRunsPaginated']>,
+  flowRuns: ComputedRef<FlowRun[]>,
+  count: ComputedRef<number>,
+  limit: ComputedRef<number>,
+  pages: ComputedRef<number>,
+  page: ComputedRef<number>,
+}
 
-export function usePaginatedFlowRuns(filter?: MaybeRefOrGetter<MaybeReadonly<FlowRunsFilter> | null | undefined>, options?: PaginationOptions): UsePaginatedFlowRuns {
+export function usePaginatedFlowRuns(filter: MaybeRefOrGetter<FlowRunsPaginationFilter | null | undefined> = {}, options?: SubscriptionOptions & { mode?: 'boolean' }): UsePaginatedFlowRuns {
   const api = useWorkspaceApi()
   const can = useCan()
 
-  const parameters: Getter<[FlowRunsFilter] | null> = () => {
+  const getter: Getter<[FlowRunsPaginationFilter] | null> = () => {
     if (!can.read.flow_run) {
       return null
     }
@@ -31,16 +33,21 @@ export function usePaginatedFlowRuns(filter?: MaybeRefOrGetter<MaybeReadonly<Flo
     return [value]
   }
 
-  const pagination = usePagination({
-    fetchMethod: api.flowRuns.getFlowRuns,
-    fetchParameters: parameters,
-    countMethod: api.flowRuns.getFlowRunsCount,
-    countParameters: parameters,
-    options,
-  })
+  const parameters = toRef(getter)
+  const subscription = useSubscriptionWithDependencies(api.flowRuns.getFlowRunsPaginated, parameters, options)
+
+  const flowRuns = computed(() => subscription.response?.results ?? [])
+  const pages = computed(() => subscription.response?.pages ?? 0)
+  const limit = computed(() => subscription.response?.limit ?? 0)
+  const count = computed(() => subscription.response?.count ?? 0)
+  const page = computed(() => subscription.response?.page ?? 1)
 
   return {
-    ...pagination,
-    flowRuns: pagination.results,
+    subscription,
+    flowRuns,
+    pages,
+    page,
+    limit,
+    count,
   }
 }

--- a/src/compositions/usePaginatedFlowRuns.ts
+++ b/src/compositions/usePaginatedFlowRuns.ts
@@ -15,7 +15,7 @@ type UsePaginatedFlowRuns = {
   page: ComputedRef<number>,
 }
 
-export function usePaginatedFlowRuns(filter: MaybeRefOrGetter<FlowRunsPaginationFilter | null | undefined> = {}, options?: SubscriptionOptions & { mode?: 'boolean' }): UsePaginatedFlowRuns {
+export function usePaginatedFlowRuns(filter: MaybeRefOrGetter<FlowRunsPaginationFilter | null | undefined> = {}, options?: SubscriptionOptions): UsePaginatedFlowRuns {
   const api = useWorkspaceApi()
   const can = useCan()
 

--- a/src/maps/filters.ts
+++ b/src/maps/filters.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import { asArray } from '@prefecthq/prefect-design'
-import { Any, Like, All, IsNull, OperatorRequest, TagFilterRequest, FlowFilterRequest, FlowRunFilterRequest, NotAny, StateFilterRequest, Before, After, TaskRunFilterRequest, Exists, DeploymentFilterRequest, Equals, FlowsFilterRequest, FlowRunsFilterRequest, TaskRunsFilterRequest, DeploymentsFilterRequest, BlockTypeFilterRequest, BlockSchemaFilterRequest, BlockDocumentFilterRequest, NotificationsFilterRequest, SavedSearchesFilterRequest, LogsFilterRequest, GreaterThan, LessThan, ConcurrencyLimitsFilterRequest, BlockTypesFilterRequest, BlockSchemasFilterRequest, BlockDocumentsFilterRequest, WorkQueuesFilterRequest, StartsWith, WorkPoolFilterRequest, WorkPoolsFilterRequest, WorkPoolQueueFilterRequest, FlowRunsHistoryFilterRequest, WorkPoolWorkersFilterRequest, WorkPoolQueuesFilterRequest, ArtifactsFilterRequest, ArtifactFilterRequest, NullableEquals, VariablesFilterRequest, VariableFilterRequest, TaskRunsHistoryFilterRequest } from '@/models/api/Filters'
-import { FlowFilter, FlowRunFilter, Operation, StateFilter, TagFilter, TaskRunFilter, DeploymentFilter, FlowsFilter, FlowRunsFilter, TaskRunsFilter, DeploymentsFilter, BlockTypeFilter, BlockSchemaFilter, BlockDocumentFilter, NotificationsFilter, SavedSearchesFilter, LogsFilter, ConcurrencyLimitsFilter, BlockTypesFilter, BlockSchemasFilter, BlockDocumentsFilter, WorkQueuesFilter, WorkPoolFilter, WorkPoolsFilter, WorkPoolQueueFilter, FlowRunsHistoryFilter, WorkPoolWorkersFilter, WorkPoolQueuesFilter, ArtifactsFilter, ArtifactFilter, VariablesFilter, VariableFilter, TaskRunsHistoryFilter } from '@/models/Filters'
+import { Any, Like, All, IsNull, OperatorRequest, TagFilterRequest, FlowFilterRequest, FlowRunFilterRequest, NotAny, StateFilterRequest, Before, After, TaskRunFilterRequest, Exists, DeploymentFilterRequest, Equals, FlowsFilterRequest, FlowRunsFilterRequest, TaskRunsFilterRequest, DeploymentsFilterRequest, BlockTypeFilterRequest, BlockSchemaFilterRequest, BlockDocumentFilterRequest, NotificationsFilterRequest, SavedSearchesFilterRequest, LogsFilterRequest, GreaterThan, LessThan, ConcurrencyLimitsFilterRequest, BlockTypesFilterRequest, BlockSchemasFilterRequest, BlockDocumentsFilterRequest, WorkQueuesFilterRequest, StartsWith, WorkPoolFilterRequest, WorkPoolsFilterRequest, WorkPoolQueueFilterRequest, FlowRunsHistoryFilterRequest, WorkPoolWorkersFilterRequest, WorkPoolQueuesFilterRequest, ArtifactsFilterRequest, ArtifactFilterRequest, NullableEquals, VariablesFilterRequest, VariableFilterRequest, TaskRunsHistoryFilterRequest, FlowRunsPaginationFilterRequest } from '@/models/api/Filters'
+import { FlowFilter, FlowRunFilter, Operation, StateFilter, TagFilter, TaskRunFilter, DeploymentFilter, FlowsFilter, FlowRunsFilter, TaskRunsFilter, DeploymentsFilter, BlockTypeFilter, BlockSchemaFilter, BlockDocumentFilter, NotificationsFilter, SavedSearchesFilter, LogsFilter, ConcurrencyLimitsFilter, BlockTypesFilter, BlockSchemasFilter, BlockDocumentsFilter, WorkQueuesFilter, WorkPoolFilter, WorkPoolsFilter, WorkPoolQueueFilter, FlowRunsHistoryFilter, WorkPoolWorkersFilter, WorkPoolQueuesFilter, ArtifactsFilter, ArtifactFilter, VariablesFilter, VariableFilter, TaskRunsHistoryFilter, FlowRunsPaginationFilter } from '@/models/Filters'
 import { MapFunction } from '@/services'
 import { removeEmptyObjects } from '@/utilities'
 
@@ -343,6 +343,16 @@ export const mapFlowRunsFilter: MapFunction<FlowRunsFilter, FlowRunsFilterReques
     limit: source.limit,
     offset: source.offset,
   })
+}
+
+export const mapFlowRunsPaginationFilter: MapFunction<FlowRunsPaginationFilter, FlowRunsPaginationFilterRequest> = function(source) {
+  // eslint-disable-next-line no-unused-vars
+  const { offset, ...filter } = this.map('FlowRunsFilter', source, 'FlowRunsFilterRequest')
+
+  return {
+    ...filter,
+    page: source.page,
+  }
 }
 
 export const mapFlowRunsHistoryFilter: MapFunction<FlowRunsHistoryFilter, FlowRunsHistoryFilterRequest> = function(source) {

--- a/src/maps/index.ts
+++ b/src/maps/index.ts
@@ -37,7 +37,7 @@ import { mapDeploymentStatsFilterToFlowRunsFilter } from '@/maps/deploymentStats
 import { mapDeploymentStatusToServerDeploymentStatus, mapServerDeploymentStatusToDeploymentStatus } from '@/maps/deploymentStatus'
 import { mapRunHistoryToDivergingBarChartItem } from '@/maps/divergingBarChartItem'
 import { mapEmpiricalPolicyToEmpiricalPolicyResponse, mapEmpiricalPolicyResponseToEmpiricalPolicy, mapEmpiricalPolicyToEmpiricalPolicyRequest } from '@/maps/empiricalPolicy'
-import { mapFlowFilter, mapDeploymentFilter, mapFlowRunFilter, mapStateFilter, mapFlowsFilter, mapDeploymentsFilter, mapFlowRunsFilter, mapTagFilter, mapTaskRunFilter, mapTaskRunsFilter, mapBlockDocumentFilter, mapBlockSchemaFilter, mapBlockTypeFilter, mapBlockDocumentsFilter, mapBlockSchemasFilter, mapBlockTypesFilter, mapWorkPoolsFilter, mapWorkPoolFilter, mapWorkPoolQueueFilter, mapFlowRunsHistoryFilter, mapLogsFilter, mapNotificationsFilter, mapSavedSearchesFilter, mapWorkQueuesFilter, mapWorkPoolWorkersFilter, mapWorkPoolQueuesFilter, mapArtifactFilter, mapArtifactsFilter, mapVariablesFilter, mapVariableFilter, mapTaskRunsHistoryFilter } from '@/maps/filters'
+import { mapFlowFilter, mapDeploymentFilter, mapFlowRunFilter, mapStateFilter, mapFlowsFilter, mapDeploymentsFilter, mapFlowRunsFilter, mapTagFilter, mapTaskRunFilter, mapTaskRunsFilter, mapBlockDocumentFilter, mapBlockSchemaFilter, mapBlockTypeFilter, mapBlockDocumentsFilter, mapBlockSchemasFilter, mapBlockTypesFilter, mapWorkPoolsFilter, mapWorkPoolFilter, mapWorkPoolQueueFilter, mapFlowRunsHistoryFilter, mapLogsFilter, mapNotificationsFilter, mapSavedSearchesFilter, mapWorkQueuesFilter, mapWorkPoolWorkersFilter, mapWorkPoolQueuesFilter, mapArtifactFilter, mapArtifactsFilter, mapVariablesFilter, mapVariableFilter, mapTaskRunsHistoryFilter, mapFlowRunsPaginationFilter } from '@/maps/filters'
 import { mapFlowToFlowResponse, mapFlowResponseToFlow, mapFlowToAutomationTrigger } from '@/maps/flow'
 import { mapFlowRunResponseToFlowRun } from '@/maps/flowRun'
 import { mapRunHistoryToFlowRunHistoryResponse, mapFlowRunHistoryResponseToRunHistory } from '@/maps/flowRunHistory'
@@ -50,6 +50,7 @@ import { mapNotificationCreateToNotificationCreateRequest } from '@/maps/notific
 import { mapNotificationUpdateToNotificationUpdateRequest } from '@/maps/notificationUpdate'
 import { mapNumberToString, mapStringToNumber } from '@/maps/number'
 import { mapOrchestrationResultResponseToOrchestrationResult } from '@/maps/orchestrationResult'
+import { mapFlowRunsPaginationResponseToFlowRunsPagination } from '@/maps/pagination'
 import { mapRunGraphDataResponse, mapRunGraphNodeResponse, mapRunGraphArtifactResponse, mapRunGraphStateResponse } from '@/maps/runGraphData'
 import { mapSavedSearchResponseToSavedSearch, mapSavedSearchToLocationQuery } from '@/maps/savedSearch'
 import { mapSavedSearchCreateToSavedSearchCreateRequest } from '@/maps/savedSearchCreate'
@@ -146,7 +147,9 @@ export const maps = {
   FlowRunInputKeyset: { FlowRunInputKeysetResponse: mapFlowRunInputKeysetResponseToFlowRunInputKeyset },
   FlowRunInputKeysetResponse: { FlowRunInputKeyset: mapFlowRunInputKeysetToFlowRunInputKeysetResponse },
   FlowRunResponse: { FlowRun: mapFlowRunResponseToFlowRun },
+  FlowRunsPaginationResponse: { FlowRunsPagination: mapFlowRunsPaginationResponseToFlowRunsPagination },
   FlowRunsFilter: { FlowRunsFilterRequest: mapFlowRunsFilter },
+  FlowRunsPaginationFilter: { FlowRunsPaginationFilterRequest: mapFlowRunsPaginationFilter },
   FlowRunsHistoryFilter: { FlowRunsHistoryFilterRequest: mapFlowRunsHistoryFilter },
   FlowsFilter: { FlowsFilterRequest: mapFlowsFilter },
   FlowStatsFilter: {

--- a/src/maps/pagination.ts
+++ b/src/maps/pagination.ts
@@ -1,0 +1,12 @@
+import { FlowRun, FlowRunResponse } from '@/models'
+import { Paginated } from '@/models/pagination'
+import { MapFunction } from '@/services'
+
+export const mapFlowRunsPaginationResponseToFlowRunsPagination: MapFunction<Paginated<FlowRunResponse>, Paginated<FlowRun>> = function(source) {
+  const results = this.map('FlowRunResponse', source.results, 'FlowRun')
+
+  return {
+    ...source,
+    results,
+  }
+}

--- a/src/models/Filters.ts
+++ b/src/models/Filters.ts
@@ -1,5 +1,5 @@
 import { DeploymentStatus } from '@/models/DeploymentStatus'
-import { ArtifactSortValues, FlowSortValues, FlowRunSortValues, TaskRunSortValues, DeploymentSortValues, LogSortValues, VariableSortValues, BlockDocumentSortValues } from '@/types'
+import { ArtifactSortValues, FlowSortValues, FlowRunSortValues, TaskRunSortValues, DeploymentSortValues, LogSortValues, VariableSortValues, BlockDocumentSortValues, Require } from '@/types'
 
 export type Operation = 'and' | 'or'
 
@@ -136,6 +136,7 @@ export type WorkPoolQueueFilter = {
 }
 
 export type UnionFilterSort = FlowSortValues | FlowRunSortValues | TaskRunSortValues | DeploymentSortValues
+
 export type UnionFilter<T extends UnionFilterSort = UnionFilterSort> = {
   flows?: FlowFilter,
   flowRuns?: FlowRunFilter,
@@ -174,6 +175,22 @@ export type FlowsFilter = UnionFilter<FlowSortValues>
 export type FlowRunsFilter = UnionFilter<FlowRunSortValues>
 export type TaskRunsFilter = UnionFilter<TaskRunSortValues>
 export type DeploymentsFilter = UnionFilter<DeploymentSortValues>
+
+export type PaginationUnionFilter<T extends UnionFilterSort = UnionFilterSort> = {
+  flows?: FlowFilter,
+  flowRuns?: FlowRunFilter,
+  taskRuns?: TaskRunFilter,
+  deployments?: DeploymentFilter,
+  workPools?: WorkPoolFilter,
+  workPoolQueues?: WorkPoolQueueFilter,
+  sort?: T,
+  page?: number,
+  limit?: number,
+}
+
+export type WithPage<T extends PaginationUnionFilter> = Require<T, 'page'>
+
+export type FlowRunsPaginationFilter = PaginationUnionFilter<FlowRunSortValues>
 
 export type FlowRunsHistoryFilter = FlowRunsFilter & {
   historyStart: Date,

--- a/src/models/api/Filters.ts
+++ b/src/models/api/Filters.ts
@@ -136,6 +136,20 @@ export type FlowRunsFilterRequest = UnionFilterRequest<FlowRunSortValues>
 export type TaskRunsFilterRequest = UnionFilterRequest<TaskRunSortValues>
 export type DeploymentsFilterRequest = UnionFilterRequest<DeploymentSortValues>
 
+export type PaginationUnionFilterRequest<T> = {
+  flows?: FlowFilterRequest,
+  flow_runs?: FlowRunFilterRequest,
+  task_runs?: TaskRunFilterRequest,
+  deployments?: DeploymentFilterRequest,
+  work_pools?: WorkPoolFilterRequest,
+  work_pool_queues?: WorkPoolQueueFilterRequest,
+  sort?: T,
+  page?: number,
+  limit?: number,
+}
+
+export type FlowRunsPaginationFilterRequest = PaginationUnionFilterRequest<FlowRunSortValues>
+
 export type ArtifactFilterRequest = {
   id?: Any,
   key?: Any & Like & Exists,

--- a/src/models/pagination.ts
+++ b/src/models/pagination.ts
@@ -1,0 +1,7 @@
+export type Paginated<TResult> = {
+  results: TResult[],
+  limit: number,
+  page: number,
+  pages: number,
+  count: number,
+}

--- a/src/services/WorkspaceFlowRunsApi.ts
+++ b/src/services/WorkspaceFlowRunsApi.ts
@@ -5,9 +5,10 @@ import { FlowRunResponse } from '@/models/api/FlowRunResponse'
 import { OrchestrationResult } from '@/models/api/OrchestrationResult'
 import { OrchestrationResultResponse } from '@/models/api/OrchestrationResultResponse'
 import { RunGraphDataResponse } from '@/models/api/RunGraphDataResponse'
-import { FlowRunsFilter, FlowRunsHistoryFilter } from '@/models/Filters'
+import { FlowRunsFilter, FlowRunsHistoryFilter, FlowRunsPaginationFilter } from '@/models/Filters'
 import { FlowRun } from '@/models/FlowRun'
 import { FlowRunInputKeyset } from '@/models/FlowRunInputKeyset'
+import { Paginated } from '@/models/pagination'
 import { RunHistory } from '@/models/RunHistory'
 import { SchemaResponseV2, SchemaV2, SchemaValuesV2 } from '@/schemas'
 import { BatchProcessor } from '@/services/BatchProcessor'
@@ -46,6 +47,13 @@ export class WorkspaceFlowRunsApi extends WorkspaceApi {
     const { data } = await this.post<FlowRunResponse[]>('/filter', request)
 
     return mapper.map('FlowRunResponse', data, 'FlowRun')
+  }
+
+  public async getFlowRunsPaginated(filter: FlowRunsPaginationFilter = {}): Promise<Paginated<FlowRun>> {
+    const request = mapper.map('FlowRunsPaginationFilter', filter, 'FlowRunsPaginationFilterRequest')
+    const { data } = await this.post<Paginated<FlowRunResponse>>('/paginate', request)
+
+    return mapper.map('FlowRunsPaginationResponse', data, 'FlowRunsPagination')
   }
 
   public async getFlowRunsCount(filter: FlowRunsFilter = {}): Promise<number> {
@@ -137,4 +145,5 @@ export class WorkspaceFlowRunsApi extends WorkspaceApi {
   public deleteFlowRun(flowRunId: string): Promise<void> {
     return this.delete(`/${flowRunId}`)
   }
+
 }


### PR DESCRIPTION
# Description
Moving over from using the deprecated `usePaginationX` compositions which attempted to do pagination using multiple api calls into a single call using the new `/paginate` endpoint for flow runs. This means

- No more "infinite" mode. Paging only
- No more multiple calls
- No more flickering when an interval poll happens

Putting this up for review but can't merge this yet until I have the nebula-ui and oss PRs ready because this is a breaking change to the `usePaginatedFlowRuns` composition.