### PR TITLE
Update date time formats to use FormattedDate component

### DIFF
--- a/src/components/ArtifactCard.vue
+++ b/src/components/ArtifactCard.vue
@@ -20,7 +20,7 @@
             </span>
             <span class="artifact-card__summary-item-value">
               <slot name="summary-value">
-                {{ formatDateTime(artifact.created) }}
+                <FormattedDate :date="artifact.created" format="datetime" />
               </slot>
             </span>
           </div>
@@ -41,9 +41,9 @@
 
 <script lang="ts" setup>
   import { computed } from 'vue'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { localization } from '@/localization'
   import { Artifact } from '@/models'
-  import { formatDateTime } from '@/utilities'
 
   const props = defineProps<{
     artifact: Artifact,

--- a/src/components/ArtifactCollections.vue
+++ b/src/components/ArtifactCollections.vue
@@ -15,7 +15,7 @@
               {{ localization.info.lastUpdated }}
             </template>
             <template #summary-value>
-              {{ formatDateTime(item.updated) }}
+              <FormattedDate :date="item.updated" format="datetime" />
             </template>
           </ArtifactCard>
         </router-link>
@@ -34,12 +34,12 @@
   import { ArtifactTypeSelect, ResultsCount, SearchInput } from '@/components'
   import ArtifactCard from '@/components/ArtifactCard.vue'
   import ArtifactCollectionsEmptyState from '@/components/ArtifactCollectionsEmptyState.vue'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import RowGridLayoutList from '@/components/RowGridLayoutList.vue'
   import ViewModeButtonGroup from '@/components/ViewModeButtonGroup.vue'
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { localization } from '@/localization'
   import { ArtifactsFilter, ArtifactType, ArtifactCollection } from '@/models'
-  import { formatDateTime } from '@/utilities'
 
   const searchTerm = ref<string>('')
   const searchTermDebounced = useDebouncedRef(searchTerm, 1200)

--- a/src/components/ArtifactDetails.vue
+++ b/src/components/ArtifactDetails.vue
@@ -43,7 +43,11 @@
         </template>
       </p-key-value>
 
-      <p-key-value label="Created" :value="formatDateTimeNumeric(artifact.created)" :alternate="alternate" />
+      <p-key-value label="Created" :alternate="alternate">
+        <template #value>
+          <FormattedDate :date="artifact.created" format="numeric" />
+        </template>
+      </p-key-value>
     </template>
 
     <template v-if="can.read.flow_run && flowRun">
@@ -65,13 +69,21 @@
         </template>
       </p-key-value>
 
-      <p-key-value label="Created" :value="formatDateTimeNumeric(flowRun.created)" :alternate="alternate" />
+      <p-key-value label="Created" :alternate="alternate">
+        <template #value>
+          <FormattedDate :date="flowRun.created" format="numeric" />
+        </template>
+      </p-key-value>
 
       <template v-if="flowRun.createdBy">
         <p-key-value label="Created By" :value="flowRun.createdBy.displayValue" :alternate="alternate" />
       </template>
 
-      <p-key-value label="Last Updated" :value="formatDateTimeNumeric(flowRun.updated)" :alternate="alternate" />
+      <p-key-value label="Last Updated" :alternate="alternate">
+        <template #value>
+          <FormattedDate :date="flowRun.updated" format="numeric" />
+        </template>
+      </p-key-value>
 
       <p-key-value label="Tags" :alternate="alternate">
         <template v-if="flowRun.tags?.length" #value>
@@ -93,9 +105,17 @@
         Task Run
       </p-heading>
 
-      <p-key-value label="Created" :value="formatDateTimeNumeric(taskRun.created)" :alternate="alternate" />
+      <p-key-value label="Created" :alternate="alternate">
+        <template #value>
+          <FormattedDate :date="taskRun.created" format="numeric" />
+        </template>
+      </p-key-value>
 
-      <p-key-value label="Last Updated" :value="formatDateTimeNumeric(taskRun.updated)" :alternate="alternate" />
+      <p-key-value label="Last Updated" :alternate="alternate">
+        <template #value>
+          <FormattedDate :date="taskRun.updated" format="numeric" />
+        </template>
+      </p-key-value>
 
       <p-key-value label="Tags" :alternate="alternate">
         <template v-if="taskRun.tags?.length" #value>
@@ -110,9 +130,9 @@
   import { PKeyValue, PTags } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import { FlowRunStartTime, DurationIconText, FlowRunIconText, TaskRunIconText, ArtifactKeyIconText } from '@/components'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useCan, useFlowRun, useTaskRun } from '@/compositions'
   import { Artifact } from '@/models'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
     artifact: Artifact,

