### PR TITLE
Chore: consistent status label conversions

### DIFF
--- a/src/automations/components/AutomationTriggerDescriptionDeploymentStatus.vue
+++ b/src/automations/components/AutomationTriggerDescriptionDeploymentStatus.vue
@@ -24,7 +24,7 @@
       </template>
     </template>
 
-    {{ getAutomationTriggerEventPostureLabel(trigger.posture) }} {{ getDeploymentStatusLabel(trigger.status) }}
+    {{ getAutomationTriggerEventPostureLabel(trigger.posture) }} {{ getDeploymentStatusLabel(trigger.status).toLowerCase() }}
 
     <template v-if="trigger.posture === 'Proactive'">
       for {{ secondsToString(trigger.time) }}

--- a/src/automations/components/AutomationTriggerDescriptionWorkPoolStatus.vue
+++ b/src/automations/components/AutomationTriggerDescriptionWorkPoolStatus.vue
@@ -20,7 +20,7 @@
 
     {{ getAutomationTriggerEventPostureLabel(trigger.posture) }}
 
-    {{ getWorkPoolStatusLabel(trigger.status) }}
+    {{ getWorkPoolStatusLabel(trigger.status).toLowerCase() }}
 
     <template v-if="trigger.posture === 'Proactive'">
       for {{ secondsToString(trigger.time) }}
@@ -37,7 +37,6 @@
   import { useWorkPools } from '@/compositions'
   import { getWorkPoolStatusLabel } from '@/models/WorkPoolStatus'
   import { secondsToString } from '@/utilities/seconds'
