### PR TITLE
Continue polling /graph-v2 after terminal state to account for eventual consistency

### DIFF
--- a/src/components/FlowRunGraph.vue
+++ b/src/components/FlowRunGraph.vue
@@ -130,7 +130,7 @@
   }))
 
   const taskRunCountOptions = computed(() => ({
-    interval: isTerminalStateType(props.flowRun.state?.type) ? undefined : 1000,
+    interval: isTerminalStateType(props.flowRun.state?.type) ? 10000 : 1000,
   }))
 
   const { count, subscription } = useTaskRunsCount(() => ({


### PR DESCRIPTION
This PR updates our graph endpoint polling strategy to support an eventually consistent model for flow runs. It ensures that we continue to poll for updates even after a flow run has reached a terminal state.
Changes

## Implement continuous polling for the graph endpoint, regardless of flow run state
- Poll every 1 second for active flow runs
- Poll every 10 seconds for flow runs in a terminal state (previously: no polling)

## Motivation
We are moving to an eventually consistent model where logs and other data may continue to be ingested even after a flow run has completed. This change ensures that our UI can capture and display these late-arriving updates, providing a more complete and accurate view of flow run data.

## Implementation Details
- Modified the polling logic to continue after a flow run reaches a terminal state
- For active flow runs, maintained the current 1-second polling interval
- For flow runs in a terminal state, implemented a 10-second polling interval
- Removed the previous logic that stopped polling upon reaching a terminal state