--- a/src/components/ConcurrencyLimitDetails.vue
+++ b/src/components/ConcurrencyLimitDetails.vue
@@ -10,15 +10,23 @@
 
     <p-key-value label="Concurrency Limit ID" :value="concurrencyLimit.id" :alternate="alternate" />
 
-    <p-key-value v-if="concurrencyLimit.created" label="Created" :value="formatDateTimeNumeric(concurrencyLimit.created)" :alternate="alternate" />
+    <p-key-value v-if="concurrencyLimit.created" label="Created" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="concurrencyLimit.created" format="numeric" />
+      </template>
+    </p-key-value>
 
-    <p-key-value v-if="concurrencyLimit.updated" label="Updated" :value="formatDateTimeNumeric(concurrencyLimit.updated)" :alternate="alternate" />
+    <p-key-value v-if="concurrencyLimit.updated" label="Updated" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="concurrencyLimit.updated" format="numeric" />
+      </template>
+    </p-key-value>
   </div>
 </template>
 
 <script lang="ts" setup>
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { ConcurrencyLimit } from '@/models/ConcurrencyLimit'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   defineProps<{
     concurrencyLimit: ConcurrencyLimit,

--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -49,13 +49,21 @@
       </template>
     </p-key-value>
 
-    <p-key-value label="Created" :value="formatDateTimeNumeric(deployment.created)" :alternate="alternate" />
+    <p-key-value label="Created" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="deployment.created" format="numeric" />
+      </template>
+    </p-key-value>
 
     <template v-if="deployment.createdBy">
       <p-key-value label="Created By" :value="deployment.createdBy.displayValue" :alternate="alternate" />
     </template>
 
-    <p-key-value label="Last Updated" :value="formatDateTimeNumeric(deployment.updated)" :alternate="alternate" />
+    <p-key-value label="Last Updated" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="deployment.updated" format="numeric" />
+      </template>
+    </p-key-value>
 
     <template v-if="deployment.updatedBy">
       <p-key-value label="Updated By" :value="deployment.updatedBy.displayValue" :alternate="alternate" />
@@ -98,11 +106,11 @@
   import AutomationIconText from '@/automations/components/AutomationIconText.vue'
   import { BlockIconText, DeploymentStatusBadge, DeploymentSchedulesFieldset } from '@/components'
   import DeploymentToggle from '@/components/DeploymentToggle.vue'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useWorkspaceApi, useCan, useWorkspaceRoutes } from '@/compositions'
   import { useAutomationsByRelatedResource } from '@/compositions/useAutomationsByRelatedResource'
   import { localization } from '@/localization'
   import { Deployment, DeploymentScheduleCompatible } from '@/models'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
     deployment: Deployment,

--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -56,14 +56,6 @@
         </div>
       </template>
 
-      <template #updated="{ row }">
-        <FormattedDate :date="row.updated" />
-      </template>
-
-      <template #created="{ row }">
-        <FormattedDate :date="row.created" />
-      </template>
-
       <template #schedules="{ row }">
         <DeploymentScheduleTags :schedules="row.schedules" justify="right" />
       </template>

--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -2,12 +2,15 @@
   <div class="event-card p-background">
     <template v-if="event">
       <WorkspaceEventDescription :event="event" />
-      <p-key-value label="Occurred">
+
+      <p-key-value label="Occurred" alternate>
         <template #value>
-          <span class="event-card__date">{{ formatDateTimeNumeric(event.occurred) }}</span>
+          <FormattedDate :date="event.occurred" format="numeric" />
         </template>
       </p-key-value>
+
       <EventResourceKeyValue class="workspace-events-list-item__resource" :event="event" alternate />
+
       <template v-if="event.related.length">
         <EventRelatedKeyValue :event="event" alternate />
       </template>
@@ -22,9 +25,9 @@
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
   import { EventRelatedKeyValue, EventResourceKeyValue } from '@/components'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import WorkspaceEventDescription from '@/components/WorkspaceEventDescription.vue'
   import { useWorkspaceApi } from '@/compositions/useWorkspaceApi'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
     eventId: string,
