### PR TITLE
Fix some flow run lists not being reactive to filter changes

### DIFF
--- a/src/compositions/usePaginatedFlowRuns.ts
+++ b/src/compositions/usePaginatedFlowRuns.ts
@@ -1,5 +1,6 @@
 import { SubscriptionOptions, UseSubscription, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
-import { ComputedRef, MaybeRefOrGetter, computed, toRef, toValue } from 'vue'
+import merge from 'lodash.merge'
+import { ComputedRef, MaybeRefOrGetter, computed, toRef, toValue, watch, watchEffect } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
 import { FlowRun, FlowRunsPaginationFilter } from '@/models'
@@ -30,7 +31,8 @@ export function usePaginatedFlowRuns(filter: MaybeRefOrGetter<FlowRunsPagination
       return null
     }
 
-    return [value]
+    // merge here is important to track changes to `filter` if it is a reactive
+    return [merge({}, value)]
   }
 
   const parameters = toRef(getter)


### PR DESCRIPTION
# Description
The new `usePaginatedFlowRuns` composition wasn't correctly tracking changes to the base filter if it was reactive. This is because the computed getter was only checking to see if the filter existed at all and not actually accessing any of the filter properties. This meant that vue wasn't tracking effects for any of the individual filters. 

What ultimately ended up happening is the filters wouldn't be applied until the polling interval triggered another fetch. 

Adding `merge({}, filter)` to the getter forces vue to track effects for all of the individual nested filters. We've done this in other compositions and seems to work well. 