### PR TITLE
Add a few things to the negated set of the URL regex

### DIFF
--- a/src/utilities/urls.ts
+++ b/src/utilities/urls.ts
@@ -1,1 +1,1 @@
-export const urlRegex = /((?:https?|ftp):\/\/[^\s/$.?#].[^\s]*)/g
+export const urlRegex = /((?:https?|ftp):\/\/[^\s/$.?#].[^\s)"(]*)/g


### PR DESCRIPTION
Adds `(`,`"`, and `)` to the negated set at the end of the regex for URLs.

Closes https://github.com/PrefectHQ/prefect/issues/15239