### PR TITLE
Chore: Add avoid-collisions prop to formatted date tooltip

### DIFF
--- a/src/components/FormattedDate.vue
+++ b/src/components/FormattedDate.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-tooltip>
+  <p-tooltip avoid-collisions>
     <template #content>
       <slot name="tooltip">
         <div class="formatted-date__tooltip">


### PR DESCRIPTION
Noticed these weren't rendering properly everywhere