### PR TITLE
Fix flow run popover cutoff by deployments table

### DIFF
--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -229,6 +229,10 @@
 </script>
 
 <style>
+.deployment-list__table { @apply
+  overflow-visible
+}
+
 .deployment-list__table .p-table__table { @apply
   table-fixed
   w-full


### PR DESCRIPTION
# Description
This component already has these styles for the table element. Which means the overflow properties on `p-table` won't apply here (the table is not allowed to overflow). So by making overflow visible the popover is no longer cut off at the bottom of the table. 

```css
.deployment-list__table .p-table__table { @apply
  table-fixed
  w-full
}
```

Closes https://github.com/PrefectHQ/prefect-ui-library/issues/2206
Related https://github.com/PrefectHQ/prefect-design/pull/1353