@@ -44,9 +47,5 @@
   flex
   flex-col
   gap-2
-}
-
-.event-card__date { @apply
-  text-sm
 }
 </style>

--- a/src/components/FlowDetails.vue
+++ b/src/components/FlowDetails.vue
@@ -2,15 +2,24 @@
   <div class="flow-details">
     <p-key-value label="Flow ID" :value="flow.id" :alternate="alternate" />
 
-    <p-key-value label="Created" :value="formatDateTimeNumeric(flow.created)" :alternate="alternate" />
 
-    <p-key-value label="Updated" :value="formatDateTimeNumeric(flow.updated)" :alternate="alternate" />
+    <p-key-value label="Created" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="flow.created" format="numeric" />
+      </template>
+    </p-key-value>
+
+    <p-key-value label="Updated" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="flow.updated" format="numeric" />
+      </template>
+    </p-key-value>
   </div>
 </template>
 
 <script lang="ts" setup>
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { Flow } from '@/models/Flow'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   defineProps<{
     flow: Flow,

--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -29,7 +29,12 @@
           <p-link :to="routes.flow(row.id)" class="flow-list__name">
             <span>{{ row.name }}</span>
           </p-link>
-          <span class="flow-list__created-date">Created {{ formatDateTimeNumeric(row.created) }}</span>
+
+          <FormattedDate :date="row.created" format="numeric">
+            <template #default="{ date }">
+              <span class="flow-list__created-date">Created {{ date }}</span>
+            </template>
+          </FormattedDate>
         </div>
       </template>
 
@@ -104,6 +109,7 @@
     SelectedCount,
     FlowRunTagsInput
   } from '@/components'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useCan, useWorkspaceRoutes, useFlows, useWorkspaceApi, useFlowsPaginationFilterFromRoute } from '@/compositions'
   import { useComponent } from '@/compositions/useComponent'
   import { FlowsFilter } from '@/models/Filters'
@@ -111,7 +117,6 @@
   import { Getter } from '@/types'
   import { flowSortOptions } from '@/types/SortOptionTypes'
   import { snakeCase } from '@/utilities'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
     filter?: FlowsFilter,

--- a/src/components/FlowRunDetails.vue
+++ b/src/components/FlowRunDetails.vue
@@ -2,13 +2,21 @@
   <div class="flow-run-details">
     <p-key-value label="Run Count" :value="flowRun.runCount ?? 0" :alternate="alternate" />
 
-    <p-key-value label="Created" :value="formatDateTimeNumeric(flowRun.created)" :alternate="alternate" />
+    <p-key-value label="Created" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="flowRun.created" format="numeric" />
+      </template>
+    </p-key-value>
 
     <template v-if="flowRun.createdBy">
       <p-key-value label="Created By" :value="flowRun.createdBy.displayValue" :alternate="alternate" />
     </template>
 
-    <p-key-value label="Last Updated" :value="formatDateTimeNumeric(flowRun.updated)" :alternate="alternate" />
+    <p-key-value label="Last Updated" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="flowRun.updated" format="numeric" />
+      </template>
+    </p-key-value>
 
     <template v-if="flowRun.idempotencyKey">
       <p-key-value label="Idempotency Key" :value="flowRun.idempotencyKey" :alternate="alternate" />
@@ -48,8 +56,8 @@
 <script lang="ts" setup>
   import { PKeyValue, PTags } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { FlowRun } from '@/models/FlowRun'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
     flowRun: FlowRun,

--- a/src/components/FlowRunGraphStatePopover.vue
+++ b/src/components/FlowRunGraphStatePopover.vue
@@ -12,7 +12,7 @@
       </p-key-value>
       <p-key-value label="Occurred">
         <template #value>
-          {{ formatDateTimeNumeric(selection.timestamp) }}
+          <FormattedDate :date="selection.timestamp" format="numeric" />
         </template>
       </p-key-value>
     </div>
@@ -22,7 +22,7 @@
 <script lang="ts" setup>
   import { StateSelection } from '@prefecthq/graphs'
   import { FlowRunGraphPopover } from '@/components'
