### PR TITLE
Add concurrency limit input to DeploymentForm

### DIFF
--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -31,6 +31,10 @@
       <p-tags-input v-model="tags" empty-message="Add tags" />
     </p-label>
 
+    <p-label label="Concurrency Limit (Optional)" :state="concucurrencyLimitState" :message="concucurrencyLimitError">
+      <p-number-input v-model="concurrencyLimit" :state="concucurrencyLimitState" />
+    </p-label>
+
     <p-divider />
 
     <template v-if="schemaHasParameters">
@@ -99,6 +103,7 @@
   const description = ref(props.deployment.description)
   const workPoolName = ref(props.deployment.workPoolName)
   const workQueueName = ref(props.deployment.workQueueName)
+  const concurrencyLimit = ref(props.deployment.concurrencyLimit)
   const parameters = ref(props.deployment.parameters)
   const tags = ref(props.deployment.tags)
   const jobVariables = ref(stringify(props.deployment.jobVariables))
@@ -124,6 +129,13 @@
     if (props.deployment.name === value) {
       return 'Name must be different from the original deployment'
     }
+  })
+  const { state: concucurrencyLimitState, error: concucurrencyLimitError } = useValidation(concurrencyLimit, (value) => {
+    if (value != null && value < 1) {
+      return 'Concurrency limit must be greater than 0. To unset, leave the field empty.'
+    }
+
+    return true
   })
 
   const emit = defineEmits<{
@@ -173,6 +185,7 @@
         storageDocumentId: props.deployment.storageDocumentId,
         infrastructureDocumentId: props.deployment.infrastructureDocumentId,
         pullSteps: props.deployment.pullSteps,
+        concurrencyLimit: concurrencyLimit.value,
       }
       emit('submit', deploymentCreate)
     } else {
@@ -184,6 +197,7 @@
         tags: tags.value,
         enforceParameterSchema: enforceParameterSchema.value,
         jobVariables: JSON.parse(jobVariables.value),
+        concurrencyLimit: concurrencyLimit.value,
       }
       emit('submit', deploymentUpdate)
     }

--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -31,8 +31,8 @@
       <p-tags-input v-model="tags" empty-message="Add tags" />
     </p-label>
 
-    <p-label label="Concurrency Limit (Optional)" :state="concucurrencyLimitState" :message="concucurrencyLimitError">
-      <p-number-input v-model="concurrencyLimit" :state="concucurrencyLimitState" />
+    <p-label label="Concurrency Limit (Optional)" :state="concurrencyLimitState" :message="concurrencyLimitError">
+      <p-number-input v-model="concurrencyLimit" :state="concurrencyLimitState" />
     </p-label>
 
     <p-divider />
@@ -130,7 +130,7 @@
       return 'Name must be different from the original deployment'
     }
   })
-  const { state: concucurrencyLimitState, error: concucurrencyLimitError } = useValidation(concurrencyLimit, (value) => {
+  const { state: concurrencyLimitState, error: concurrencyLimitError } = useValidation(concurrencyLimit, (value) => {
     if (value != null && value < 1) {
       return 'Concurrency limit must be greater than 0. To unset, leave the field empty.'
     }

--- a/src/maps/deployment.ts
+++ b/src/maps/deployment.ts
@@ -37,6 +37,7 @@ export const mapDeploymentResponseToDeployment: MapFunction<DeploymentResponse, 
     can: createObjectLevelCan(),
     status: this.map('ServerDeploymentStatus', source.status, 'DeploymentStatus'),
     disabled: source.disabled ?? false,
+    concurrencyLimit: source.concurrency_limit,
   })
 }
 
@@ -50,6 +51,7 @@ export const mapDeploymentUpdateV2ToDeploymentUpdateRequest: MapFunction<Deploym
     work_pool_name: source.workPoolName,
     job_variables: source.jobVariables,
     enforce_parameter_schema: source.enforceParameterSchema,
+    concurrency_limit: source.concurrencyLimit,
   }
 }
 
