### PR TITLE
Enhancement: Allow resizing deployment name column

### DIFF
--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -172,6 +172,9 @@
   const columns = computed<TableColumn<Deployment>[]>(() => [
     {
       label: 'Deployment',
+      minWidth: '200px',
+      width: '200px',
+      maxWidth: '1000px',
     },
     {
       label: 'Status',
@@ -181,19 +184,21 @@
     {
       label: 'Activity',
       visible: media.lg,
-      maxWidth: '15%',
+      width: '200px',
     },
     {
       label: 'Tags',
       property: 'tags',
       visible: media.md,
       maxWidth: '15%',
+      width: '200px',
     },
     {
       label: 'Schedules',
       property: 'schedules',
-      visible: media.md,
+      visible: media.lg,
       maxWidth: '15%',
+      width: '200px',
     },
     {
       label: 'Action',
@@ -293,6 +298,10 @@
   flex
   justify-end
   items-center
+}
+
+.p-table-header.deployment-list__deployment-column { @apply
+  resize-x
 }
 
 .deployment-list__row--subdued .deployment-list__deployment-column,

--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -117,7 +117,7 @@
   import { secondsInWeek } from 'date-fns/constants'
   import { snakeCase } from 'lodash'
   import merge from 'lodash.merge'
-  import { computed, ref } from 'vue'
+  import { computed, ref, watch } from 'vue'
   import {
     DeploymentsDeleteButton,
     ResultsCount,
@@ -164,6 +164,9 @@
     page,
   }), props.prefix)
 
+  watch(limit, () => {
+    page.value = 1
+  })
 
   const { deployments, subscription, count, pages } = useDeployments(filter, {
     interval: 30000,
@@ -228,7 +231,7 @@
 
 <style>
 .deployment-list__table { @apply
-  overflow-visible
+  overflow-auto
 }
 
 .deployment-list__table .p-table__table { @apply


### PR DESCRIPTION
This PR updates some column sizing on the deployment table and allows resizing the name column. This isn't a perfect solution but is probably the least-involved way we can handle this atm. 


https://github.com/user-attachments/assets/1c72368d-83ee-459d-94e7-ff145d182188

