### PR TITLE
Port Automate menu items from cloud for flows and work pool queues.

### DIFF
--- a/src/components/FlowMenu.vue
+++ b/src/components/FlowMenu.vue
@@ -1,9 +1,16 @@
 <template>
   <p-icon-button-menu v-bind="$attrs">
     <copy-overflow-menu-item label="Copy ID" :item="flow.id" />
+
     <p-overflow-menu-item label="Delete" :value="flow.id" @click="openDeleteModal" />
-    <slot v-bind="{ flow }" />
+
+    <slot v-bind="{ flow }">
+      <router-link v-if="can.create.automation" :to="routes.automateFlow(flow.id)">
+        <p-overflow-menu-item label="Automate" />
+      </router-link>
+    </slot>
   </p-icon-button-menu>
+
   <ConfirmDeleteModal
     v-if="flow"
     v-model:showModal="showDeleteModal"
@@ -24,7 +31,7 @@
 <script lang="ts" setup>
   import CopyOverflowMenuItem from '@/components/CopyOverflowMenuItem.vue'
   import { ConfirmDeleteModal } from '@/components/index'
-  import { useShowModal, useWorkspaceApi } from '@/compositions'
+  import { useCan, useShowModal, useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { Flow } from '@/models'
   import { deleteItem } from '@/utilities'
 
@@ -32,7 +39,10 @@
     flow: Flow,
   }>()
 
+  const can = useCan()
   const api = useWorkspaceApi()
+  const routes = useWorkspaceRoutes()
+
   const { showModal: showDeleteModal, open: openDeleteModal } = useShowModal()
 
   const emit = defineEmits(['delete'])

--- a/src/components/WorkPoolQueueMenu.vue
+++ b/src/components/WorkPoolQueueMenu.vue
@@ -1,12 +1,20 @@
 <template>
   <p-icon-button-menu v-bind="$attrs" class="work-pool-queue-menu">
     <CopyOverflowMenuItem label="Copy ID" :item="workPoolQueue.id" />
-    <slot v-bind="{ workPoolQueue }" />
+
+    <slot v-bind="{ workPoolQueue }">
+      <router-link v-if="can.create.automation" :to="routes.automateWorkPoolQueue(workPoolQueue.id)">
+        <p-overflow-menu-item label="Automate" />
+      </router-link>
+    </slot>
+
     <router-link :to="routes.workPoolQueueEdit(workPoolName, workPoolQueue.name)">
       <p-overflow-menu-item v-if="can.update.work_queue" label="Edit" />
     </router-link>
+
     <p-overflow-menu-item v-if="showDelete" label="Delete" @click="open" />
   </p-icon-button-menu>
+
   <ConfirmDeleteModal
     v-model:showModal="showModal"
     label="Work Queue"

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -32,6 +32,24 @@ export function createWorkspaceRoutes(config?: CreateWorkspaceRoutesConfig) {
         query,
       } as const
     },
+    automateFlow: (flowId: string, actions?: AutomationAction[]) => {
+      const query = mapper.map('CreateAutomationQuery', { from: 'flow', flowId, actions }, 'LocationQuery')
+
+      return {
+        name: 'workspace.automation.create',
+        params: { ...config },
+        query,
+      } as const
+    },
+    automateWorkPoolQueue: (workPoolQueueId: string, actions?: AutomationAction[]) => {
+      const query = mapper.map('CreateAutomationQuery', { from: 'workPoolQueue', workPoolQueueId, actions }, 'LocationQuery')
+
+      return {
+        name: 'workspace.automation.create',
+        params: { ...config },
+        query,
+      } as const
+    },
     events: () => ({ name: 'workspace.events' }) as const,
     event: (eventId: string, eventDate: Date) => {
 


### PR DESCRIPTION
This PR adds menu items to the following places as shortcuts to create automations. Ported from Cloud - using fallback slot content for smoother backwards compat w/ cloud implementation.

| Where | 📸 |
| ---- | ---- |
| flow | <img width="886" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/bf06107e-45b6-44cb-9c4b-fe48446c97f4"> |
| work pool queue | <img width="892" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/a4481856-ad96-4ac6-a76f-7f56afcebab1"> |

This PR is purely a port - may tweak some things (menu item order is inconsistent) and/or add another shortcut for Work Pools in a follow-up

Closes https://github.com/PrefectHQ/prefect/issues/14358