### PR TITLE
Enhancement: Blocks catalog polish

### DIFF
--- a/src/components/BlockTypeCard.vue
+++ b/src/components/BlockTypeCard.vue
@@ -1,59 +1,41 @@
 <template>
   <p-card class="block-type-card">
+    <template #header>
+      <LogoImage v-if="blockType.logoUrl" :url="blockType.logoUrl" class="block-type-card__logo" size="lg" />
+      <p-icon v-else icon="PBlock" class="block-type-card__icon" />
+      <p-heading class="block-type-card-preview__name" heading="3">
+        {{ blockType.name }}
+      </p-heading>
+    </template>
+
     <p-content>
-      <LogoImage :url="blockType.logoUrl" class="block-type-card__logo" />
-
-      <p-key-value label="Name" :value="blockType.name" />
-
-      <p-key-value label="Slug" :value="blockType.slug" />
-
-      <template v-if="blockSchema && hasCapabilities">
-        <p-key-value label="Capabilities">
-          <template #value>
-            <BlockSchemaCapabilities :capabilities="blockSchema.capabilities" class="block-type-card__capabilities" />
-          </template>
-        </p-key-value>
-      </template>
-
-      <template v-if="blockType.description">
-        <p-key-value label="Description" :value="blockType.description" />
-      </template>
+      <p-markdown-renderer v-if="description" :text="description" class="block-type-card__description" />
 
       <template v-if="blockType.codeExample">
-        <p-key-value label="Example">
-          <template #value>
-            <BlockTypeSnippet :snippet="blockType.codeExample" />
-          </template>
-        </p-key-value>
+        <p-heading class="block-type-card-preview__name" heading="5">
+          Example
+        </p-heading>
+        <BlockTypeSnippet :snippet="blockType.codeExample" />
       </template>
-      <div class="block-type-card__actions">
-        <template v-if="blockType.documentationUrl">
-          <a :href="blockType.documentationUrl" target="_blank">
-            <p-button icon-append="ArrowTopRightOnSquareIcon">
-              <slot>
-                View Docs
-              </slot>
-            </p-button>
-          </a>
-        </template>
+    </p-content>
 
+    <template #footer>
+      <div class="block-type-card__actions">
         <p-link :to="routes.blockCreate(blockType.slug)" class="block-type-card__action">
-          <p-button icon-append="PlusIcon" class="block-type-card__button">
-            Add Block
+          <p-button variant="default" class="block-type-card__button">
+            Create
           </p-button>
         </p-link>
       </div>
-    </p-content>
+    </template>
   </p-card>
 </template>
 
 <script lang="ts" setup>
-  import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
-  import BlockSchemaCapabilities from '@/components/BlockSchemaCapabilities.vue'
   import BlockTypeSnippet from '@/components/BlockTypeSnippet.vue'
   import LogoImage from '@/components/LogoImage.vue'
-  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import { useWorkspaceRoutes } from '@/compositions'
   import { BlockType } from '@/models/BlockType'
 
   const props = defineProps<{
@@ -62,18 +44,56 @@
 
   const routes = useWorkspaceRoutes()
 
-  const blockTypeId = computed(() => props.blockType.id)
-  const api = useWorkspaceApi()
-  const blockSchemaSubscription = useSubscription(api.blockSchemas.getBlockSchemaForBlockType, [blockTypeId])
-  const blockSchema = computed(() => blockSchemaSubscription.response)
-  const hasCapabilities = computed(() => blockSchema.value?.capabilities.length)
+  const description = computed(() => {
+    let baseDescription = props.blockType.description
+
+    if (props.blockType.documentationUrl) {
+      baseDescription += ` [Documentation](${props.blockType.documentationUrl})`
+    }
+
+    return baseDescription
+  })
 </script>
 
 <style>
+.block-type-card .p-card-header { @apply
+  flex
+  flex-row
+  justify-start
+  items-center
+  gap-4
+}
+
+.block-type-card__description { @apply
+  text-sm
+}
+
 .block-type-card__actions { @apply
   flex
   gap-2
-  items-center
   justify-end
+  w-full
+  text-sm
+  items-center
+}
+
+.block-type-card__logo { @apply
+  shrink-0
+  w-14
+  h-14
+}
+
+.block-type-card__icon { @apply
+  shrink-0
+  w-14
+  h-14
+  overflow-hidden
+  rounded
+  bg-black
+  bg-opacity-10
+  dark:bg-white
+  dark:bg-opacity-25
+  backdrop-blur-sm
+  p-1
 }
 </style>

--- a/src/components/BlockTypeCardPreview.vue
+++ b/src/components/BlockTypeCardPreview.vue
@@ -87,7 +87,7 @@
   text-subdued
   text-xs
   overflow-auto
-  max-h-24
+  h-24
   grow
 }
 

