### PR TITLE
Hide active slots on v2 limit create form

### DIFF
--- a/src/components/ConcurrencyLimitsV2CreateModal.vue
+++ b/src/components/ConcurrencyLimitsV2CreateModal.vue
@@ -14,10 +14,6 @@
           <p-number-input v-model="decay" :min="0" />
         </p-label>
 
-        <p-label label="Active Slots">
-          <p-number-input v-model="activeSlots" :min="0" />
-        </p-label>
-
         <p-label label="Active">
           <p-toggle v-model="active" />
         </p-label>
@@ -64,8 +60,6 @@
 
   const decay = ref(0)
 
-  const activeSlots = ref(0)
-
   const internalShowModal = computed({
     get() {
       return props.showModal
@@ -83,7 +77,6 @@
     limit.value = 0
     decay.value = 0
     active.value = true
-    activeSlots.value = 0
   }
 
   const { valid, pending, validate } = useValidationObserver()
@@ -96,7 +89,6 @@
           limit: limit.value,
           slotDecayPerSecond: decay.value,
           active: active.value,
-          activeSlots: activeSlots.value,
         }
         await api.concurrencyV2Limits.createConcurrencyV2Limit(concurrencyLimit)
         concurrencyLimitSubscription.refresh()

--- a/src/maps/concurrencyV2LimitCreate.ts
+++ b/src/maps/concurrencyV2LimitCreate.ts
@@ -13,7 +13,6 @@ export const mapConcurrencyV2CreateToConcurrencyV2CreateRequest: MapFunction<Con
     active,
     name,
     limit,
-    active_slots: source.activeSlots,
     denied_slots: source.deniedSlots,
     slot_decay_per_second: source.slotDecayPerSecond,
   }

--- a/src/models/ConcurrencyV2Create.ts
+++ b/src/models/ConcurrencyV2Create.ts
@@ -2,7 +2,6 @@ export type ConcurrencyV2Create = {
   active?: boolean,
   name?: string,
   limit?: number,
-  activeSlots?: number,
   deniedSlots?: number,
   slotDecayPerSecond?: number,
 }


### PR DESCRIPTION
Showing the "active slots" field, which we use internally to track holders of an active limit, is confusing on the Create Concurrency Limit form. It will seldom be used on that form, and it conflicts (semantically) with both the "active" flag and the "concurrency limit" field, making users unsure how to proceed.

The API endpoint to create limits defaults to 0 for this property, so we can skip it from the POST.

See: https://github.com/PrefectHQ/prefect/issues/13361

I also get confused by this every time I use the form. 😂 