### PR TITLE
Update pagination for flows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "vue-tsc": "^2.0.19"
             },
             "peerDependencies": {
-                "@prefecthq/prefect-design": "^2.10.14",
+                "@prefecthq/prefect-design": "^2.11.0",
                 "@prefecthq/vue-charts": "^2.0.3",
                 "@prefecthq/vue-compositions": "^1.11.4",
                 "vee-validate": "^4.7.0",
@@ -1222,9 +1222,9 @@
             }
         },
         "node_modules/@prefecthq/prefect-design": {
-            "version": "2.10.14",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.10.14.tgz",
-            "integrity": "sha512-hPKGZNcZwPwxXAQkywtQ2cGPciQMV/pgyALjNtRG7TxWwepJjWU59xubVvJV1YpVO4yNdvx4IocrTY4CXFS9hg==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.11.0.tgz",
+            "integrity": "sha512-RV1F6buCFxme83I8X8u0KI6UjjRBfNnqCM8GB3sy6+P8BFMdowH1gJ80rdPxlm+CcdAZx2OvHSsXoh6Ko4m9kA==",
             "peer": true,
             "dependencies": {
                 "@fontsource-variable/inconsolata": "^5.0.18",
@@ -8730,9 +8730,9 @@
             }
         },
         "@prefecthq/prefect-design": {
-            "version": "2.10.14",
-            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.10.14.tgz",
-            "integrity": "sha512-hPKGZNcZwPwxXAQkywtQ2cGPciQMV/pgyALjNtRG7TxWwepJjWU59xubVvJV1YpVO4yNdvx4IocrTY4CXFS9hg==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@prefecthq/prefect-design/-/prefect-design-2.11.0.tgz",
+            "integrity": "sha512-RV1F6buCFxme83I8X8u0KI6UjjRBfNnqCM8GB3sy6+P8BFMdowH1gJ80rdPxlm+CcdAZx2OvHSsXoh6Ko4m9kA==",
             "peer": true,
             "requires": {
                 "@fontsource-variable/inconsolata": "^5.0.18",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "vue-tsc": "^2.0.19"
     },
     "peerDependencies": {
-        "@prefecthq/prefect-design": "^2.10.14",
+        "@prefecthq/prefect-design": "^2.11.0",
         "@prefecthq/vue-charts": "^2.0.3",
         "@prefecthq/vue-compositions": "^1.11.4",
         "vee-validate": "^4.7.0",

--- a/src/components/FlowCombobox.vue
+++ b/src/components/FlowCombobox.vue
@@ -48,7 +48,7 @@
     flows: {
       nameLike: searchDebounced.value,
     },
-    limit: 20,
+    limit: 100,
   }))
 
   const moreLink = computed(() => withQuery(routes.flows(), {

--- a/src/components/FlowCombobox.vue
+++ b/src/components/FlowCombobox.vue
@@ -1,8 +1,9 @@
 <template>
-  <p-combobox v-model="selected" v-model:search="search" :options="options" manual @bottom="next">
+  <p-combobox v-model="selected" v-model:search="search" :options manual>
     <template #combobox-options-empty>
       No flows
     </template>
+
     <template #default="scope">
       <slot v-bind="scope">
         <UseFlowSlot v-if="isString(scope.value)" :flow-id="scope.value">
@@ -12,8 +13,15 @@
         </UseFlowSlot>
       </slot>
     </template>
+
     <template #option="{ option }">
       <slot name="option" :option="option" />
+    </template>
+
+    <template v-if="count > flows.length" #bottom>
+      <p class="flow-combobox__more">
+        {{ count - flows.length }} more results. <span><p-link :to="moreLink">Browse all</p-link></span>
+      </p>
     </template>
   </p-combobox>
 </template>
@@ -23,39 +31,29 @@
   import { useDebouncedRef } from '@prefecthq/vue-compositions'
   import { computed, ref } from 'vue'
   import UseFlowSlot from '@/components/UseFlowSlot.vue'
-  import { useFlows } from '@/compositions'
-  import { FlowsFilter } from '@/models/Filters'
-  import { isString } from '@/utilities'
+  import { useFlows, useWorkspaceRoutes } from '@/compositions'
+  import { isString, withQuery } from '@/utilities'
+
+  const selected = defineModel<string | string[] | null | undefined>('selected', { required: true })
 
   const props = defineProps<{
-    selected: string | string[] | null | undefined,
     allowUnset?: boolean,
   }>()
 
-  const emit = defineEmits<{
-    (event: 'update:selected', value: string | string[] | null): void,
-  }>()
-
+  const routes = useWorkspaceRoutes()
   const search = ref('')
   const searchDebounced = useDebouncedRef(search, 500)
 
-  const selected = computed({
-    get() {
-      return props.selected ?? null
-    },
-    set(value) {
-      emit('update:selected', value)
-    },
-  })
-
-  const filter = (): FlowsFilter => ({
+  const { flows, count } = useFlows(() => ({
     flows: {
       nameLike: searchDebounced.value,
     },
     limit: 20,
-  })
+  }))
 
-  const { flows, next } = useFlows(filter, { mode: 'infinite' })
+  const moreLink = computed(() => withQuery(routes.flows(), {
+    'flows.nameLike': search.value,
+  }))
 
   const options = computed<SelectOption[]>(() => {
     const options: SelectOption[] = flows.value.map(flow => ({
@@ -73,3 +71,14 @@
     return options
   })
 </script>
+
+<style>
+.flow-combobox__more { @apply
+  text-sm
+  text-subdued
+  text-center
+  border-t-divider
+  border-t
+  pt-1
+}
+</style>

--- a/src/compositions/filters.ts
+++ b/src/compositions/filters.ts
@@ -10,7 +10,7 @@ import { FlowRunSortValuesSortParam } from '@/formatters/FlowRunSortValuesSortPa
 import { FlowSortValuesSortParam } from '@/formatters/FlowSortValuesSortParam'
 import { OperatorRouteParam } from '@/formatters/OperatorRouteParam'
 import { TaskRunSortValuesSortParam } from '@/formatters/TaskRunSortValuesSortParam'
-import { BlockDocumentFilter, BlockDocumentsFilter, BlockSchemaFilter, BlockSchemasFilter, BlockTypeFilter, BlockTypesFilter, DeploymentFilter, DeploymentsFilter, FlowFilter, FlowRunFilter, FlowRunsFilter, FlowRunsHistoryFilter, FlowRunsPaginationFilter, FlowsFilter, PaginationUnionFilter, StateFilter, TagFilter, TaskRunFilter, TaskRunsFilter, UnionFilter, VariableFilter, VariablesFilter, WithPage, WorkPoolFilter, WorkPoolQueueFilter, WorkPoolsFilter } from '@/models/Filters'
+import { BlockDocumentFilter, BlockDocumentsFilter, BlockSchemaFilter, BlockSchemasFilter, BlockTypeFilter, BlockTypesFilter, DeploymentFilter, DeploymentsFilter, FlowFilter, FlowRunFilter, FlowRunsFilter, FlowRunsHistoryFilter, FlowRunsPaginationFilter, FlowsFilter, FlowsPaginationFilter, PaginationUnionFilter, StateFilter, TagFilter, TaskRunFilter, TaskRunsFilter, UnionFilter, VariableFilter, VariablesFilter, WithPage, WorkPoolFilter, WorkPoolQueueFilter, WorkPoolsFilter } from '@/models/Filters'
 import { defaultDeploymentSort, defaultFlowRunSort, defaultFlowSort, defaultTaskRunSort, defaultVariableSort } from '@/types'
 import { AnyRecord } from '@/types/any'
 import { MaybeReactive } from '@/types/reactivity'
@@ -611,8 +611,26 @@ const paginationUnionFilterSchema: Omit<RouteQueryParamsSchema<PaginationUnionFi
   limit: NumberRouteParam,
 }
 
+export function useFlowsPaginationFilter(defaultValue: MaybeReactive<FlowsPaginationFilter> = {}): UseFilter<WithPage<FlowsPaginationFilter>> {
+  return usePaginationUnionFilter<FlowsPaginationFilter>(defaultValue, defaultFlowSort)
+}
+
 export function useFlowRunsPaginationFilter(defaultValue: MaybeReactive<FlowRunsPaginationFilter> = {}): UseFilter<WithPage<FlowRunsPaginationFilter>> {
   return usePaginationUnionFilter<FlowRunsPaginationFilter>(defaultValue, defaultFlowRunSort)
+}
+
+const flowsPaginationFilterSchema: RouteQueryParamsSchema<FlowsPaginationFilter> = {
+  ...paginationUnionFilterSchema,
+  sort: FlowSortValuesSortParam,
+}
+
+export function useFlowsPaginationFilterFromRoute(defaultValue: MaybeReactive<FlowsPaginationFilter> = {}, prefix?: string): UseFilter<WithPage<FlowsPaginationFilter>> {
+  const response = useFlowsPaginationFilter(defaultValue)
+  const { filter: query } = usePaginationFilterFromRoute(flowsPaginationFilterSchema, defaultValue, defaultFlowSort, prefix)
+
+  syncFilterWithFilterFromRoute(response.filter, query)
+
+  return response
 }
 
 const flowRunsPaginationFilterSchema: RouteQueryParamsSchema<FlowRunsPaginationFilter> = {

--- a/src/compositions/useFlows.ts
+++ b/src/compositions/useFlows.ts
@@ -1,23 +1,26 @@
-import { MaybeRefOrGetter, toValue } from 'vue'
+import { SubscriptionOptions, UseSubscription, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
+import { ComputedRef, MaybeRefOrGetter, computed, toRef, toValue } from 'vue'
 import { useCan } from '@/compositions/useCan'
-import { PaginationOptions, UsePaginationEntity, usePagination } from '@/compositions/usePagination'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-import { FlowsFilter } from '@/models'
+import { Flow, FlowsPaginationFilter } from '@/models'
 import { WorkspaceFlowsApi } from '@/services'
 import { Getter } from '@/types/reactivity'
 
-export type UseFlows = UsePaginationEntity<
-WorkspaceFlowsApi['getFlows'],
-WorkspaceFlowsApi['getFlowsCount'],
-'flows'
->
+type UseFlows = {
+  subscription: UseSubscription<WorkspaceFlowsApi['getFlowsPaginated']>,
+  flows: ComputedRef<Flow[]>,
+  count: ComputedRef<number>,
+  limit: ComputedRef<number>,
+  pages: ComputedRef<number>,
+  page: ComputedRef<number>,
+}
 
-export function useFlows(filter?: MaybeRefOrGetter<FlowsFilter | null | undefined>, options?: PaginationOptions): UseFlows {
+export function useFlows(filter?: MaybeRefOrGetter<FlowsPaginationFilter | null | undefined>, options?: SubscriptionOptions): UseFlows {
   const api = useWorkspaceApi()
   const can = useCan()
 
-  const parameters: Getter<[FlowsFilter?] | null> = () => {
-    if (!can.read.flow) {
+  const getter: Getter<[FlowsPaginationFilter] | null> = () => {
+    if (!can.read.flow_run) {
       return null
     }
 
@@ -30,16 +33,21 @@ export function useFlows(filter?: MaybeRefOrGetter<FlowsFilter | null | undefine
     return [value]
   }
 
-  const pagination = usePagination({
-    fetchMethod: api.flows.getFlows,
-    fetchParameters: parameters,
-    countMethod: api.flows.getFlowsCount,
-    countParameters: parameters,
-    options,
-  })
+  const parameters = toRef(getter)
+  const subscription = useSubscriptionWithDependencies(api.flows.getFlowsPaginated, parameters, options)
+
+  const flows = computed(() => subscription.response?.results ?? [])
+  const pages = computed(() => subscription.response?.pages ?? 0)
+  const limit = computed(() => subscription.response?.limit ?? 0)
+  const count = computed(() => subscription.response?.count ?? 0)
+  const page = computed(() => subscription.response?.page ?? 1)
 
   return {
-    ...pagination,
-    flows: pagination.results,
+    subscription,
+    flows,
+    pages,
+    page,
+    limit,
+    count,
   }
 }

--- a/src/compositions/useFlows.ts
+++ b/src/compositions/useFlows.ts
@@ -1,4 +1,5 @@
 import { SubscriptionOptions, UseSubscription, useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
+import merge from 'lodash.merge'
 import { ComputedRef, MaybeRefOrGetter, computed, toRef, toValue } from 'vue'
 import { useCan } from '@/compositions/useCan'
 import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
@@ -30,7 +31,8 @@ export function useFlows(filter?: MaybeRefOrGetter<FlowsPaginationFilter | null 
       return null
     }
 
-    return [value]
+    // merge here is important to track changes to `filter` if it is a reactive
+    return [merge({}, value)]
   }
 
   const parameters = toRef(getter)

--- a/src/maps/filters.ts
+++ b/src/maps/filters.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import { asArray } from '@prefecthq/prefect-design'
-import { Any, Like, All, IsNull, OperatorRequest, TagFilterRequest, FlowFilterRequest, FlowRunFilterRequest, NotAny, StateFilterRequest, Before, After, TaskRunFilterRequest, Exists, DeploymentFilterRequest, Equals, FlowsFilterRequest, FlowRunsFilterRequest, TaskRunsFilterRequest, DeploymentsFilterRequest, BlockTypeFilterRequest, BlockSchemaFilterRequest, BlockDocumentFilterRequest, NotificationsFilterRequest, SavedSearchesFilterRequest, LogsFilterRequest, GreaterThan, LessThan, ConcurrencyLimitsFilterRequest, BlockTypesFilterRequest, BlockSchemasFilterRequest, BlockDocumentsFilterRequest, WorkQueuesFilterRequest, StartsWith, WorkPoolFilterRequest, WorkPoolsFilterRequest, WorkPoolQueueFilterRequest, FlowRunsHistoryFilterRequest, WorkPoolWorkersFilterRequest, WorkPoolQueuesFilterRequest, ArtifactsFilterRequest, ArtifactFilterRequest, NullableEquals, VariablesFilterRequest, VariableFilterRequest, TaskRunsHistoryFilterRequest, FlowRunsPaginationFilterRequest } from '@/models/api/Filters'
-import { FlowFilter, FlowRunFilter, Operation, StateFilter, TagFilter, TaskRunFilter, DeploymentFilter, FlowsFilter, FlowRunsFilter, TaskRunsFilter, DeploymentsFilter, BlockTypeFilter, BlockSchemaFilter, BlockDocumentFilter, NotificationsFilter, SavedSearchesFilter, LogsFilter, ConcurrencyLimitsFilter, BlockTypesFilter, BlockSchemasFilter, BlockDocumentsFilter, WorkQueuesFilter, WorkPoolFilter, WorkPoolsFilter, WorkPoolQueueFilter, FlowRunsHistoryFilter, WorkPoolWorkersFilter, WorkPoolQueuesFilter, ArtifactsFilter, ArtifactFilter, VariablesFilter, VariableFilter, TaskRunsHistoryFilter, FlowRunsPaginationFilter } from '@/models/Filters'
+import { Any, Like, All, IsNull, OperatorRequest, TagFilterRequest, FlowFilterRequest, FlowRunFilterRequest, NotAny, StateFilterRequest, Before, After, TaskRunFilterRequest, Exists, DeploymentFilterRequest, Equals, FlowsFilterRequest, FlowRunsFilterRequest, TaskRunsFilterRequest, DeploymentsFilterRequest, BlockTypeFilterRequest, BlockSchemaFilterRequest, BlockDocumentFilterRequest, NotificationsFilterRequest, SavedSearchesFilterRequest, LogsFilterRequest, GreaterThan, LessThan, ConcurrencyLimitsFilterRequest, BlockTypesFilterRequest, BlockSchemasFilterRequest, BlockDocumentsFilterRequest, WorkQueuesFilterRequest, StartsWith, WorkPoolFilterRequest, WorkPoolsFilterRequest, WorkPoolQueueFilterRequest, FlowRunsHistoryFilterRequest, WorkPoolWorkersFilterRequest, WorkPoolQueuesFilterRequest, ArtifactsFilterRequest, ArtifactFilterRequest, NullableEquals, VariablesFilterRequest, VariableFilterRequest, TaskRunsHistoryFilterRequest, FlowRunsPaginationFilterRequest, FlowsPaginationFilterRequest } from '@/models/api/Filters'
+import { FlowFilter, FlowRunFilter, Operation, StateFilter, TagFilter, TaskRunFilter, DeploymentFilter, FlowsFilter, FlowRunsFilter, TaskRunsFilter, DeploymentsFilter, BlockTypeFilter, BlockSchemaFilter, BlockDocumentFilter, NotificationsFilter, SavedSearchesFilter, LogsFilter, ConcurrencyLimitsFilter, BlockTypesFilter, BlockSchemasFilter, BlockDocumentsFilter, WorkQueuesFilter, WorkPoolFilter, WorkPoolsFilter, WorkPoolQueueFilter, FlowRunsHistoryFilter, WorkPoolWorkersFilter, WorkPoolQueuesFilter, ArtifactsFilter, ArtifactFilter, VariablesFilter, VariableFilter, TaskRunsHistoryFilter, FlowRunsPaginationFilter, FlowsPaginationFilter } from '@/models/Filters'
 import { MapFunction } from '@/services'
 import { removeEmptyObjects } from '@/utilities'
 
@@ -343,6 +343,16 @@ export const mapFlowRunsFilter: MapFunction<FlowRunsFilter, FlowRunsFilterReques
     limit: source.limit,
     offset: source.offset,
   })
+}
+
+export const mapFlowsPaginationFilter: MapFunction<FlowsPaginationFilter, FlowsPaginationFilterRequest> = function(source) {
+  // eslint-disable-next-line no-unused-vars
+  const { offset, ...filter } = this.map('FlowsFilter', source, 'FlowsFilterRequest')
+
+  return {
+    ...filter,
+    page: source.page,
+  }
 }
 
 export const mapFlowRunsPaginationFilter: MapFunction<FlowRunsPaginationFilter, FlowRunsPaginationFilterRequest> = function(source) {

--- a/src/maps/index.ts
+++ b/src/maps/index.ts
@@ -37,7 +37,7 @@ import { mapDeploymentStatsFilterToFlowRunsFilter } from '@/maps/deploymentStats
 import { mapDeploymentStatusToServerDeploymentStatus, mapServerDeploymentStatusToDeploymentStatus } from '@/maps/deploymentStatus'
 import { mapRunHistoryToDivergingBarChartItem } from '@/maps/divergingBarChartItem'
 import { mapEmpiricalPolicyToEmpiricalPolicyResponse, mapEmpiricalPolicyResponseToEmpiricalPolicy, mapEmpiricalPolicyToEmpiricalPolicyRequest } from '@/maps/empiricalPolicy'
-import { mapFlowFilter, mapDeploymentFilter, mapFlowRunFilter, mapStateFilter, mapFlowsFilter, mapDeploymentsFilter, mapFlowRunsFilter, mapTagFilter, mapTaskRunFilter, mapTaskRunsFilter, mapBlockDocumentFilter, mapBlockSchemaFilter, mapBlockTypeFilter, mapBlockDocumentsFilter, mapBlockSchemasFilter, mapBlockTypesFilter, mapWorkPoolsFilter, mapWorkPoolFilter, mapWorkPoolQueueFilter, mapFlowRunsHistoryFilter, mapLogsFilter, mapNotificationsFilter, mapSavedSearchesFilter, mapWorkQueuesFilter, mapWorkPoolWorkersFilter, mapWorkPoolQueuesFilter, mapArtifactFilter, mapArtifactsFilter, mapVariablesFilter, mapVariableFilter, mapTaskRunsHistoryFilter, mapFlowRunsPaginationFilter } from '@/maps/filters'
+import { mapFlowFilter, mapDeploymentFilter, mapFlowRunFilter, mapStateFilter, mapFlowsFilter, mapDeploymentsFilter, mapFlowRunsFilter, mapTagFilter, mapTaskRunFilter, mapTaskRunsFilter, mapBlockDocumentFilter, mapBlockSchemaFilter, mapBlockTypeFilter, mapBlockDocumentsFilter, mapBlockSchemasFilter, mapBlockTypesFilter, mapWorkPoolsFilter, mapWorkPoolFilter, mapWorkPoolQueueFilter, mapFlowRunsHistoryFilter, mapLogsFilter, mapNotificationsFilter, mapSavedSearchesFilter, mapWorkQueuesFilter, mapWorkPoolWorkersFilter, mapWorkPoolQueuesFilter, mapArtifactFilter, mapArtifactsFilter, mapVariablesFilter, mapVariableFilter, mapTaskRunsHistoryFilter, mapFlowRunsPaginationFilter, mapFlowsPaginationFilter } from '@/maps/filters'
 import { mapFlowToFlowResponse, mapFlowResponseToFlow, mapFlowToAutomationTrigger } from '@/maps/flow'
 import { mapFlowRunResponseToFlowRun } from '@/maps/flowRun'
 import { mapRunHistoryToFlowRunHistoryResponse, mapFlowRunHistoryResponseToRunHistory } from '@/maps/flowRunHistory'
@@ -50,7 +50,7 @@ import { mapNotificationCreateToNotificationCreateRequest } from '@/maps/notific
 import { mapNotificationUpdateToNotificationUpdateRequest } from '@/maps/notificationUpdate'
 import { mapNumberToString, mapStringToNumber } from '@/maps/number'
 import { mapOrchestrationResultResponseToOrchestrationResult } from '@/maps/orchestrationResult'
-import { mapFlowRunsPaginationResponseToFlowRunsPagination } from '@/maps/pagination'
+import { mapFlowRunsPaginationResponseToFlowRunsPagination, mapFlowsPaginationResponseToFlowRunsPagination } from '@/maps/pagination'
 import { mapRunGraphDataResponse, mapRunGraphNodeResponse, mapRunGraphArtifactResponse, mapRunGraphStateResponse } from '@/maps/runGraphData'
 import { mapSavedSearchResponseToSavedSearch, mapSavedSearchToLocationQuery } from '@/maps/savedSearch'
 import { mapSavedSearchCreateToSavedSearchCreateRequest } from '@/maps/savedSearchCreate'
@@ -142,6 +142,7 @@ export const maps = {
   },
   FlowFilter: { FlowFilterRequest: mapFlowFilter },
   FlowResponse: { Flow: mapFlowResponseToFlow },
+  FlowsPaginationResponse: { FlowsPagination: mapFlowsPaginationResponseToFlowRunsPagination },
   FlowRunFilter: { FlowRunFilterRequest: mapFlowRunFilter },
   FlowRunHistoryResponse: { RunHistory: mapFlowRunHistoryResponseToRunHistory },
   FlowRunInputKeyset: { FlowRunInputKeysetResponse: mapFlowRunInputKeysetResponseToFlowRunInputKeyset },
@@ -152,6 +153,7 @@ export const maps = {
   FlowRunsPaginationFilter: { FlowRunsPaginationFilterRequest: mapFlowRunsPaginationFilter },
   FlowRunsHistoryFilter: { FlowRunsHistoryFilterRequest: mapFlowRunsHistoryFilter },
   FlowsFilter: { FlowsFilterRequest: mapFlowsFilter },
+  FlowsPaginationFilter: { FlowsPaginationFilterRequest: mapFlowsPaginationFilter },
   FlowStatsFilter: {
     FlowRunsFilter: mapFlowStatsFilterToFlowRunsFilter,
     TaskRunsFilter: mapFlowStatsFilterToTaskRunsFilter,

--- a/src/maps/pagination.ts
+++ b/src/maps/pagination.ts
@@ -1,9 +1,18 @@
-import { FlowRun, FlowRunResponse } from '@/models'
+import { Flow, FlowResponse, FlowRun, FlowRunResponse } from '@/models'
 import { Paginated } from '@/models/pagination'
 import { MapFunction } from '@/services'
 
 export const mapFlowRunsPaginationResponseToFlowRunsPagination: MapFunction<Paginated<FlowRunResponse>, Paginated<FlowRun>> = function(source) {
   const results = this.map('FlowRunResponse', source.results, 'FlowRun')
+
+  return {
+    ...source,
+    results,
+  }
+}
+
+export const mapFlowsPaginationResponseToFlowRunsPagination: MapFunction<Paginated<FlowResponse>, Paginated<Flow>> = function(source) {
+  const results = this.map('FlowResponse', source.results, 'Flow')
 
   return {
     ...source,

--- a/src/models/Filters.ts
+++ b/src/models/Filters.ts
@@ -190,6 +190,7 @@ export type PaginationUnionFilter<T extends UnionFilterSort = UnionFilterSort> =
 
 export type WithPage<T extends PaginationUnionFilter> = Require<T, 'page'>
 
+export type FlowsPaginationFilter = PaginationUnionFilter<FlowSortValues>
 export type FlowRunsPaginationFilter = PaginationUnionFilter<FlowRunSortValues>
 
 export type FlowRunsHistoryFilter = FlowRunsFilter & {

--- a/src/models/api/Filters.ts
+++ b/src/models/api/Filters.ts
@@ -148,6 +148,7 @@ export type PaginationUnionFilterRequest<T> = {
   limit?: number,
 }
 
+export type FlowsPaginationFilterRequest = PaginationUnionFilterRequest<FlowSortValues>
 export type FlowRunsPaginationFilterRequest = PaginationUnionFilterRequest<FlowRunSortValues>
 
 export type ArtifactFilterRequest = {

--- a/src/services/WorkspaceFlowsApi.ts
+++ b/src/services/WorkspaceFlowsApi.ts
@@ -1,5 +1,6 @@
 import { Flow, FlowResponse } from '@/models'
-import { FlowsFilter } from '@/models/Filters'
+import { FlowsFilter, FlowsPaginationFilter } from '@/models/Filters'
+import { Paginated } from '@/models/pagination'
 import { BatchProcessor } from '@/services/BatchProcessor'
 import { mapper } from '@/services/Mapper'
 import { WorkspaceApi } from '@/services/WorkspaceApi'
@@ -35,6 +36,13 @@ export class WorkspaceFlowsApi extends WorkspaceApi {
     const { data } = await this.post<FlowResponse[]>('filter', request)
 
     return mapper.map('FlowResponse', data, 'Flow')
+  }
+
+  public async getFlowsPaginated(filter: FlowsPaginationFilter = {}): Promise<Paginated<Flow>> {
+    const request = mapper.map('FlowsPaginationFilter', filter, 'FlowsPaginationFilterRequest')
+    const { data } = await this.post<Paginated<FlowResponse>>('/paginate', request)
+
+    return mapper.map('FlowsPaginationResponse', data, 'FlowsPagination')
   }
 
   public async getFlowsCount(filter: FlowsFilter = {}): Promise<number> {


### PR DESCRIPTION
# Description
Continuing on the theme from https://github.com/PrefectHQ/prefect-ui-library/pull/2505

Updates the `useFlows` composition (which was already paginated using the `usePagination` composition). To use the new `/flows/paginate` endpoint to reduce requests and improve data consistency. 

Removes infinite scrolling from `FlowCombobox`. Now shows up to 100 results with a link to browse flows. P95 of workspaces in cloud  is `52` total flows. So very few users will even see this ux. 

Needs https://github.com/PrefectHQ/prefect-design/pull/1339

<img width="373" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/a366d22c-2b9a-4342-8b41-49b0b71498a7">

