### PR TITLE
Chore: remove global pause/resume from deployments list

### DIFF
--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -84,7 +84,6 @@
 
       <template #action="{ row }">
         <div class="deployment-list__action">
-          <DeploymentToggle :deployment="row" @update="refresh" />
           <DeploymentMenu
             class="deployment-list__menu"
             small
@@ -134,7 +133,6 @@
     MiniDeploymentHistory,
     SelectedCount,
     DeploymentTagsInput,
-    DeploymentToggle,
     FormattedDate,
     DeploymentStatusBadge,
     DeploymentScheduleTags

--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -83,16 +83,14 @@
       </template>
 
       <template #action="{ row }">
-        <div class="deployment-list__action">
-          <DeploymentMenu
-            class="deployment-list__menu"
-            small
-            show-all
-            :deployment="row"
-            flat
-            @delete="refresh"
-          />
-        </div>
+        <DeploymentMenu
+          class="deployment-list__menu"
+          small
+          show-all
+          :deployment="row"
+          flat
+          @delete="refresh"
+        />
       </template>
 
       <template #empty-state>
@@ -254,12 +252,6 @@
 
 .deployment-list__search-input { @apply
   w-64
-}
-
-.deployment-list__action { @apply
-  flex
-  justify-end
-  items-center
 }
 
 .deployment-list__deployment { @apply


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/14385

Manipulating the `paused` state of a deployment has become a different action from enabling or disabling all of the schedules for a deployment and does not impact scheduling flow runs via automation trigger, the UI, CLI, etc. Until we can determine the best way to handle this functionality going forward, we're going to remove this toggle.