-  import { formatDateTimeNumeric } from '@/utilities'
+  import FormattedDate from '@/components/FormattedDate.vue'
 
   defineProps<{
     selection: StateSelection,

--- a/src/components/FlowRunStartTime.vue
+++ b/src/components/FlowRunStartTime.vue
@@ -1,12 +1,18 @@
 <template>
   <p-icon-text class="flow-run-list-item-date" icon="CalendarIcon">
     <template v-if="flowRun.startTime">
-      {{ formatDateTimeNumeric(flowRun.startTime) }}
-      {{ flowRun.delta }}
+      <FormattedDate :date="flowRun.startTime" format="numeric">
+        <template #default="{ date }">
+          {{ date }} {{ flowRun.delta }}
+        </template>
+      </FormattedDate>
     </template>
     <template v-else-if="flowRun.expectedStartTime">
-      Scheduled for {{ formatDateTimeNumeric(flowRun.expectedStartTime) }}
-      {{ flowRun.delta }}
+      <FormattedDate :date="flowRun.expectedStartTime" format="numeric">
+        <template #default="{ date }">
+          Scheduled for {{ date }} {{ flowRun.delta }}
+        </template>
+      </FormattedDate>
     </template>
     <template v-else>
       No start time
@@ -15,8 +21,8 @@
 </template>
 
 <script lang="ts" setup>
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { FlowRun } from '@/models/FlowRun'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   defineProps<{
     flowRun: FlowRun,

--- a/src/components/FlowRunTimelineSubFlowRunDetails.vue
+++ b/src/components/FlowRunTimelineSubFlowRunDetails.vue
@@ -7,13 +7,21 @@
           <StateBadge :state="flowRun.state" class="timeline-task-details__state-badge" />
         </template>
       </p-key-value>
+
       <p-key-value label="Flow Run ID" :value="flowRun.id" :alternate="alternate" />
+
       <p-key-value label="Duration" :alternate="alternate">
         <template #value>
           <DurationIconText :duration="flowRun.duration" />
         </template>
       </p-key-value>
-      <p-key-value label="Created" :value="formatDateTimeNumeric(flowRun.created)" :alternate="alternate" />
+
+      <p-key-value label="Created" :alternate="alternate">
+        <template #value>
+          <FormattedDate :date="flowRun.created" format="numeric" />
+        </template>
+      </p-key-value>
+
       <p-key-value label="Tags" :alternate="alternate">
         <template v-if="flowRun.tags?.length" #value>
           <p-tags :tags="flowRun.tags!" class="flow-run-timeline-sub-flow-run-details__tags" />
@@ -27,8 +35,8 @@
   import { BreadCrumbs } from '@prefecthq/prefect-design'
   import { computed, toRefs } from 'vue'
   import { StateBadge, DurationIconText } from '@/components'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useFlow, useFlowRun, useWorkspaceRoutes } from '@/compositions'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
     flowRunId: string,

--- a/src/components/FlowRunTimelineTaskDetails.vue
+++ b/src/components/FlowRunTimelineTaskDetails.vue
@@ -11,13 +11,21 @@
           <StateBadge :state="taskRun.state" class="flow-run-timeline-task-details__state-badge" />
         </template>
       </p-key-value>
+
       <p-key-value label="Task Run ID" :value="taskRun.id" :alternate="alternate" />
+
       <p-key-value label="Duration" :alternate="alternate">
         <template #value>
           <DurationIconText :duration="taskRun.duration" />
         </template>
       </p-key-value>
-      <p-key-value label="Created" :value="formatDateTimeNumeric(taskRun.created)" :alternate="alternate" />
+
+      <p-key-value label="Created" :alternate="alternate">
+        <template #value>
+          <FormattedDate :date="taskRun.created" format="numeric" />
+        </template>
+      </p-key-value>
+
       <p-key-value label="Tags" :alternate="alternate">
         <template v-if="taskRun.tags?.length" #value>
           <p-tags :tags="taskRun.tags!" class="flow-run-timeline-task-details__tags" />
@@ -30,8 +38,8 @@
 <script lang="ts" setup>
   import { toRefs } from 'vue'
   import { StateBadge, DurationIconText } from '@/components'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useTaskRun, useWorkspaceRoutes } from '@/compositions'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
     taskRunId: string,

