### PR TITLE
Fix: Make deployment toggles visible but disabled for deployments when a user does not have update deployment permissions

### DIFF
--- a/src/components/DeploymentDisableToggle.vue
+++ b/src/components/DeploymentDisableToggle.vue
@@ -1,6 +1,6 @@
 <template>
   <p-tooltip :text="tooltipText" side="left">
-    <p-toggle v-if="deployment.can.update" v-model="internalValue" :state :disabled="deployment.deprecated" />
+    <p-toggle v-model="internalValue" :state :disabled="deployment.deprecated || !deployment.can.update" />
   </p-tooltip>
 </template>
 
@@ -36,6 +36,9 @@
   })
 
   const tooltipText = computed(() => {
+    if (!props.deployment.can.update) {
+      return localization.info.deploymentUpdateDisabled
+    }
     return props.deployment.disabled ? localization.info.deploymentDisabled : localization.info.deploymentEnabled
   })
 

--- a/src/components/DeploymentScheduleToggle.vue
+++ b/src/components/DeploymentScheduleToggle.vue
@@ -1,6 +1,6 @@
 <template>
-  <p-tooltip text="Pause or resume this schedule" side="left">
-    <p-toggle v-if="deployment.can.update" v-model="internalValue" :disabled="loading || deployment.paused || deployment.disabled" />
+  <p-tooltip :text="tooltipText" side="left">
+    <p-toggle v-model="internalValue" :disabled="loading || deployment.paused || deployment.disabled || !deployment.can.update" />
   </p-tooltip>
 </template>
 
@@ -33,6 +33,13 @@
   })
 
   const loading = ref(false)
+
+  const tooltipText = computed(() => {
+    if (!props.deployment.can.update) {
+      return localization.info.deploymentUpdateDisabled
+    }
+    return 'Pause or resume this schedule'
+  })
 
   const updateSchedule = async (value: boolean): Promise<void> => {
     loading.value = true

--- a/src/components/DeploymentToggle.vue
+++ b/src/components/DeploymentToggle.vue
@@ -1,6 +1,6 @@
 <template>
-  <p-tooltip text="Pause or resume all schedules" side="left">
-    <p-toggle v-if="deployment.can.update" v-model="internalValue" :state :disabled="deployment.deprecated || deployment.disabled" />
+  <p-tooltip :text="tooltipText" side="left">
+    <p-toggle v-model="internalValue" :state :disabled="deployment.deprecated || deployment.disabled || !deployment.can.update" />
   </p-tooltip>
 </template>
 
@@ -32,6 +32,13 @@
   })
 
   const state = reactive<State>({ pending: false, valid: true, validated: false })
+
+  const tooltipText = computed(() => {
+    if (!props.deployment.can.update) {
+      return localization.info.deploymentUpdateDisabled
+    }
+    return 'Pause or resume all schedules'
+  })
 
   const toggleDeploymentSchedule = async (value: boolean): Promise<void> => {
     state.pending = true

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -133,6 +133,7 @@ export const en = {
     deploymentName: 'Deployment name',
     deploymentDisabled: 'Deployment disabled, click to enable',
     deploymentEnabled: 'Deployment enabled, click to disable',
+    deploymentUpdateDisabled: 'You do not have the right permissions to update this deployment',
     searchByDeploymentName: 'Search by deployment name',
     workPools: 'Work Pools',
     all: 'All',


### PR DESCRIPTION
Currently we hide action items from users who do not have permission to take the relevant actions.  This includes hiding the deployment schedule toggle from a user who does not have permission to update a deployment.  However, the toggle shows information as well as an action.  

This PR updates the different deployment toggles to allow a toggle to convey information about a deployment's/schedule's status and instead disables the toggle so a user without permissions cannot update the deployment. It also updates the related tooltip to advise the user they don't have permission to update the deployment. 

Current - A user with Runner permissions can see that their deployment has two schedules but can not tell that one has been disabled:
<img width="1489" alt="image" src="https://github.com/user-attachments/assets/51a695bd-eba8-42ff-92de-7149b041ae3b">

This PR - A user with Runner permissions can see that a schedule is disabled but can not update it:
<img width="1489" alt="image" src="https://github.com/user-attachments/assets/299c0c09-6785-439c-96d1-3492ee534f5c">

This PR is separate from the deployment status updates in https://github.com/PrefectHQ/prefect-ui-library/pull/2645 and is aimed only at making status more visible for users who do not have permissions to take action. 

Resolves https://github.com/PrefectHQ/prefect/issues/15071