@@ -90,5 +92,6 @@ export const mapDeploymentCreateToDeploymentCreateRequest: MapFunction<Deploymen
     entrypoint: source.entrypoint,
     version: source.version,
     paused: source.paused,
+    concurrency_limit: source.concurrencyLimit,
   }
 }

--- a/src/mocks/deployment.ts
+++ b/src/mocks/deployment.ts
@@ -40,6 +40,7 @@ export const randomDeployment: MockFunction<Deployment, [Partial<Deployment>?]> 
     can: createObjectLevelCan(),
     status: this.create('deploymentStatus'),
     disabled: disabled,
+    concurrencyLimit: null,
     ...overrides,
   }
 }

--- a/src/models/Deployment.ts
+++ b/src/models/Deployment.ts
@@ -32,6 +32,7 @@ export interface IDeployment {
   can: ObjectLevelCan<'deployment'>,
   status: DeploymentStatus,
   disabled: boolean,
+  concurrencyLimit: number | null,
 }
 
 export class Deployment implements IDeployment {
@@ -63,6 +64,7 @@ export class Deployment implements IDeployment {
   public can: ObjectLevelCan<'deployment'>
   public status: DeploymentStatus
   public disabled: boolean
+  public concurrencyLimit: number | null
 
   public constructor(deployment: IDeployment) {
     this.id = deployment.id
@@ -92,6 +94,7 @@ export class Deployment implements IDeployment {
     this.can = deployment.can
     this.status = deployment.status
     this.disabled = deployment.disabled
+    this.concurrencyLimit = deployment.concurrencyLimit
   }
 
   public get deprecated(): boolean {

--- a/src/models/DeploymentCreate.ts
+++ b/src/models/DeploymentCreate.ts
@@ -21,4 +21,5 @@ export type DeploymentCreate = {
   workPoolName: string | null,
   enforceParameterSchema: boolean,
   pullSteps: unknown,
+  concurrencyLimit: number | null,
 }

--- a/src/models/DeploymentUpdate.ts
+++ b/src/models/DeploymentUpdate.ts
@@ -8,6 +8,7 @@ type Base = {
   workPoolName?: string | null,
   jobVariables?: Record<string, unknown> | null,
   enforceParameterSchema?: boolean,
+  concurrencyLimit?: number | null,
 }
 
 type WithoutParameters = Base & {

--- a/src/models/DeploymentUpdate.ts
+++ b/src/models/DeploymentUpdate.ts
@@ -21,3 +21,4 @@ type WithParameters = Base & {
 }
 
 export type DeploymentUpdateV2 = WithoutParameters | WithParameters
+export type DeploymentUpdate = DeploymentUpdateV2

--- a/src/models/api/DeploymentCreateRequest.ts
+++ b/src/models/api/DeploymentCreateRequest.ts
@@ -20,4 +20,5 @@ export type DeploymentCreateRequest = {
   entrypoint: string | null,
   version: string | null,
   paused: boolean,
+  concurrency_limit: number | null,
 }

--- a/src/models/api/DeploymentResponse.ts
+++ b/src/models/api/DeploymentResponse.ts
@@ -35,4 +35,5 @@ export type DeploymentResponse = {
   pull_steps: unknown,
   status: ServerDeploymentStatus,
   disabled?: boolean,
+  concurrency_limit: number | null,
 }

--- a/src/models/api/DeploymentUpdateRequest.ts
+++ b/src/models/api/DeploymentUpdateRequest.ts
@@ -15,4 +15,5 @@ export type DeploymentUpdateRequest = Partial<{
   work_pool_name: string | null,
   job_variables: Record<string, unknown> | null,
   enforce_parameter_schema: boolean,
+  concurrency_limit: number | null,
 }>


### PR DESCRIPTION
This PR adds a number input to the DeploymentForm for configuring a deployment's concurrency limit(new). 

<img width="796" alt="Screenshot 2024-09-04 at 3 47 08 PM" src="https://github.com/user-attachments/assets/b8687fa6-6c33-4adc-88e0-4c0313f1ea7d">

I'm going to add a Key value Pair into the well in a follow-up for reading this field outside of this form.