--- a/src/components/FlowRunsAccordionHeader.vue
+++ b/src/components/FlowRunsAccordionHeader.vue
@@ -4,9 +4,14 @@
       <p-link :to="routes.flow(flow.id)" class="flow-runs-accordion-header__name">
         {{ flow.name }}
       </p-link>
-      <span class="flow-runs-accordion-header__time">
-        {{ lastRunTime }}
-      </span>
+
+      <template v-if="lastFlowRun?.startTime">
+        <FormattedDate :date="lastFlowRun.startTime" format="relative">
+          <template #default="{ date }">
+            <span class="flow-runs-accordion-header__time ">{{ date }}</span>
+          </template>
+        </FormattedDate>
+      </template>
     </div>
 
     <span class="flow-runs-accordion-header__count">
@@ -16,14 +21,13 @@
 </template>
 
 <script lang="ts" setup>
-  import { useNow } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useFlowRunsCount } from '@/compositions/useFlowRunsCount'
   import { useLastFlowRun } from '@/compositions/useLastFlowRun'
   import { useWorkspaceRoutes } from '@/compositions/useWorkspaceRoutes'
   import { FlowRunsFilter } from '@/models/Filters'
   import { Flow } from '@/models/Flow'
-  import { formatDateTimeRelative } from '@/utilities/dates'
 
   const props = defineProps<{
     flow: Flow,
@@ -31,7 +35,6 @@
   }>()
 
   const routes = useWorkspaceRoutes()
-  const { now } = useNow({ interval: 1000 })
 
   const filter = computed<FlowRunsFilter>(() => ({
     ...props.filter,
@@ -40,16 +43,8 @@
       id: [props.flow.id],
     },
   }))
+
   const { flowRun: lastFlowRun } = useLastFlowRun(filter)
-
-  const lastRunTime = computed(() => {
-    if (lastFlowRun.value?.startTime) {
-      return formatDateTimeRelative(lastFlowRun.value.startTime, now.value)
-    }
-
-    return undefined
-  })
-
   const { count } = useFlowRunsCount(filter)
 </script>
 
@@ -65,13 +60,12 @@
 
 .flow-runs-accordion-header__content { @apply
   grid
-  gap-0.5
   grid-cols-1
   text-left
 }
 
 .flow-runs-accordion-header__time { @apply
-  text-xs
+  text-sm
   text-subdued
 }
 

--- a/src/components/FormattedDate.vue
+++ b/src/components/FormattedDate.vue
@@ -1,7 +1,7 @@
 <template>
   <p-tooltip>
     <template #content>
-      <slot>
+      <slot name="tooltip">
         <div class="formatted-date__tooltip">
           {{ date }}
         </div>
@@ -9,7 +9,7 @@
     </template>
 
     <button type="button" class="formatted-date">
-      <slot name="text" v-bind="{ formattedText }">
+      <slot v-bind="{ date: formattedText }">
         {{ formattedText }}
       </slot>
     </button>
@@ -17,39 +17,38 @@
 </template>
 
 <script lang="ts" setup>
+  import { useNow } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
   import { formatDateTimeRelative, formatDateTimeNumeric, formatDate, formatDateTime } from '@/utilities'
 
   const props = defineProps<{
-    date: Date | string,
+    date: Date,
     format?: 'date' | 'datetime' | 'relative' | 'numeric',
   }>()
 