--- a/src/components/BlockTypeCardPreview.vue
+++ b/src/components/BlockTypeCardPreview.vue
@@ -1,29 +1,30 @@
 <template>
-  <p-card>
-    <div class="block-type-card-preview">
+  <p-card class="block-type-card-preview">
+    <template #header>
       <LogoImage :url="blockType.logoUrl" class="block-type-card-preview__logo" />
       <p class="block-type-card-preview__name">
         <p-link :to="routes.blocksCatalogView(blockType.slug)">
           {{ blockType.name }}
         </p-link>
       </p>
+    </template>
 
-      <template v-if="blockType.description">
-        <p class="block-type-card-preview__description">
-          {{ blockType.description }}
-        </p>
-      </template>
+    <template v-if="blockType.description">
+      <p-markdown-renderer :text="blockType.description" class="block-type-card-preview__description" />
+    </template>
 
-      <template v-if="blockSchema">
-        <BlockSchemaCapabilities :capabilities="blockSchema.capabilities" class="block-type-card-preview__capabilities" />
-      </template>
+    <template v-if="blockSchema">
+      <BlockSchemaCapabilities :capabilities="blockSchema.capabilities" class="block-type-card-preview__capabilities" />
+    </template>
 
-      <template v-if="slots.actions">
-        <div class="block-type-card-preview__action">
-          <slot name="actions" />
-        </div>
-      </template>
-    </div>
+    <template v-if="slots.actions" #footer>
+      <div class="block-type-card-preview__actions">
+        <p-button size="sm" variant="ghost" :to="routes.blocksCatalogView(blockType.slug)">
+          Details
+        </p-button>
+        <slot name="actions" />
+      </div>
+    </template>
   </p-card>
 </template>
 
