### PR TITLE
Add automate shortcut to work pool menu

### DIFF
--- a/src/automations/compositions/useCreateAutomationQueryParams.ts
+++ b/src/automations/compositions/useCreateAutomationQueryParams.ts
@@ -26,6 +26,9 @@ export function useCreateAutomationQueryParams(): UseCreateAutomationQueryParams
   // flow trigger
   const { value: flowId } = useRouteQueryParam('flowId')
 
+  // work pool
+  const { value: workPoolId } = useRouteQueryParam('workPoolId')
+
   // work pool queue
   const { value: workPoolQueueId } = useRouteQueryParam('workPoolQueueId')
 
@@ -35,6 +38,8 @@ export function useCreateAutomationQueryParams(): UseCreateAutomationQueryParams
         return await getEventTriggerTemplate()
       case 'flow':
         return await getFlowTriggerTemplate()
+      case 'workPool':
+        return await getWorkPoolTriggerTemplate()
       case 'workPoolQueue':
         return await getWorkPoolQueueTriggerTemplate()
       default:
@@ -74,6 +79,16 @@ export function useCreateAutomationQueryParams(): UseCreateAutomationQueryParams
     const flow = await api.flows.getFlow(flowId)
 
     return mapper.map('Flow', flow, 'AutomationTrigger')
+  }
+
+  async function getWorkPoolTriggerTemplate(): Promise<AutomationTrigger> {
+    if (!workPoolId) {
+      throw new Error('Failed creating automation trigger from work pool. Missing workPoolId query param.')
+    }
+
+    const workPool = await api.workPools.getWorkPoolById(workPoolId)
+
+    return mapper.map('WorkPool', workPool, 'AutomationTrigger')
   }
 
   async function getWorkPoolQueueTriggerTemplate(): Promise<AutomationTrigger> {

--- a/src/automations/maps/createAutomationQuery.ts
+++ b/src/automations/maps/createAutomationQuery.ts
@@ -1,5 +1,5 @@
 import { LocationQuery } from 'vue-router'
-import { CreateAutomationActionQuery, CreateAutomationQuery, CreateAutomationTriggerQuery, isCreateAutomationActionQuery, isCreateAutomationTriggerQuery, isCreateEventAutomationQuery, isCreateFlowAutomationQuery, isCreateWorkPoolQueueAutomationQuery } from '@/automations/types/createAutomationQuery'
+import { CreateAutomationActionQuery, CreateAutomationQuery, CreateAutomationTriggerQuery, isCreateAutomationActionQuery, isCreateAutomationTriggerQuery, isCreateEventAutomationQuery, isCreateFlowAutomationQuery, isCreateWorkPoolAutomationQuery, isCreateWorkPoolQueueAutomationQuery } from '@/automations/types/createAutomationQuery'
 import { MapFunction } from '@/services/Mapper'
 
 export const mapCreateAutomationTriggerQueryToLocationQuery: MapFunction<CreateAutomationTriggerQuery, LocationQuery> = function(source) {
@@ -19,6 +19,14 @@ export const mapCreateAutomationTriggerQueryToLocationQuery: MapFunction<CreateA
       ...query,
       from: 'flow',
       flowId: source.flowId,
+    }
+  }
+
+  if (isCreateWorkPoolAutomationQuery(source)) {
+    return {
+      ...query,
+      from: 'workPool',
+      workPoolId: source.workPoolId,
     }
   }
 

--- a/src/automations/types/createAutomationQuery.ts
+++ b/src/automations/types/createAutomationQuery.ts
@@ -20,6 +20,15 @@ export function isCreateFlowAutomationQuery(value: unknown): value is CreateFlow
   return isRecord(value) && 'from' in value && value.from === 'flow'
 }
 