+  const { now } = useNow({ interval: 60_000 })
+
   const formattedText = computed(() => {
-    const normalizedDate = new Date(props.date)
-
-    if (normalizedDate.toString() === 'Invalid Date') {
-      console.warn('Invalid date provided to FormattedDate:', props.date)
-      return props.date
-    }
-
     switch (props.format) {
       case 'numeric':
-        return formatDateTimeNumeric(normalizedDate)
+        return formatDateTimeNumeric(props.date)
       case 'date':
-        return formatDate(normalizedDate)
+        return formatDate(props.date)
       case 'datetime':
-        return formatDateTime(normalizedDate)
+        return formatDateTime(props.date)
       case 'relative':
       default:
-        return formatDateTimeRelative(normalizedDate)
+        return formatDateTimeRelative(props.date, now.value)
     }
   })
 </script>
 
 <style>
 .formatted-date { @apply
-  font-mono
+  text-left
+  font-mono;
+  /* mono font is smaller than the sans font. This bumps whatever the font is by 2px so it matches  */
+  font-size: calc(1em + 2px)
 }
 
 .formatted-date__tooltip { @apply

--- a/src/components/TaskRunDetails.vue
+++ b/src/components/TaskRunDetails.vue
@@ -7,7 +7,11 @@
     </p-key-value>
 
     <template v-if="taskRun.startTime">
-      <p-key-value label="Start Time" :alternate="alternate" :value="formatDateTimeNumeric(taskRun.startTime)" />
+      <p-key-value label="Start Time" :alternate="alternate">
+        <template #value>
+          <FormattedDate :date="taskRun.startTime" format="numeric" />
+        </template>
+      </p-key-value>
     </template>
 
     <p-key-value label="Duration" :alternate="alternate">
@@ -20,9 +24,17 @@
 
     <p-key-value label="Estimated Run Time" :value="secondsToApproximateString(taskRun.estimatedRunTime ?? 0)" :alternate="alternate" />
 
-    <p-key-value label="Created" :value="formatDateTimeNumeric(taskRun.created)" :alternate="alternate" />
+    <p-key-value label="Created" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="taskRun.created" format="numeric" />
+      </template>
+    </p-key-value>
 
-    <p-key-value label="Last Updated" :value="formatDateTimeNumeric(taskRun.updated)" :alternate="alternate" />
+    <p-key-value label="Last Updated" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="taskRun.updated" format="numeric" />
+      </template>
+    </p-key-value>
 
     <p-key-value label="Cache Key" :value="taskRun.cacheKey" :alternate="alternate" />
 
@@ -72,10 +84,10 @@
   import { computed } from 'vue'
   import DurationIconText from '@/components/DurationIconText.vue'
   import FlowRunIconText from '@/components/FlowRunIconText.vue'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useTaskRunResult } from '@/compositions'
   import { localization } from '@/localization'
   import { TaskRun } from '@/models/TaskRun'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
   import { secondsToApproximateString } from '@/utilities/seconds'
 
   const props = defineProps<{

--- a/src/components/TaskRunListItem.vue
+++ b/src/components/TaskRunListItem.vue
@@ -27,14 +27,12 @@
         <p-icon-text icon="ClockIcon">
           {{ secondsToApproximateString(taskRun.duration) }}
         </p-icon-text>
-        <p-icon-text class="flow-run-date-icon-text" icon="CalendarIcon">
-          <template v-if="taskRun.startTime">
-            {{ formatDateTimeNumeric(taskRun.startTime) }}
-          </template>
-          <template v-else-if="taskRun.expectedStartTime">
-            {{ formatDateTimeNumeric(taskRun.expectedStartTime) }}
-          </template>
-        </p-icon-text>
+
+        <template v-if="startTime">
+          <p-icon-text class="flow-run-date-icon-text" icon="CalendarIcon">
+            <FormattedDate :date="startTime" format="numeric" />
+          </p-icon-text>
+        </template>
       </template>
 
       <template v-if="showFlowRun && visible" #relationships>
@@ -59,11 +57,11 @@
   import FlowRunDeployment from '@/components/FlowRunDeployment.vue'
   import FlowRunWorkPool from '@/components/FlowRunWorkPool.vue'
   import FlowRunWorkQueue from '@/components/FlowRunWorkQueue.vue'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import StateBadge from '@/components/StateBadge.vue'
   import StateListItem from '@/components/StateListItem.vue'
   import { useFlow, useFlowRun, useWorkspaceRoutes } from '@/compositions'
   import { TaskRun } from '@/models/TaskRun'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
   import { secondsToApproximateString } from '@/utilities/seconds'
 
   const props = defineProps<{
@@ -90,6 +88,7 @@
   const stateType = computed(() => props.taskRun.state?.type)
   const tags = computed(() => props.taskRun.tags)
   const value = computed(() => props.taskRun.id)
+  const startTime = computed(() => props.taskRun.startTime ?? props.taskRun.expectedStartTime)
 
   const { flowRun } = useFlowRun(props.taskRun.flowRunId)
   const isFlowRunRoute = computed(() => route.name === routes.flowRun('').name)

--- a/src/components/VariablesV2Table.vue
+++ b/src/components/VariablesV2Table.vue
@@ -43,7 +43,7 @@
       </template>
 
       <template #updated="{ row }">
-        {{ formatDateTimeNumeric(row.updated) }}
+        <FormattedDate :date="row.updated" format="numeric" />
       </template>
 
       <template #tags="{ row }">
@@ -89,12 +89,12 @@
   import merge from 'lodash.merge'
   import { computed, ref } from 'vue'
   import { VariablesDeleteButton, VariableV2Menu, ResultsCount, SearchInput, SelectedCount, VariableTagsInput } from '@/components'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import VariableV2DisplayPreview from '@/components/VariableV2DisplayPreview.vue'
   import { useCan, useVariablesFilter, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { VariablesFilter, VariableV2 } from '@/models'
   import { variableSortOptions } from '@/types'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const DEFAULT_LIMIT = 25
 

--- a/src/components/WorkPoolDetails.vue
+++ b/src/components/WorkPoolDetails.vue
@@ -14,11 +14,23 @@
 
     <p-key-value label="Concurrency Limit" :value="workPool.concurrencyLimit" :alternate="alternate" />
 
-    <p-key-value label="Created" :value="formatDateTimeNumeric(workPool.created)" :alternate="alternate" />
+    <p-key-value label="Created" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="workPool.created" format="numeric" />
+      </template>
+    </p-key-value>
 
-    <p-key-value label="Last Updated" :value="formatDateTimeNumeric(workPool.updated)" :alternate="alternate" />
+    <p-key-value label="Last Updated" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="workPool.updated" format="numeric" />
+      </template>
+    </p-key-value>
 
-    <p-key-value v-if="workPoolWorkers.length" label="Last Polled" :value="formatDateTimeNumeric(lastWorkerHeartbeat)" :alternate="alternate" />
+    <p-key-value v-if="workPoolWorkers.length" label="Last Polled" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="lastWorkerHeartbeat" format="numeric" />
+      </template>
+    </p-key-value>
 
     <template v-if="showBaseJobTemplateDetails">
       <p-divider />
@@ -34,10 +46,10 @@
   import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
   import { SchemaPropertiesKeyValues, WorkPoolStatusBadge } from '@/components'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useWorkspaceApi } from '@/compositions'
   import { WorkPool } from '@/models'
   import { getSchemaDefaultValues, mapper } from '@/services'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
     workPool: WorkPool,

--- a/src/components/WorkPoolQueueDetails.vue
+++ b/src/components/WorkPoolQueueDetails.vue
@@ -13,7 +13,11 @@
     </p-key-value>
 
     <template v-if="workQueueStatus">
-      <p-key-value label="Last Polled" :value="workQueueLastPolled" :alternate="alternate" />
+      <p-key-value label="Last Polled" :alternate="alternate">
+        <template v-if="workQueueLastPolled" #value>
+          <FormattedDate :date="workPoolQueue.updated" format="numeric" />
+        </template>
+      </p-key-value>
     </template>
 
     <p-key-value label="Description" :value="workPoolQueue.description" :alternate="alternate" />
@@ -26,9 +30,17 @@
 
     <p-key-value label="Flow Run Concurrency" :value="workPoolQueue.concurrencyLimit" :alternate="alternate" />
 
-    <p-key-value label="Created" :value="formatDateTimeNumeric(workPoolQueue.created)" :alternate="alternate" />
+    <p-key-value label="Created" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="workPoolQueue.created" format="numeric" />
+      </template>
+    </p-key-value>
 
-    <p-key-value label="Last Updated" :value="formatDateTimeNumeric(workPoolQueue.updated)" :alternate="alternate" />
+    <p-key-value label="Last Updated" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="workPoolQueue.updated" format="numeric" />
+      </template>
+    </p-key-value>
   </div>
 </template>
 
@@ -36,9 +48,9 @@
   import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
   import { toRefs, computed } from 'vue'
   import { WorkPoolIconText, WorkPoolQueueStatusBadge } from '@/components'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useWorkspaceApi, useWorkQueueStatus } from '@/compositions'
   import { WorkPoolQueue, WorkPoolsFilter } from '@/models'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
     workPoolQueue: WorkPoolQueue,
@@ -63,7 +75,7 @@
   const workPoolsSubscription = useSubscriptionWithDependencies(api.workPools.getWorkPools, workPoolArgs)
   const workPools = computed(() => workPoolsSubscription.response ?? [])
   const workPool = computed(() => workPools.value[0])
-  const workQueueLastPolled = computed(() => workQueueStatus.value?.lastPolled ? formatDateTimeNumeric(workQueueStatus.value.lastPolled) : null)
+  const workQueueLastPolled = computed(() => workQueueStatus.value?.lastPolled ? workQueueStatus.value.lastPolled : null)
 </script>
 
 

--- a/src/components/WorkQueueDetails.vue
+++ b/src/components/WorkQueueDetails.vue
@@ -16,10 +16,18 @@
 
     <p-key-value label="Flow Run Concurrency" :value="workQueue.concurrencyLimit" :alternate="alternate" />
 
-    <p-key-value label="Created" :value="formatDateTimeNumeric(workQueue.created)" :alternate="alternate" />
+    <p-key-value label="Created" :alternate="alternate">
+      <template #value>
+        <FormattedDate :date="workQueue.created" format="numeric" />
+      </template>
+    </p-key-value>
 
     <template v-if="workQueueStatus">
-      <p-key-value label="Last Polled" :value="workQueueStatus.lastPolled ? formatDateTimeNumeric(workQueueStatus.lastPolled) : null" :alternate="alternate" />
+      <p-key-value label="Last Polled" :alternate="alternate">
+        <template v-if="workQueueStatus.lastPolled" #value>
+          <FormattedDate :date="workQueueStatus.lastPolled" format="numeric" />
+        </template>
+      </p-key-value>
     </template>
 
     <template v-if="workQueue.filter">
@@ -49,9 +57,9 @@
   import { computed } from 'vue'
   import { WorkQueueStatusBadge } from '@/components'
   import DeploymentIconText from '@/components/DeploymentIconText.vue'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useWorkQueueStatus } from '@/compositions'
   import { WorkQueue } from '@/models/WorkQueue'
