### PR TITLE
Update work pools to support object level permissions

### DIFF
--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -17,7 +17,7 @@
         <div class="deployment-details__schedule-label">
           <span>Schedules</span>
           <!-- We need to display this toggle if the deployment is paused so a user can enabled it -->
-          <DeploymentToggle v-if="can.update.deployment && (deployment.schedules.length > 3 || deployment.paused)" :deployment="deployment" @update="emit('update')" />
+          <DeploymentToggle v-if="deployment.can.update && (deployment.schedules.length > 3 || deployment.paused)" :deployment="deployment" @update="emit('update')" />
         </div>
       </template>
       <template #value>

--- a/src/components/WorkPoolIconText.vue
+++ b/src/components/WorkPoolIconText.vue
@@ -1,5 +1,5 @@
 <template>
-  <template v-if="can.read.work_pool">
+  <template v-if="workPool?.can.read">
     <p-link :to="routes.workPool(workPoolName)" class="work-pool-icon-text">
       <p-icon-text icon="PWorkPool">
         <span>{{ workPoolName }}</span>
@@ -9,14 +9,12 @@
 </template>
 
 <script lang="ts" setup>
-  import { toRefs } from 'vue'
-  import { useCan, useWorkspaceRoutes } from '@/compositions'
+  import { useWorkPool, useWorkspaceRoutes } from '@/compositions'
 
   const props = defineProps<{
     workPoolName: string,
   }>()
 
-  const can = useCan()
   const routes = useWorkspaceRoutes()
-  const { workPoolName } = toRefs(props)
+  const { workPool } = useWorkPool(() => props.workPoolName)
 </script>

--- a/src/components/WorkPoolMenu.vue
+++ b/src/components/WorkPoolMenu.vue
@@ -2,9 +2,9 @@
   <p-icon-button-menu v-bind="$attrs" class="work-pool-menu">
     <CopyOverflowMenuItem label="Copy ID" :item="workPool.id" />
     <router-link :to="routes.workPoolEdit(workPool.name)">
-      <p-overflow-menu-item v-if="can.update.work_pool" label="Edit" />
+      <p-overflow-menu-item v-if="workPool.can.update" label="Edit" />
     </router-link>
-    <p-overflow-menu-item v-if="can.delete.work_pool" label="Delete" @click="open" />
+    <p-overflow-menu-item v-if="workPool.can.delete" label="Delete" @click="open" />
 
     <router-link :to="routes.automateWorkPool(workPool.id)">
       <p-overflow-menu-item label="Automate" />

--- a/src/components/WorkPoolToggle.vue
+++ b/src/components/WorkPoolToggle.vue
@@ -1,6 +1,6 @@
 <template>
   <p-tooltip text="Pause or resume this work pool">
-    <p-toggle v-if="can.update.work_pool" v-model="internalValue" />
+    <p-toggle v-if="workPool.can.update" v-model="internalValue" />
   </p-tooltip>
 </template>
 

--- a/src/maps/workPool.ts
+++ b/src/maps/workPool.ts
@@ -1,6 +1,6 @@
 import { AutomationTriggerEvent } from '@/automations/types/automationTriggerEvent'
 import { AutomationTrigger } from '@/automations/types/triggers'
-import { WorkPool, WorkPoolCreateRequest, WorkPoolEdit, WorkPoolEditRequest, WorkPoolResponse, WorkPoolCreate } from '@/models'
+import { WorkPool, WorkPoolCreateRequest, WorkPoolEdit, WorkPoolEditRequest, WorkPoolResponse, WorkPoolCreate, createObjectLevelCan } from '@/models'
 import { MapFunction } from '@/services/Mapper'
 
 export const mapWorkPoolResponseToWorkPool: MapFunction<WorkPoolResponse, WorkPool> = function(source) {
@@ -17,6 +17,7 @@ export const mapWorkPoolResponseToWorkPool: MapFunction<WorkPoolResponse, WorkPo
     concurrencyLimit: source.concurrency_limit,
     defaultQueueId: source.default_queue_id,
     baseJobTemplate: source.base_job_template,
+    can: createObjectLevelCan(),
     status: this.map('ServerWorkPoolStatus', source.status, 'WorkPoolStatus'),
   })
 }

--- a/src/mocks/workPool.ts
+++ b/src/mocks/workPool.ts
@@ -1,4 +1,4 @@
-import { WorkPool } from '@/models'
+import { createObjectLevelCan, WorkPool } from '@/models'
 import { MockFunction } from '@/services'
 
 export const randomWorkPool: MockFunction<WorkPool, [Partial<WorkPool>?]> =
@@ -21,6 +21,7 @@ export const randomWorkPool: MockFunction<WorkPool, [Partial<WorkPool>?]> =
       defaultQueueId: this.create('id'),
       baseJobTemplate: this.create('parameters', [{}, this.create('schema')]),
       status: this.create('workPoolStatus'),
+      can: createObjectLevelCan(),
       ...overrides,
     })
   }

--- a/src/models/ObjectLevelCan.ts
+++ b/src/models/ObjectLevelCan.ts
@@ -14,6 +14,7 @@ export type ObjectLevelCan<TObjectType extends ObjectTypesWithPermissions> = {
 
 export function createObjectLevelCan<T extends ObjectTypesWithPermissions>(): ObjectLevelCan<T> {
   const knownProperties = permissionVerbs
+
   return new Proxy({} as ObjectLevelCan<T>, {
     get(_target, property) {
       // only proxy known properties so that vue doesn't think it's a ref in templates

--- a/src/models/WorkPool.ts
+++ b/src/models/WorkPool.ts
@@ -1,5 +1,6 @@
 import { SelectOptionNormalized } from '@prefecthq/prefect-design'
 import { BaseJobTemplateRequest } from '@/models/api/WorkPoolRequest'
+import { ObjectLevelCan } from '@/models/ObjectLevelCan'
 import { WorkPoolStatus } from '@/models/WorkPoolStatus'
 import { titleCase } from '@/utilities'
 
@@ -17,6 +18,7 @@ export interface IWorkPool {
   concurrencyLimit: number | null,
   baseJobTemplate: BaseJobTemplateRequest,
   status: WorkPoolStatus | null,
+  can: ObjectLevelCan<'work_pool'>,
 }
 
 export class WorkPool implements IWorkPool {
@@ -33,6 +35,7 @@ export class WorkPool implements IWorkPool {
   public concurrencyLimit: number | null
   public baseJobTemplate: BaseJobTemplateRequest
   public status: WorkPoolStatus | null
+  public can: ObjectLevelCan<'work_pool'>
 
   public constructor(workPool: IWorkPool) {
     this.id = workPool.id
@@ -48,6 +51,7 @@ export class WorkPool implements IWorkPool {
     this.concurrencyLimit = workPool.concurrencyLimit
     this.baseJobTemplate = workPool.baseJobTemplate
     this.status = workPool.status
+    this.can = workPool.can
   }
 
   public get typeLabel(): string {


### PR DESCRIPTION
# Description
Adds object level permissions to work pools. In oss these always return `true` but these will be overridden in cloud to adhere to work pool acls

part of ENTRP-27