+export type CreateWorkPoolAutomationQuery = {
+  from: 'workPool',
+  workPoolId: string,
+}
+
+export function isCreateWorkPoolAutomationQuery(value: unknown): value is CreateWorkPoolAutomationQuery {
+  return isRecord(value) && 'from' in value && value.from === 'workPool'
+}
+
 export type CreateWorkPoolQueueAutomationQuery = {
   from: 'workPoolQueue',
   workPoolQueueId: string,
@@ -32,10 +41,11 @@ export function isCreateWorkPoolQueueAutomationQuery(value: unknown): value is C
 export type CreateAutomationTriggerQuery =
   | CreateEventAutomationQuery
   | CreateFlowAutomationQuery
+  | CreateWorkPoolAutomationQuery
   | CreateWorkPoolQueueAutomationQuery
 
 export function isCreateAutomationTriggerQuery(value: unknown): value is CreateAutomationTriggerQuery {
-  return isCreateEventAutomationQuery(value) || isCreateFlowAutomationQuery(value) || isCreateWorkPoolQueueAutomationQuery(value)
+  return isCreateEventAutomationQuery(value) || isCreateFlowAutomationQuery(value) || isCreateWorkPoolAutomationQuery(value) || isCreateWorkPoolQueueAutomationQuery(value)
 }
 
 export type CreateAutomationActionQuery = { actions: AutomationAction[] }

--- a/src/components/WorkPoolMenu.vue
+++ b/src/components/WorkPoolMenu.vue
@@ -6,6 +6,10 @@
     </router-link>
     <p-overflow-menu-item v-if="can.delete.work_pool" label="Delete" @click="open" />
 
+    <router-link :to="routes.automationCreate({ from: 'workPool', workPoolId: workPool.id })">
+      <p-overflow-menu-item label="Automate" />
+    </router-link>
+
     <slot v-bind="{ workPool }" />
   </p-icon-button-menu>
   <ConfirmDeleteModal

--- a/src/components/WorkPoolMenu.vue
+++ b/src/components/WorkPoolMenu.vue
@@ -6,7 +6,7 @@
     </router-link>
     <p-overflow-menu-item v-if="can.delete.work_pool" label="Delete" @click="open" />
 
-    <router-link :to="routes.automationCreate({ from: 'workPool', workPoolId: workPool.id })">
+    <router-link :to="routes.automateWorkPool(workPool.id)">
       <p-overflow-menu-item label="Automate" />
     </router-link>
 

--- a/src/components/WorkPoolQueueMenu.vue
+++ b/src/components/WorkPoolQueueMenu.vue
@@ -2,17 +2,17 @@
   <p-icon-button-menu v-bind="$attrs" class="work-pool-queue-menu">
     <CopyOverflowMenuItem label="Copy ID" :item="workPoolQueue.id" />
 
-    <slot v-bind="{ workPoolQueue }">
-      <router-link v-if="can.create.automation" :to="routes.automateWorkPoolQueue(workPoolQueue.id)">
-        <p-overflow-menu-item label="Automate" />
-      </router-link>
-    </slot>
-
     <router-link :to="routes.workPoolQueueEdit(workPoolName, workPoolQueue.name)">
       <p-overflow-menu-item v-if="can.update.work_queue" label="Edit" />
     </router-link>
 
     <p-overflow-menu-item v-if="showDelete" label="Delete" @click="open" />
+
+    <slot v-bind="{ workPoolQueue }">
+      <router-link v-if="can.create.automation" :to="routes.automateWorkPoolQueue(workPoolQueue.id)">
+        <p-overflow-menu-item label="Automate" />
+      </router-link>
+    </slot>
   </p-icon-button-menu>
 
   <ConfirmDeleteModal

--- a/src/maps/index.ts
+++ b/src/maps/index.ts
@@ -74,7 +74,7 @@ import { mapUiTaskRunCountsByStateResponseToUiTaskRunCountsByState } from '@/map
 import { mapVariableResponseToVariable, mapVariableEditToVariableEditRequest, mapVariableCreateToVariableCreateRequest, mapVariableV2CreateToVariableV2CreateRequest, mapVariableV2EditToVariableV2EditRequest, mapVariableV2ResponseToVariableV2 } from '@/maps/variable'
 import { mapPrefectWorkerCollectionResponseToWorkerCollectionItemArray, mapWorkerSchemaValuesToWorkerSchemaValuesRequest } from '@/maps/workerCollection'
 import { mapWorkerScheduledFlowRunResponseToWorkerScheduledFlowRun, mapWorkerScheduledFlowRunsToWorkerScheduledFlowRunsRequest } from '@/maps/workerScheduledFlowRun'
-import { mapWorkPoolCreateToWorkPoolCreateRequest, mapWorkPoolEditToWorkPoolEditRequest, mapWorkPoolResponseToWorkPool, mapWorkPoolToWorkPoolResponse } from '@/maps/workPool'
+import { mapWorkPoolCreateToWorkPoolCreateRequest, mapWorkPoolEditToWorkPoolEditRequest, mapWorkPoolResponseToWorkPool, mapWorkPoolToAutomationTrigger, mapWorkPoolToWorkPoolResponse } from '@/maps/workPool'
 import { mapWorkPoolQueueCreateToWorkPoolQueueCreateRequest, mapWorkPoolQueueEditToWorkPoolQueueEditRequest, mapWorkPoolQueueResponseToWorkPoolQueue, mapWorkPoolQueueToAutomationTrigger, mapWorkPoolQueueToWorkPoolQueueResponse } from '@/maps/workPoolQueue'
 import { mapServerWorkPoolStatusToWorkPoolStatus, mapWorkPoolStatusToServerWorkPoolStatus } from '@/maps/workPoolStatus'
 import { mapWorkPoolWorkerResponseToWorkPoolWorker } from '@/maps/workPoolWorker'
@@ -234,7 +234,10 @@ export const maps = {
   WorkerScheduledFlowRunResponse: { WorkerScheduledFlowRun: mapWorkerScheduledFlowRunResponseToWorkerScheduledFlowRun },
   WorkerScheduledFlowRuns: { WorkerScheduledFlowRunsRequest: mapWorkerScheduledFlowRunsToWorkerScheduledFlowRunsRequest },
   WorkerSchemaProperty: { WorkerSchemaPropertyRequest: mapWorkerSchemaValuesToWorkerSchemaValuesRequest },
-  WorkPool: { WorkPoolResponse: mapWorkPoolToWorkPoolResponse },
+  WorkPool: {
+    WorkPoolResponse: mapWorkPoolToWorkPoolResponse,
+    AutomationTrigger: mapWorkPoolToAutomationTrigger,
+  },
   WorkPoolCreate: { WorkPoolCreateRequest: mapWorkPoolCreateToWorkPoolCreateRequest },
   WorkPoolEdit: { WorkPoolEditRequest: mapWorkPoolEditToWorkPoolEditRequest },
   WorkPoolFilter: { WorkPoolFilterRequest: mapWorkPoolFilter },

--- a/src/maps/workPool.ts
+++ b/src/maps/workPool.ts
@@ -1,3 +1,5 @@
+import { AutomationTriggerEvent } from '@/automations/types/automationTriggerEvent'
+import { AutomationTrigger } from '@/automations/types/triggers'
 import { WorkPool, WorkPoolCreateRequest, WorkPoolEdit, WorkPoolEditRequest, WorkPoolResponse, WorkPoolCreate } from '@/models'
 import { MapFunction } from '@/services/Mapper'
 
@@ -67,4 +69,15 @@ export const mapWorkPoolEditToWorkPoolEditRequest: MapFunction<WorkPoolEdit, Wor
     concurrency_limit: source.concurrencyLimit,
     base_job_template: baseJobTemplateSchema,
   }
+}
+
+export const mapWorkPoolToAutomationTrigger: MapFunction<WorkPool, AutomationTrigger> = function(workPool) {
+  return new AutomationTriggerEvent({
+    'posture': 'Reactive',
+    'match': {
+      'prefect.resource.id': `prefect.work-pool.${workPool.id}`,
+    },
+    'forEach': ['prefect.resource.id'],
+    'expect': ['prefect.work-pool.not-ready'],
+  })
 }

