### PR TITLE
Chore: Remove forEach from the default/initial custom automation trigger.

### DIFF
--- a/src/automations/defaultTriggerValues.ts
+++ b/src/automations/defaultTriggerValues.ts
@@ -47,7 +47,7 @@ const defaultAutomationTriggerValues = {
     match: {
       'prefect.resource.id': ['prefect.flow-run.*'],
     },
-    forEach: ['prefect.resource.id'],
+    forEach: [],
     expect: ['prefect.flow-run.Failed'],
     threshold: 5,
     within: 60,


### PR DESCRIPTION
Slight footgun as a starter since it's hidden in the form view (need to toggle to JSON to remove it).

Closes https://github.com/PrefectHQ/nebula-ui/issues/4801