### PR TITLE
Add deployment.concurrencyLimit to DeploymentDetails

### DIFF
--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -85,6 +85,8 @@
 
     <p-key-value label="Path" :value="deployment.path" :alternate="alternate" />
 
+    <p-key-value label="Concurrency Limit" :value="deployment.concurrencyLimit" :alternate="alternate" />
+
     <p-divider />
 
     <template v-if="can.read.flow">


### PR DESCRIPTION
follow-up to #2704 , this PR adds concurrency limit to the details well/tab for reading outside of the form.

<img width="1276" alt="Screenshot 2024-09-04 at 3 58 53 PM" src="https://github.com/user-attachments/assets/95952a69-1ff7-435a-b36d-972b3f0e6de0">