-  import { formatDateTimeNumeric } from '@/utilities/dates'
 
   const props = defineProps<{
     workQueue: WorkQueue,

--- a/src/components/WorkQueueLastPolled.vue
+++ b/src/components/WorkQueueLastPolled.vue
@@ -1,13 +1,11 @@
 <template>
-  <span v-if="lastPolled" class="work-queue-last-polled">
-    {{ formatDateTimeNumeric(lastPolled) }}
-  </span>
+  <FormattedDate v-if="lastPolled" :date="lastPolled" format="numeric" class="work-queue-last-polled" />
 </template>
 
 <script lang="ts" setup>
   import { computed } from 'vue'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useWorkQueueStatus } from '@/compositions'
-  import { formatDateTimeNumeric } from '@/utilities'
 
   const props = defineProps<{
     workQueueId: string,

--- a/src/components/WorkersTable.vue
+++ b/src/components/WorkersTable.vue
@@ -12,7 +12,7 @@
       </template>
 
       <template #last-seen="{ value }">
-        <span>{{ formatDateTimeRelative(value, now) }}</span>
+        <FormattedDate :date="value" format="relative" />
       </template>
 
       <template #status="{ row }">
@@ -59,9 +59,10 @@
   import { useNow, useSubscription } from '@prefecthq/vue-compositions'
   import { computed, ref, toRefs } from 'vue'
   import { ResultsCount, SearchInput, CopyOverflowMenuItem, WorkerStatusBadge, ConfirmDeleteModal } from '@/components'
+  import FormattedDate from '@/components/FormattedDate.vue'
   import { useWorkspaceApi, useShowModal } from '@/compositions'
   import { WorkPoolWorker } from '@/models'
-  import { deleteItem, formatDateTimeRelative } from '@/utilities'
+  import { deleteItem } from '@/utilities'
 
   const props = defineProps<{
     workPoolName: string,


### PR DESCRIPTION
# Description
Progress towards https://github.com/PrefectHQ/prefect/issues/11467

Almost all references of `formatDateTime`, `formatDateTimeNumeric` and `formatDateTimeRelative` to use the `FormattedDate` component which displays the date with some formatting/styling and adds a tooltip to see the full date with timezone information. 

This applies to many pages and pieces of ui including run list items, detail tabs/pages, popovers, etc. 

Before
<img width="853" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/fc316efb-06ec-40b9-bcd8-ef50e80751d9">

After
<img width="864" alt="image" src="https://github.com/PrefectHQ/prefect-ui-library/assets/6200442/1c3ab2d0-8441-4b4c-b32f-821d7fca9131">
