### PR TITLE
Enhancement: Update favicon compositions

### DIFF
--- a/src/compositions/useFlowRunFavicon.ts
+++ b/src/compositions/useFlowRunFavicon.ts
@@ -1,20 +1,12 @@
 import { MaybeRefOrGetter, computed, toValue } from 'vue'
 import { useFavicon } from '@/compositions/useFavicon'
-import { useFlowRun } from '@/compositions/useFlowRun'
-import { backgroundSubscriptionManager } from '@/utilities/subscriptions'
+import { FlowRun } from '@/models'
 
-export function useFlowRunFavicon(flowRunId: MaybeRefOrGetter<string>): void {
-  const interval = 5000
-  const { flowRun, subscription } = useFlowRun(flowRunId, { interval })
-  const { flowRun: backgroundFlowRun } = useFlowRun(() => {
-    if (subscription.paused) {
-      return toValue(flowRunId)
-    }
-
-    return null
-  }, { interval, manager: backgroundSubscriptionManager })
-
-  const state = computed(() => backgroundFlowRun.value?.stateType ?? flowRun.value?.stateType)
+export function useFlowRunFavicon(flowRun: MaybeRefOrGetter<FlowRun | undefined>): void {
+  const state = computed(() => {
+    const flowRunValue = toValue(flowRun)
+    return flowRunValue?.stateType
+  })
 
   useFavicon(state)
 }

--- a/src/compositions/useTaskRunFavicon.ts
+++ b/src/compositions/useTaskRunFavicon.ts
@@ -1,20 +1,12 @@
 import { MaybeRefOrGetter, computed, toValue } from 'vue'
 import { useFavicon } from '@/compositions/useFavicon'
-import { useTaskRun } from '@/compositions/useTaskRun'
-import { backgroundSubscriptionManager } from '@/utilities/subscriptions'
+import { TaskRun } from '@/models'
 
-export function useTaskRunFavicon(taskRunId: MaybeRefOrGetter<string>): void {
-  const interval = 5000
-  const { taskRun, subscription } = useTaskRun(taskRunId, { interval })
-  const { taskRun: backgroundTaskRun } = useTaskRun(() => {
-    if (subscription.paused) {
-      return toValue(taskRunId)
-    }
-
-    return null
-  }, { interval, manager: backgroundSubscriptionManager })
-
-  const state = computed(() => backgroundTaskRun.value?.stateType ?? taskRun.value?.stateType)
+export function useTaskRunFavicon(taskRun: MaybeRefOrGetter<TaskRun | undefined>): void {
+  const state = computed(() => {
+    const taskRunValue = toValue(taskRun)
+    return taskRunValue?.stateType
+  })
 
   useFavicon(state)
 }


### PR DESCRIPTION
These compositions were polling aggressively and needlessly - I've updated them to take the entire flow run or task run object and to instead rely on the caller for data freshness.