### PR TITLE
Remove old work queues part 1

### DIFF
--- a/src/components/WorkQueueToWorkPoolQueueRedirect.vue
+++ b/src/components/WorkQueueToWorkPoolQueueRedirect.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+  /**
+   * This component is used to redirect the user from an old, deprecated work queue route
+   * to a work pool queue route. This is necessary because the old work queue routes are
+   * were keyed on work queue id and the new routes are nested under work pools by
+   * work pool name and work queue name.
+   */
+  import { useRouteParam, useSubscription } from '@prefecthq/vue-compositions'
+
+  import { useRouter } from 'vue-router'
+  import { useWorkspaceRoutes, useWorkspaceApi } from '@/compositions'
+
+  const workQueueId = useRouteParam('workQueueId')
+
+  const api = useWorkspaceApi()
+  const workQueueSubscription = useSubscription(api.workQueues.getWorkQueue, [workQueueId])
+
+  const router = useRouter()
+  const routes = useWorkspaceRoutes()
+
+  workQueueSubscription.promise().then(({ response: workQueue }) => {
+    if (!workQueue.workPoolName) {
+      router.replace(routes.workPools())
+      return
+    }
+    router.replace(routes.workPoolQueue(workQueue.workPoolName, workQueue.name))
+  })
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -158,7 +158,7 @@ export function createWorkspaceRouteRecords(components: Partial<WorkspaceRouteCo
         {
           name: 'workspace.work-queues.work-queue',
           path: 'work-queue/:workQueueId',
-          component: components.workQueue,
+          component: components.workQueue ?? import('@/components/WorkQueueToWorkPoolQueueRedirect.vue'),
         },
         {
           name: 'workspace.work-queues.work-queue-edit',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -143,30 +143,9 @@ export function createWorkspaceRouteRecords(components: Partial<WorkspaceRouteCo
       },
       children: [
         {
-          name: 'workspace.work-queues',
-          path: '',
-          component: components.workQueues,
-        },
-        {
-          name: 'workspace.work-queues.work-queue-create',
-          path: 'create',
-          component: components.workQueueCreate,
-          meta: {
-            can: 'create:work_queue',
-          },
-        },
-        {
           name: 'workspace.work-queues.work-queue',
           path: 'work-queue/:workQueueId',
           component: components.workQueue ?? import('@/components/WorkQueueToWorkPoolQueueRedirect.vue'),
-        },
-        {
-          name: 'workspace.work-queues.work-queue-edit',
-          path: 'work-queue/:workQueueId/edit',
-          component: components.workQueueEdit,
-          meta: {
-            can: 'update:work_queue',
-          },
         },
       ],
     },


### PR DESCRIPTION
Part 1 of work queue removal. 

Following this I will:
1. cut a new version and bump in downstream apps. Removed route definitions so that the routes will 404 (those that shouldn't have any remaining references in app code). The 1 workQueue(id) route will remain since it's still used in 2 small places - this PR "shims" it by stubbing in a page component that fetches the work queue to redirect to the work pool's corresponding work queue page. Everything should still work - no breaking changes yet.
2. upgrade in downstream apps. Can then start removing all work queue related files (pages, components, & route definitions) from downstream app repositories
3. come back to ui-library and cull out the rest -- at this point there will be breaking changes but the downstream repo's will have been already updated to handle them.
4. cut a new version and upgrade in downstream repos