-
 
   const props = defineProps<{
     trigger: WorkPoolStatusTrigger,

--- a/src/automations/components/AutomationTriggerDescriptionWorkQueueStatus.vue
+++ b/src/automations/components/AutomationTriggerDescriptionWorkQueueStatus.vue
@@ -32,7 +32,7 @@
 
     {{ getAutomationTriggerEventPostureLabel(trigger.posture) }}
 
-    {{ getWorkPoolQueueStatusLabel(trigger.status) }}
+    {{ getWorkPoolQueueStatusLabel(trigger.status).toLowerCase() }}
 
     <template v-if="trigger.posture === 'Proactive'">
       for {{ secondsToString(trigger.time) }}

--- a/src/automations/maps/workQueueStatusTrigger.ts
+++ b/src/automations/maps/workQueueStatusTrigger.ts
@@ -1,7 +1,7 @@
 import { toResourceId, toMatchRelatedId, fromResourceId } from '@/automations/maps/utilities'
 import { AutomationTriggerEvent } from '@/automations/types'
 import { WorkQueueStatusEvent, WorkQueueStatusTrigger, isWorkQueueStatusEvent } from '@/automations/types/workQueueStatusTrigger'
-import { WorkPoolQueueStatus } from '@/models'
+import { WorkPoolQueueStatus, workPoolQueueStatus } from '@/models'
 import { MapFunction } from '@/services'
 
 export const mapWorkQueueStatusTriggerToAutomationTrigger: MapFunction<WorkQueueStatusTrigger, AutomationTriggerEvent> = function(source) {
@@ -43,7 +43,7 @@ function mapProactiveWorkQueueStatusTriggerToAutomationTrigger(source: WorkQueue
 }
 
 function anyStatusExcept(status: WorkPoolQueueStatus): WorkPoolQueueStatus[] {
-  return (['ready', 'not_ready', 'paused'] as const).filter(_status => _status !== status)
+  return workPoolQueueStatus.filter(_status => _status !== status)
 }
 
 export const mapAutomationTriggerToWorkQueueStatusTrigger: MapFunction<AutomationTriggerEvent, WorkQueueStatusTrigger> = function(source) {

--- a/src/components/DeploymentStatusBadge.vue
+++ b/src/components/DeploymentStatusBadge.vue
@@ -1,7 +1,7 @@
 <template>
   <p-tag v-if="deployment.status" :class="classes.root" class="deployment-status-badge">
     <DeploymentStatusIcon :status="deployment.status" />
-    {{ titleCase(deployment.status) }}
+    {{ getDeploymentStatusLabel(deployment.status) }}
   </p-tag>
 </template>
 
@@ -9,7 +9,7 @@
   import { computed } from 'vue'
   import DeploymentStatusIcon from '@/components/DeploymentStatusIcon.vue'
   import { Deployment } from '@/models'
-  import { titleCase } from '@/utilities'
+  import { getDeploymentStatusLabel } from '@/models/DeploymentStatus'
 
   const props = defineProps<{
     deployment: Deployment,

--- a/src/components/DeploymentStatusSelect.vue
+++ b/src/components/DeploymentStatusSelect.vue
@@ -4,7 +4,7 @@
 
 <script lang="ts" setup>
   import { SelectOption } from '@prefecthq/prefect-design'
-  import { capitalize, computed } from 'vue'
+  import { computed } from 'vue'
   import { DeploymentStatus, deploymentStatus, getDeploymentStatusLabel } from '@/models/DeploymentStatus'
 
   type StatusOption = SelectOption & {
@@ -20,7 +20,7 @@
   }>()
 
   const options: StatusOption[] = deploymentStatus.map(status => ({
-    label: capitalize(getDeploymentStatusLabel(status)),
+    label: getDeploymentStatusLabel(status),
     value: status,
   }))
 

--- a/src/components/WorkPoolQueueStatusBadge.vue
+++ b/src/components/WorkPoolQueueStatusBadge.vue
@@ -2,23 +2,18 @@
   <template v-if="workQueue">
     <p-tag class="work-pool-queue-status-badge">
       <WorkPoolQueueStatusIcon :work-pool-queue="workQueue" />
-      {{ label }}
+      {{ getWorkPoolQueueStatusLabel(workQueue.status) }}
     </p-tag>
   </template>
 </template>
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
   import WorkPoolQueueStatusIcon from '@/components/WorkPoolQueueStatusIcon.vue'
-  import { WorkPoolQueue } from '@/models'
+  import { WorkPoolQueue, getWorkPoolQueueStatusLabel } from '@/models'
 
-  const props = defineProps<{
+  defineProps<{
     workQueue: WorkPoolQueue,
   }>()
-
-  const label = computed(() => (
-    { 'ready': 'Ready', 'not_ready': 'Not Ready', 'paused': 'Paused' }[props.workQueue.status]
-  ))
 </script>
 
 <style>

--- a/src/components/WorkPoolStatusBadge.vue
+++ b/src/components/WorkPoolStatusBadge.vue
@@ -2,15 +2,14 @@
   <template v-if="workPool.status">
     <p-tag>
       <WorkPoolStatusIcon :work-pool="workPool" />
-      {{ titleCase(workPool.status) }}
+      {{ getWorkPoolStatusLabel(workPool.status) }}
     </p-tag>
   </template>
 </template>
 
 <script lang="ts" setup>
   import WorkPoolStatusIcon from '@/components/WorkPoolStatusIcon.vue'
-  import { WorkPool } from '@/models'
-  import { titleCase } from '@/utilities'
+  import { WorkPool, getWorkPoolStatusLabel } from '@/models'
 
   defineProps<{
     workPool: WorkPool,

--- a/src/components/WorkPoolStatusSelect.vue
+++ b/src/components/WorkPoolStatusSelect.vue
@@ -5,7 +5,7 @@
 <script lang="ts" setup>
   import { SelectOption } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
-  import { WorkPoolStatus } from '@/models/WorkPoolStatus'
+  import { WorkPoolStatus, getWorkPoolStatusLabel, workPoolStatus } from '@/models/WorkPoolStatus'
 
   type StatusOption = SelectOption & {
     value: WorkPoolStatus,
@@ -19,11 +19,10 @@
     (event: 'update:selected', value: WorkPoolStatus | null): void,
   }>()
 
-  const options: StatusOption[] = [
-    { label: 'Ready', value: 'ready' },
-    { label: 'Not Ready', value: 'not_ready' },
-    { label: 'Paused', value: 'paused' },
-  ]
+  const options: StatusOption[] = workPoolStatus.map(status => ({
+    label: getWorkPoolStatusLabel(status),
+    value: status,
+  }))
 
   const internalSelected = computed({
     get() {

--- a/src/components/WorkQueueStatusSelect.vue
+++ b/src/components/WorkQueueStatusSelect.vue
@@ -5,7 +5,7 @@
 <script lang="ts" setup>
   import { SelectOption } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
-  import { WorkPoolQueueStatus } from '@/models/WorkPoolQueue'
+  import { WorkPoolQueueStatus, getWorkPoolQueueStatusLabel, workPoolQueueStatus } from '@/models/WorkPoolQueue'
 
   const props = defineProps<{
     selected: WorkPoolQueueStatus,
@@ -18,11 +18,10 @@
   type WorkQueueStatusOption = SelectOption & {
     value: WorkPoolQueueStatus,
   }
-  const options: WorkQueueStatusOption[] = [
-    { label: 'Ready', value: 'ready' },
-    { label: 'Paused', value: 'paused' },
-    { label: 'Not Ready', value: 'not_ready' },
-  ]
+  const options: WorkQueueStatusOption[] = workPoolQueueStatus.map(status => ({
+    label: getWorkPoolQueueStatusLabel(status),
+    value: status,
+  }))
 
   const internalSelected = computed({
     get() {

--- a/src/models/DeploymentStatus.ts
+++ b/src/models/DeploymentStatus.ts
@@ -8,9 +8,9 @@ export type ServerDeploymentStatus = Uppercase<typeof deploymentStatus[number]>
 export function getDeploymentStatusLabel(status: DeploymentStatus): string {
   switch (status) {
     case 'not_ready':
-      return 'not ready'
+      return 'Not Ready'
     case 'ready':
-      return 'ready'
+      return 'Ready'
     default:
       const exhaustive: never = status
       throw new Error(`getDeploymentStatusLabel missing case for status: ${exhaustive}`)

--- a/src/models/WorkPoolQueue.ts
+++ b/src/models/WorkPoolQueue.ts
@@ -1,16 +1,19 @@
-export type WorkPoolQueueStatus = 'ready' | 'paused' | 'not_ready'
+import { createTuple } from '@/utilities'
+
+export const { values: workPoolQueueStatus, isValue: isWorkPoolQueueStatus } = createTuple(['ready', 'paused', 'not_ready'])
+export type WorkPoolQueueStatus = typeof workPoolQueueStatus[number]
 
 export function getWorkPoolQueueStatusLabel(status: WorkPoolQueueStatus): string {
   switch (status) {
     case 'not_ready':
-      return 'not ready'
+      return 'Not Ready'
     case 'paused':
-      return 'paused'
+      return 'Paused'
     case 'ready':
-      return 'ready'
+      return 'Ready'
     default:
       const exhaustive: never = status
-      throw new Error(`getWorkPoolStatusLabe missing case for ${exhaustive}`)
+      throw new Error(`getWorkPoolStatusLabel missing case for ${exhaustive}`)
   }
 }
 

--- a/src/models/WorkPoolStatus.ts
+++ b/src/models/WorkPoolStatus.ts
@@ -9,13 +9,13 @@ export type ServerWorkPoolStatus = typeof serverWorkPoolStatus[number]
 export function getWorkPoolStatusLabel(status: WorkPoolStatus): string {
   switch (status) {
     case 'not_ready':
-      return 'not ready'
+      return 'Not Ready'
     case 'paused':
-      return 'paused'
+      return 'Paused'
     case 'ready':
-      return 'ready'
+      return 'Ready'
     default:
       const exhaustive: never = status
-      throw new Error(`getWorkPoolStatusLabe missing case for ${exhaustive}`)
+      throw new Error(`getWorkPoolStatusLabel missing case for ${exhaustive}`)
   }
 }


### PR DESCRIPTION
Noticed these separate get<blank>StatusLabel functions when going through work queue stuff - this PR consolidates the deployment, work pool, and work pool queue status mappings to use those functions. 