### PR TITLE
Add support for compound and sequence triggers

### DIFF
--- a/src/automations/types/api/triggers.ts
+++ b/src/automations/types/api/triggers.ts
@@ -1,3 +1,4 @@
+import { AutomationTriggerCompoundRequire } from '@/automations/types/automationTriggerCompound'
 import { isRecord } from '@/utilities/object'
 import { createTuple } from '@/utilities/tuples'
 
@@ -51,4 +52,25 @@ export function isAutomationTriggerEventResponse(value: unknown): value is Autom
   return isRecord(value) && value.type === 'event' && isAutomationTriggerEventPosture(value.posture)
 }
 
-export type AutomationTriggerResponse = AutomationTriggerEventResponse
+export type AutomationTriggerCompoundResponse = {
+  type: 'compound',
+  triggers: AutomationTriggerResponse[],
+  within: number,
+  require: AutomationTriggerCompoundRequire,
+}
+
+export function isAutomationTriggerCompoundResponse(value: AutomationTriggerResponse): value is AutomationTriggerCompoundResponse {
+  return value.type === 'compound'
+}
+
+export type AutomationTriggerSequenceResponse = {
+  type: 'sequence',
+  triggers: AutomationTriggerResponse[],
+  within: number,
+}
+
+export function isAutomationTriggerSequenceResponse(value: AutomationTriggerResponse): value is AutomationTriggerSequenceResponse {
+  return value.type === 'sequence'
+}
+
+export type AutomationTriggerResponse = AutomationTriggerEventResponse | AutomationTriggerCompoundResponse | AutomationTriggerSequenceResponse

--- a/src/automations/types/automationTriggerCompound.ts
+++ b/src/automations/types/automationTriggerCompound.ts
@@ -1,0 +1,24 @@
+import { AutomationTrigger } from '@/automations/types/triggers'
+
+export type AutomationTriggerCompoundRequire = number | 'any' | 'all'
+
+export const DEFAULT_COMPOUND_TRIGGER_REQUIRED: AutomationTriggerCompoundRequire = 'all'
+
+export interface IAutomationTriggerCompound {
+  triggers: AutomationTrigger[],
+  within: number,
+  require: AutomationTriggerCompoundRequire,
+}
+
+export class AutomationTriggerCompound implements IAutomationTriggerCompound {
+  public readonly type = 'compound'
+  public triggers: AutomationTrigger[]
+  public within: number
+  public require: AutomationTriggerCompoundRequire
+
+  public constructor(trigger: Partial<IAutomationTriggerCompound>) {
+    this.within = trigger.within ?? 0
+    this.triggers = trigger.triggers ?? []
+    this.require = trigger.require ?? DEFAULT_COMPOUND_TRIGGER_REQUIRED
+  }
+}

--- a/src/automations/types/automationTriggerSequence.ts
+++ b/src/automations/types/automationTriggerSequence.ts
@@ -1,0 +1,17 @@
+import { AutomationTrigger } from '@/automations/types/triggers'
+
+export interface IAutomationTriggerSequence {
+  triggers: AutomationTrigger[],
+  within: number,
+}
+
+export class AutomationTriggerSequence implements IAutomationTriggerSequence {
+  public readonly type = 'sequence'
+  public triggers: AutomationTrigger[]
+  public within: number
+
+  public constructor(trigger: Partial<IAutomationTriggerSequence>) {
+    this.within = trigger.within ?? 0
+    this.triggers = trigger.triggers ?? []
+  }
+}

--- a/src/automations/types/index.ts
+++ b/src/automations/types/index.ts
@@ -56,7 +56,9 @@ export {
 
 export * from './triggers'
 export * from './triggerTemplates'
+export * from './automationTriggerCompound'
 export * from './automationTriggerEvent'
+export * from './automationTriggerSequence'
 export * from './deploymentStatusTrigger'
 export * from './flowRunStateTrigger'
 export * from './workPoolStatusTrigger'

--- a/src/automations/types/triggers.ts
+++ b/src/automations/types/triggers.ts
@@ -1,12 +1,23 @@
+import { isArray } from '@prefecthq/prefect-design'
+import { AutomationTriggerCompound } from '@/automations/types/automationTriggerCompound'
 import { AutomationTriggerEvent, isAutomationTriggerEventPosture } from '@/automations/types/automationTriggerEvent'
+import { AutomationTriggerSequence } from '@/automations/types/automationTriggerSequence'
 import { isRecord } from '@/utilities/object'
 
 export function isAutomationTriggerEvent(value: unknown): value is AutomationTriggerEvent {
   return isRecord(value) && value.type === 'event' && isAutomationTriggerEventPosture(value.posture)
 }
 
-export type AutomationTrigger = AutomationTriggerEvent
+export function isAutomationTriggerCompound(value: unknown): value is AutomationTriggerCompound {
+  return isRecord(value) && value.type === 'compound' && isArray(value.triggers) && value.triggers.every(isAutomationTrigger)
+}
+
+export function isAutomationTriggerSequence(value: unknown): value is AutomationTriggerSequence {
+  return isRecord(value) && value.type === 'sequence' && isArray(value.triggers) && value.triggers.every(isAutomationTrigger)
+}
+
+export type AutomationTrigger = AutomationTriggerEvent | AutomationTriggerCompound | AutomationTriggerSequence
 
 export function isAutomationTrigger(value: unknown): value is AutomationTrigger {
-  return isAutomationTriggerEvent(value)
+  return isAutomationTriggerEvent(value) || isAutomationTriggerCompound(value) || isAutomationTriggerSequence(value)
 }


### PR DESCRIPTION
# Description
For now compound and sequence triggers are considered "custom" triggers. But we still need the types and guards in order to support them at all in oss. 

Closes https://github.com/PrefectHQ/prefect/issues/13936