### PR TITLE
Exclude subflows when counting task runs by state

### DIFF
--- a/src/components/FlowRunTaskCounts.vue
+++ b/src/components/FlowRunTaskCounts.vue
@@ -15,9 +15,13 @@
   }>()
 
   const api = useWorkspaceApi()
+
   const filter = computed<TaskRunsFilter>(() => ({
     flowRuns: {
       id: [props.flowRunId],
+    },
+    taskRuns: {
+      subFlowRunsExist: false,
     },
   }))
 


### PR DESCRIPTION
# Description
Closes https://github.com/PrefectHQ/nebula/issues/7899

Fixes by adding the subflow run exists filter