--- a/src/maps/workPoolQueue.ts
+++ b/src/maps/workPoolQueue.ts
@@ -54,6 +54,7 @@ export const mapWorkPoolQueueEditToWorkPoolQueueEditRequest: MapFunction<WorkPoo
     priority: source.priority,
   }
 }
+
 export const mapWorkPoolQueueToAutomationTrigger: MapFunction<WorkPoolQueue, AutomationTrigger> = function(workPoolQueue) {
   return new AutomationTriggerEvent({
     'posture': 'Reactive',

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -29,11 +29,21 @@ export function createWorkspaceRoutes(config?: CreateWorkspaceRoutesConfig) {
 
       return {
         name: 'workspace.automation.create',
+        params: { ...config },
         query,
       } as const
     },
     automateFlow: (flowId: string, actions?: AutomationAction[]) => {
       const query = mapper.map('CreateAutomationQuery', { from: 'flow', flowId, actions }, 'LocationQuery')
+
+      return {
+        name: 'workspace.automation.create',
+        params: { ...config },
+        query,
+      } as const
+    },
+    automateWorkPool: (workPoolId: string, actions?: AutomationAction[]) => {
+      const query = mapper.map('CreateAutomationQuery', { from: 'workPool', workPoolId, actions }, 'LocationQuery')
 
       return {
         name: 'workspace.automation.create',


### PR DESCRIPTION
This PR adds an `Automate` shortcut to work pool menus.

<img width="911" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/50a6bf30-bc08-4ee2-8988-df90721eff91">

On click, you're brought to a pre-filled create automation form for an automation w/ a work pool status trigger for the selected work pool.

<img width="913" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/22418768/7f2f42ad-a092-4b05-9710-9468bac7a08d">
