### PR TITLE
Make the dashboard cards more responsive

### DIFF
--- a/src/components/DashboardWorkPoolCard.vue
+++ b/src/components/DashboardWorkPoolCard.vue
@@ -87,6 +87,7 @@
   p-3
   border-b
   border-default
+  flex-wrap
 }
 
 .dashboard-work-pool-card__name { @apply
@@ -98,13 +99,15 @@
 
 .dashboard-work-pool-card__mini-bars { @apply
   w-1/5
+  shrink-0
   h-6
 }
 
 .dashboard-work-pool-card__details { @apply
   p-3
   grid
-  grid-cols-4
+  grid-cols-2
+  sm:grid-cols-4
   gap-y-2
 }
 

--- a/src/components/FlowRunsAccordionHeader.vue
+++ b/src/components/FlowRunsAccordionHeader.vue
@@ -67,12 +67,12 @@
   grid
   gap-0.5
   grid-cols-1
+  text-left
 }
 
 .flow-runs-accordion-header__time { @apply
   text-xs
   text-subdued
-  text-left
 }
 
 .flow-runs-accordion-header__count { @apply

--- a/src/components/WorkspaceDashboardFlowRunsCard.vue
+++ b/src/components/WorkspaceDashboardFlowRunsCard.vue
@@ -8,8 +8,10 @@
         <StatisticKeyValue label="total" :value="count" />
       </template>
     </header>
-    <FlowRunsBarChart class="workspace-dashboard-flow-runs-card__chart" :filter="flowRunsFilter" />
-    <FlowRunStateTypeTabs :filter="flowRunsFilter" />
+    <p-content>
+      <FlowRunsBarChart class="workspace-dashboard-flow-runs-card__chart" :filter="flowRunsFilter" />
+      <FlowRunStateTypeTabs :filter="flowRunsFilter" />
+    </p-content>
   </p-card>
 </template>
 


### PR DESCRIPTION
# Description
The dashboard cards were not very responsive at at smaller screen sizes or when names got very long. This addresses that. 

Closes https://github.com/PrefectHQ/prefect-ui-library/issues/1977

Before
<img width="289" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/a03ec066-26b5-43db-aa7f-58656fb3b995">

After
<img width="297" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/70445102-d489-48f6-94e7-77c9e3238aba">
