### PR TITLE
Reduce internal marketing banner padding

### DIFF
--- a/src/components/MarketingBanner.vue
+++ b/src/components/MarketingBanner.vue
@@ -40,6 +40,7 @@
 
 <style>
 .marketing-banner { @apply
+  p-4
   relative
   overflow-hidden
   bg-[url('/marketing-banner-bg-light.svg')]

--- a/src/components/MarketingBanner.vue
+++ b/src/components/MarketingBanner.vue
@@ -56,9 +56,6 @@
   items-start
   gap-3
   z-[2]
-  p-4
-  sm:px-8
-  sm:py-10
   sm:justify-between
   sm:items-center
   sm:flex-row


### PR DESCRIPTION
This PR decreases internal padding on the marketing banner component. #2517 tweaked this component to use `<p-card />` which comes with some padding of its own. Here are some screenshots to pin to:

| **Before** | **After** |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/aacd75b5-dc0a-4e4b-b68d-f4192228cf61) | ![image](https://github.com/user-attachments/assets/7b7c2eb0-2d7a-4cf9-973d-ec6f2bfd4e22) |
| ![image](https://github.com/user-attachments/assets/6363b2be-1afa-44da-b1f0-748111b2de78) | ![image](https://github.com/user-attachments/assets/d0880f4d-1474-43fc-8dde-1c5cbd4e2016) |
| ![image](https://github.com/user-attachments/assets/58acb536-6a00-40b0-9f92-83ea35f06fe6) | ![image](https://github.com/user-attachments/assets/d4df6b7b-32d3-4143-86e1-534d09b185f6) |
| ![image](https://github.com/user-attachments/assets/01eb9c65-d3d6-4c06-8258-6d4574ef843d) | ![image](https://github.com/user-attachments/assets/8d2c5be9-6111-4fe4-bb86-8451c66fc238) |
| ![image](https://github.com/user-attachments/assets/34435580-50a5-4be4-9f37-ecc883410781) | ![image](https://github.com/user-attachments/assets/6582f0fa-7716-42e9-aa11-d4810568cb60) |





