### PR TITLE
Fix variables sometimes displaying old or incorrect values when using the "click to view" preview

### DIFF
--- a/src/components/VariablesTable.vue
+++ b/src/components/VariablesTable.vue
@@ -28,6 +28,7 @@
       :data="variables"
       :columns="columns"
       :column-classes="columnClass"
+      :row-key="(variable: Variable) => variable.id"
       @update:selected="selectedVariables = $event"
     >
       <template #name="{ row }">


### PR DESCRIPTION
# Description
Closes https://github.com/PrefectHQ/prefect-ui-library/issues/2623

Adds a `rowKey` to the table to make sure row components are not reused across variables and fixes some reactivity issues with the value preview. 