### PR TITLE
Fix unknown schema property types not rendering correctly.

### DIFF
--- a/src/schemas/components/SchemaFormPropertyUnknown.vue
+++ b/src/schemas/components/SchemaFormPropertyUnknown.vue
@@ -59,6 +59,6 @@
       })
     }
 
-    return withProps(() => ({ template: '' }))
+    return withProps(() => '')
   })
 </script>

--- a/src/schemas/compositions/useSchemaPropertyInput.ts
+++ b/src/schemas/compositions/useSchemaPropertyInput.ts
@@ -66,7 +66,7 @@ export function useSchemaPropertyInput(schemaProperty: MaybeRefOrGetter<SchemaPr
     const exhaustive: never = propertyValue.value
     console.error(new Error(`SchemaFormProperty input is not exhaustive: ${JSON.stringify(exhaustive)}`))
 
-    return withProps(() => ({ template: '' }))
+    return withProps(() => '')
   })
 
   return { input }


### PR DESCRIPTION
Regression from https://github.com/PrefectHQ/prefect-ui-library/pull/2698

Given a parameter schema containing something like:
```json
"properties": {
  ...
  "something": { "title": "something" },
```
Without an explicit `type`.

On schema form render, the following error(in prod build) occurs

![image](https://github.com/user-attachments/assets/915569a1-807f-44d6-9f9b-8920927cc176)

In dev build:
![image](https://github.com/user-attachments/assets/5276be54-1e67-4d71-a329-aeace7fdcbd8)