@@ -52,7 +53,12 @@
 .block-type-card-preview { @apply
   flex
   flex-col
-  gap-2
+}
+
+.block-type-card-preview .p-card-content { @apply
+  flex
+  flex-col
+  grow
 }
 
 .block-type-card-preview__logo { @apply
@@ -66,16 +72,19 @@
 
 .block-type-card-preview__description { @apply
   text-subdued
-  text-sm
+  text-xs
   line-clamp-5
+  grow
 }
 
 .block-type-card-preview__capabilities { @apply
   mb-2
 }
 
-.block-type-card-preview__action { @apply
-  block
-  mt-auto
+.block-type-card-preview__actions { @apply
+  flex
+  gap-2
+  justify-end
+  w-full
 }
 </style>

--- a/src/components/BlockTypeCardPreview.vue
+++ b/src/components/BlockTypeCardPreview.vue
@@ -1,13 +1,14 @@
 <template>
   <p-card class="block-type-card-preview">
     <template #header>
-      <LogoImage :url="blockType.logoUrl" class="block-type-card-preview__logo" />
-      <p class="block-type-card-preview__name">
-        <p-link :to="routes.blocksCatalogView(blockType.slug)">
-          {{ blockType.name }}
-        </p-link>
-      </p>
+      <LogoImage v-if="blockType.logoUrl" :url="blockType.logoUrl" class="block-type-card-preview__logo" size="lg" />
+      <p-icon v-else icon="PBlock" class="block-type-card-preview__icon" />
+      <!-- <img v-if="blockType.logoUrl" :src="blockType.logoUrl" class="block-type-card-preview__logo"> -->
+      <p-heading class="block-type-card-preview__name" heading="4">
+        {{ blockType.name }}
+      </p-heading>
     </template>
+
 
     <template v-if="blockType.description">
       <p-markdown-renderer :text="blockType.description" class="block-type-card-preview__description" />
@@ -41,22 +42,46 @@
 <style>
 .block-type-card-preview { @apply
   flex
+  overflow-hidden
   flex-col
+  relative
+}
+
+.block-type-card-preview .p-card-header { @apply
+  flex
+  flex-row
+  justify-start
+  items-center
+  gap-4
 }
 
 .block-type-card-preview .p-card-content { @apply
   flex
   flex-col
   grow
+  py-4
 }
 
 .block-type-card-preview__logo { @apply
-  !w-11
-  !h-11
+  shrink-0
+}
+
+.block-type-card-preview__icon { @apply
+  shrink-0
+  w-12
+  h-12
+  overflow-hidden
+  rounded
+  bg-black
+  bg-opacity-10
+  dark:bg-white
+  dark:bg-opacity-25
+  backdrop-blur-sm
+  p-1
 }
 
 .block-type-card-preview__name { @apply
-  text-base
+  grow
 }
 
 .block-type-card-preview__description { @apply

--- a/src/components/BlockTypeCardPreview.vue
+++ b/src/components/BlockTypeCardPreview.vue
@@ -59,7 +59,6 @@
   flex
   flex-col
   grow
-  py-4
 }
 
 .block-type-card-preview__logo { @apply
@@ -87,7 +86,8 @@
 .block-type-card-preview__description { @apply
   text-subdued
   text-xs
-  line-clamp-5
+  overflow-auto
+  max-h-24
   grow
 }
 

--- a/src/components/BlockTypeCardPreview.vue
+++ b/src/components/BlockTypeCardPreview.vue
@@ -3,7 +3,6 @@
     <template #header>
       <LogoImage v-if="blockType.logoUrl" :url="blockType.logoUrl" class="block-type-card-preview__logo" size="lg" />
       <p-icon v-else icon="PBlock" class="block-type-card-preview__icon" />
-      <!-- <img v-if="blockType.logoUrl" :src="blockType.logoUrl" class="block-type-card-preview__logo"> -->
       <p-heading class="block-type-card-preview__name" heading="4">
         {{ blockType.name }}
       </p-heading>

--- a/src/components/BlockTypeCardPreview.vue
+++ b/src/components/BlockTypeCardPreview.vue
@@ -13,10 +13,6 @@
       <p-markdown-renderer :text="blockType.description" class="block-type-card-preview__description" />
     </template>
 
-    <template v-if="blockSchema">
-      <BlockSchemaCapabilities :capabilities="blockSchema.capabilities" class="block-type-card-preview__capabilities" />
-    </template>
-
     <template v-if="slots.actions" #footer>
       <div class="block-type-card-preview__actions">
         <p-button size="sm" variant="ghost" :to="routes.blocksCatalogView(blockType.slug)">
@@ -29,24 +25,17 @@
 </template>
 
 <script lang="ts" setup>
-  import { useSubscription } from '@prefecthq/vue-compositions'
-  import { computed, useSlots } from 'vue'
-  import BlockSchemaCapabilities from '@/components/BlockSchemaCapabilities.vue'
+  import { useSlots } from 'vue'
   import LogoImage from '@/components/LogoImage.vue'
-  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import { useWorkspaceRoutes } from '@/compositions'
   import { BlockType } from '@/models/BlockType'
 
-  const props = defineProps<{
+  defineProps<{
     blockType: BlockType,
   }>()
 
   const slots = useSlots()
-  const api = useWorkspaceApi()
   const routes = useWorkspaceRoutes()
-
-  const blockTypeId = computed(() => props.blockType.id)
-  const blockSchemaSubscription = useSubscription(api.blockSchemas.getBlockSchemaForBlockType, [blockTypeId])
-  const blockSchema = computed(() => blockSchemaSubscription.response)
 </script>
 
 <style>

--- a/src/components/BlockTypeList.vue
+++ b/src/components/BlockTypeList.vue
@@ -2,7 +2,7 @@
   <div class="block-type-list">
     <div class="block-type-list__filters">
       <ResultsCount label="Block" :count="filteredBlockTypes.length" class="block-type-list__results" />
-      <SearchInput v-model="searchTerm" class="block-type-list__search" placeholder="Search blocks" />
+      <SearchInput v-model="searchTerm" class="block-type-list__search" size="small" placeholder="Search blocks" />
     </div>
 
     <div class="block-type-list__types">

--- a/src/components/BlockTypeList.vue
+++ b/src/components/BlockTypeList.vue
@@ -3,21 +3,18 @@
     <div class="block-type-list__filters">
       <ResultsCount label="Block" :count="filteredBlockTypes.length" class="block-type-list__results" />
       <SearchInput v-model="searchTerm" class="block-type-list__search" placeholder="Search blocks" />
-      <BlockSchemaCapabilitySelect v-model:selected="selectedCapability" class="block-type-list__capability" />
     </div>
 
     <div class="block-type-list__types">
       <template v-for="blockType in filteredBlockTypes" :key="blockType.id">
         <BlockTypeCardPreview :block-type="blockType">
           <template #actions>
-            <p-button v-if="useEmit" icon-append="PlusIcon" class="block-type-list__add" @click="emit('add', blockType)">
-              Add
+            <p-button v-if="useEmit" size="sm" variant="default" @click="emit('add', blockType)">
+              Create
             </p-button>
-            <p-link v-else :to="routes.blockCreate(blockType.slug)">
-              <p-button icon-append="PlusIcon" class="block-type-list__add">
-                Add
-              </p-button>
-            </p-link>
+            <p-button size="sm" variant="default" :to="routes.blockCreate(blockType.slug)">
+              Create
+            </p-button>
           </template>
         </BlockTypeCardPreview>
       </template>
@@ -39,7 +36,6 @@
 <script lang="ts" setup>
   import { PEmptyResults } from '@prefecthq/prefect-design'
   import { computed, ref } from 'vue'
-  import BlockSchemaCapabilitySelect from '@/components/BlockSchemaCapabilitySelect.vue'
   import BlockTypeCardPreview from '@/components/BlockTypeCardPreview.vue'
   import ResultsCount from '@/components/ResultsCount.vue'
   import SearchInput from '@/components/SearchInput.vue'
@@ -127,9 +123,5 @@
   lg:grid-cols-3
   xl:grid-cols-4
   gap-2
-}
-
-.block-type-list__add { @apply
-  w-full
 }
 </style>

--- a/src/components/BlockTypeList.vue
+++ b/src/components/BlockTypeList.vue
@@ -120,8 +120,7 @@
 .block-type-list__types { @apply
   grid
   md:grid-cols-2
-  lg:grid-cols-3
-  xl:grid-cols-4
+  xl:grid-cols-3
   gap-2
 }
 </style>

--- a/src/components/BlockTypeSnippet.vue
+++ b/src/components/BlockTypeSnippet.vue
@@ -1,6 +1,6 @@
 <template>
   <CopyableWrapper :text-to-copy="snippet" class="block-type-snippet">
-    <p-code-highlight lang="python" :text="snippet" />
+    <p-code-highlight lang="python" :text="snippet" class="block-type-snippet__code" />
   </CopyableWrapper>
 </template>
 
@@ -20,3 +20,9 @@
     return customSnippet.trim()
   })
 </script>
+
+<style>
+.block-type-snippet__code { @apply
+  p-4
+}
+</style>

--- a/src/components/LogoImage.vue
+++ b/src/components/LogoImage.vue
@@ -23,10 +23,14 @@
 .logo-image { @apply
   bg-cover
   bg-center
-  dark:rounded-default
-  dark:p-0.5
-  dark:overflow-hidden
+  overflow-hidden
+  rounded
+  bg-black
+  bg-opacity-10
   dark:bg-white
+  dark:bg-opacity-25
+  backdrop-blur-sm
+  p-1
 }
 
 .logo-image--size-sm { @apply

--- a/src/components/PageHeadingBlocksCatalog.vue
+++ b/src/components/PageHeadingBlocksCatalog.vue
@@ -22,6 +22,6 @@
 
   const crumbs: BreadCrumbs = [
     { text: 'Blocks', to: routes.blocks() },
-    { text: 'Choose a Block' },
+    { text: 'Catalog' },
   ]
 </script>

--- a/src/components/PageHeadingBlocksCatalog.vue
+++ b/src/components/PageHeadingBlocksCatalog.vue
@@ -3,7 +3,7 @@
     <page-heading class="page-heading-blocks-catalog" :crumbs="crumbs" />
 
     <p-message>
-      Can't find a block for your service? Check our
+      Can't find a block for your service? Check out the
       <p-link :to="localization.docs.collections">
         docs
       </p-link>

--- a/src/components/PageHeadingBlocksCatalog.vue
+++ b/src/components/PageHeadingBlocksCatalog.vue
@@ -3,11 +3,11 @@
     <page-heading class="page-heading-blocks-catalog" :crumbs="crumbs" />
 
     <p-message>
-      If you don't see a block for the service you're using, check out our
+      Can't find a block for your service? Check our
       <p-link :to="localization.docs.collections">
-        Integrations
+        docs
       </p-link>
-      to view a list of integration libraries and their corresponding blocks.
+      for a full list of integrations in the SDK.
     </p-message>
   </p-content>
 </template>

--- a/src/components/PageHeadingBlocksCatalogView.vue
+++ b/src/components/PageHeadingBlocksCatalogView.vue
@@ -17,7 +17,7 @@
 
   const crumbs = computed<BreadCrumbs>(() => [
     { text: 'Blocks', to: routes.blocks() },
-    { text: 'Choose a Block', to: routes.blocksCatalog() },
+    { text: 'Catalog', to: routes.blocksCatalog() },
     { text: props.blockType.name },
   ])
 </script>

--- a/src/components/PageHeadingBlocksCatalogView.vue
+++ b/src/components/PageHeadingBlocksCatalogView.vue
@@ -18,6 +18,6 @@
   const crumbs = computed<BreadCrumbs>(() => [
     { text: 'Blocks', to: routes.blocks() },
     { text: 'Catalog', to: routes.blocksCatalog() },
-    { text: props.blockType.name },
+    { text: props.blockType.slug },
   ])
 </script>


### PR DESCRIPTION
This PR cleans up some of the blocks catalog components, aiming for consistency, ease of use, and concision. 

|               | Before | After |  
|---------------|--------|-------|
| Block catalog |   <img width="1243" alt="Screenshot 2024-06-06 at 7 01 48 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/e54e74eb-920f-41bd-b0f8-807ce95f22a0">     |      <img width="1243" alt="Screenshot 2024-06-06 at 7 01 42 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/8e4530bd-e82e-4a6b-819e-61c4e71e9eef"> | 
| Block type    |  <img width="1243" alt="Screenshot 2024-06-06 at 7 01 54 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/1865c31f-2079-4b7c-97bc-1012f36eeff6">    |   <img width="1243" alt="Screenshot 2024-06-06 at 7 01 58 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/27291717/239c0e7c-d0e4-428d-a7dd-6c1ddf8848ba">    |   |   |


