### PR TITLE
Fix the flow run popover text wrap and allow breaking words

### DIFF
--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -251,7 +251,6 @@
   h-8
   pr-4
   w-full
-  text-wrap
 }
 
 .deployment-list__search-input { @apply

--- a/src/components/FlowRunPopOverContent.vue
+++ b/src/components/FlowRunPopOverContent.vue
@@ -51,6 +51,8 @@
   max-w-xs
   w-screen
   shadow-lg
+  text-wrap
+  break-words
 }
 
 .flow-run-popover-content__aside { @apply

--- a/src/components/FlowRunPopOverContent.vue
+++ b/src/components/FlowRunPopOverContent.vue
@@ -52,7 +52,8 @@
   w-screen
   shadow-lg
   text-wrap
-  break-words
+  break-words;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .flow-run-popover-content__aside { @apply


### PR DESCRIPTION
# Description
Improvement over https://github.com/PrefectHQ/prefect-ui-library/pull/2563

Prevents grid blowout in the flow run popover component and specifies wrapping css rather than depending on the cascade. 

<img width="417" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/f3d023ea-6668-43e2-898d-83e2cccb2d55">
