### PR TITLE
Fix: UI strips new-line characters for Secret block

### DIFF
--- a/src/schemas/components/SchemaFormPropertyString.vue
+++ b/src/schemas/components/SchemaFormPropertyString.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { PCombobox, PCodeInput, PTextInput, State } from '@prefecthq/prefect-design'
+  import { PCombobox, PCodeInput, PTextarea, State } from '@prefecthq/prefect-design'
   import { computed } from 'vue'
   import SchemaFormPropertyDate from '@/schemas/components/SchemaFormPropertyDate.vue'
   import SchemaFormPropertyDateTime from '@/schemas/components/SchemaFormPropertyDateTime.vue'
@@ -43,15 +43,6 @@
       })
     }
 
-    if (format === 'password') {
-      return withProps(PTextInput, {
-        type: 'password',
-        modelValue: props.value,
-        state: props.state,
-        'onUpdate:modelValue': update,
-      })
-    }
-
     if (format === 'json-string') {
       return withProps(PCodeInput, {
         lang: 'json',
@@ -70,9 +61,10 @@
       })
     }
 
-    return withProps(PTextInput, {
+    return withProps(PTextarea, {
       modelValue: props.value,
       state: props.state,
+      rows: 1,
       'onUpdate:modelValue': update,
     })
   })

--- a/src/services/schemas/properties/SchemaPropertyString.ts
+++ b/src/services/schemas/properties/SchemaPropertyString.ts
@@ -1,17 +1,27 @@
-import { PNumberInput, PCombobox, PTextInput, PDateInput } from '@prefecthq/prefect-design'
+import { PNumberInput, PCombobox, PTextarea, PDateInput } from '@prefecthq/prefect-design'
 import { format, isValid, parseISO } from 'date-fns'
 import DateInput from '@/components/DateInput.vue'
 import JsonInput from '@/components/JsonInput.vue'
 import { InvalidSchemaValueError } from '@/models'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
-import { SchemaValue } from '@/types/schemas'
+import { SchemaPropertyInputAttrs, SchemaValue } from '@/types/schemas'
 import { isDate } from '@/utilities/dates'
 import { stringifyUnknownJson } from '@/utilities/stringifyUnknownJson'
 import { isString } from '@/utilities/strings'
 import { isEmail, isJson, ValidationMethodFactory } from '@/utilities/validation'
 
 export class SchemaPropertyString extends SchemaPropertyService {
+
+  protected override get attrs(): SchemaPropertyInputAttrs {
+    if (this.componentIs(PTextarea)) {
+      return {
+        rows: 1,
+      }
+    }
+
+    return {}
+  }
 
   protected override get component(): SchemaPropertyComponentWithProps {
     if (this.has('enum')) {
@@ -32,7 +42,7 @@ export class SchemaPropertyString extends SchemaPropertyService {
       case 'time-delta':
         return this.withProps(PNumberInput)
       default:
-        return this.withProps(PTextInput)
+        return this.withProps(PTextarea)
     }
   }
 

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -96,10 +96,6 @@ export function getSchemaPropertyAttrs(property: SchemaProperty): SchemaProperty
     attrs.step = property.multipleOf
   }
 
-  if (property.format === 'password') {
-    attrs.type = 'password'
-  }
-
   return attrs
 }
 


### PR DESCRIPTION
# Description
Closes https://github.com/PrefectHQ/prefect/issues/6949

Updates how we generate inputs for schema parameters that are type `text`. All text values will use a `textarea` rather than an `input` with type text/password. This specifically fixes entering multi line secrets but also makes working with text more flexible for all text values.  