### PR TITLE
Update some work queue related stuff to be compatible with cloud acls

### DIFF
--- a/src/maps/workPoolQueue.ts
+++ b/src/maps/workPoolQueue.ts
@@ -1,6 +1,6 @@
 import { AutomationTriggerEvent } from '@/automations/types/automationTriggerEvent'
 import { AutomationTrigger } from '@/automations/types/triggers'
-import { WorkPoolQueue, WorkPoolQueueCreate, WorkPoolQueueCreateRequest, WorkPoolQueueEdit, WorkPoolQueueEditRequest, WorkPoolQueueResponse, WorkPoolQueueResponseStatus, WorkPoolQueueStatus } from '@/models'
+import { createObjectLevelCan, WorkPoolQueue, WorkPoolQueueCreate, WorkPoolQueueCreateRequest, WorkPoolQueueEdit, WorkPoolQueueEditRequest, WorkPoolQueueResponse, WorkPoolQueueResponseStatus, WorkPoolQueueStatus } from '@/models'
 import { MapFunction } from '@/services/Mapper'
 
 export const mapWorkPoolQueueResponseToWorkPoolQueue: MapFunction<WorkPoolQueueResponse, WorkPoolQueue> = function(source) {
@@ -17,6 +17,7 @@ export const mapWorkPoolQueueResponseToWorkPoolQueue: MapFunction<WorkPoolQueueR
     priority: source.priority,
     lastPolled: this.map('string', source.last_polled, 'Date'),
     status: (source.status?.toLowerCase() ?? 'not_ready') as Lowercase<WorkPoolQueueResponseStatus>,
+    can: createObjectLevelCan(),
   })
 }
 

--- a/src/mocks/workPoolQueue.ts
+++ b/src/mocks/workPoolQueue.ts
@@ -1,4 +1,4 @@
-import { WorkPoolQueue } from '@/models'
+import { createObjectLevelCan, WorkPoolQueue } from '@/models'
 import { MockFunction } from '@/services'
 
 export const randomWorkPoolQueue: MockFunction<WorkPoolQueue, [Partial<WorkPoolQueue>?]> = function(overrides = {}) {
@@ -15,6 +15,7 @@ export const randomWorkPoolQueue: MockFunction<WorkPoolQueue, [Partial<WorkPoolQ
     priority: this.create('number'),
     lastPolled: null,
     status: 'ready',
+    can: createObjectLevelCan(),
     ...overrides,
   })
 }

--- a/src/models/WorkPoolQueue.ts
+++ b/src/models/WorkPoolQueue.ts
@@ -1,3 +1,4 @@
+import { ObjectLevelCan } from '@/models/ObjectLevelCan'
 import { createTuple } from '@/utilities'
 
 export const { values: workPoolQueueStatus, isValue: isWorkPoolQueueStatus } = createTuple(['ready', 'paused', 'not_ready'])
@@ -30,6 +31,7 @@ export interface IWorkPoolQueue {
   priority: number,
   lastPolled: Date | null,
   status: WorkPoolQueueStatus,
+  can: ObjectLevelCan<'work_pool_queue'>,
 }
 
 export class WorkPoolQueue implements IWorkPoolQueue {
@@ -46,6 +48,7 @@ export class WorkPoolQueue implements IWorkPoolQueue {
   public priority: number
   public lastPolled: Date | null
   public status: WorkPoolQueueStatus
+  public can: ObjectLevelCan<'work_pool_queue'>
 
   public constructor(workPoolQueue: IWorkPoolQueue) {
     this.id = workPoolQueue.id
@@ -60,5 +63,6 @@ export class WorkPoolQueue implements IWorkPoolQueue {
     this.priority = workPoolQueue.priority
     this.lastPolled = workPoolQueue.lastPolled
     this.status = workPoolQueue.status
+    this.can = workPoolQueue.can
   }
 }

--- a/src/services/WorkspaceWorkQueuesApi.ts
+++ b/src/services/WorkspaceWorkQueuesApi.ts
@@ -23,7 +23,7 @@ export class WorkspaceWorkQueuesApi extends WorkspaceApi {
 
   protected override routePrefix = '/work_queues'
 
-  private readonly isBatcher = new BatchProcessor<string, WorkPoolQueue>(async ids => {
+  protected readonly idBatcher = new BatchProcessor<string, WorkPoolQueue>(async ids => {
     if (ids.length === 1) {
       const [id] = ids
       const { data } = await this.get<WorkPoolQueueResponse>(`/${id}`)
@@ -40,7 +40,7 @@ export class WorkspaceWorkQueuesApi extends WorkspaceApi {
     return toMap(workQueues, 'id')
   }, { maxBatchSize: 200 })
 
-  private readonly nameBatcher = new BatchProcessor<string, WorkPoolQueue>(async names => {
+  protected readonly nameBatcher = new BatchProcessor<string, WorkPoolQueue>(async names => {
     if (names.length === 1) {
       const [name] = names
       const { data } = await this.get<WorkPoolQueueResponse>(`/name/${name}`)
@@ -58,7 +58,7 @@ export class WorkspaceWorkQueuesApi extends WorkspaceApi {
   }, { maxBatchSize: 200 })
 
   public getWorkQueue(workQueueId: string): Promise<WorkPoolQueue> {
-    return this.isBatcher.batch(workQueueId)
+    return this.idBatcher.batch(workQueueId)
   }
 
   public getWorkQueueByName(workQueueName: string): Promise<WorkPoolQueue> {


### PR DESCRIPTION
# Description
Work queue's don't have ACLs of their own, but they need to respect the ACL of the work pool they belong to. So I'm adding an object level `can` to the `WorkPoolQueue` which cloud can use for this. 