### PR TITLE
Chore: Update empirical policy

### DIFF
--- a/src/components/FlowRunCreateForm.vue
+++ b/src/components/FlowRunCreateForm.vue
@@ -163,6 +163,7 @@
         retryDelay: retryDelay.value,
         maxRetries: null,
         retryDelaySeconds: null,
+        retryJitterFactor: null,
       },
       name: name.value,
       parameters: parameters.value,

--- a/src/components/TaskRunDetails.vue
+++ b/src/components/TaskRunDetails.vue
@@ -60,16 +60,9 @@
 
     <p-key-value label="Version" :value="taskRun.taskVersion" :alternate="alternate" />
 
-    <div v-if="taskRun.empiricalPolicy?.maxRetries">
-      <p-key-value label="Max Retries" :value="taskRun.empiricalPolicy?.maxRetries" :alternate="alternate" />
-
-      <p-key-value label="Retry Delay" :value="secondsToApproximateString(taskRun.empiricalPolicy?.retryDelaySeconds ?? 0)" :alternate="alternate" />
-    </div>
-    <div v-else>
-      <p-key-value label="Retries" :value="taskRun.empiricalPolicy?.retries" :alternate="alternate" />
-
-      <p-key-value label="Retry Delay" :value="secondsToApproximateString(taskRun.empiricalPolicy?.retryDelay ?? 0)" :alternate="alternate" />
-    </div>
+    <p-key-value label="Retries" :value="taskRun.empiricalPolicy?.retries" :alternate="alternate" />
+    <p-key-value label="Retry Delay" :value="secondsToApproximateString(taskRun.empiricalPolicy?.retryDelay ?? 0)" :alternate="alternate" />
+    <p-key-value label="Retry Jitter Factor" :value="taskRun.empiricalPolicy?.retryJitterFactor" :alternate="alternate" />
 
     <p-key-value label="Tags" :alternate="alternate">
       <template v-if="taskRun.tags?.length" #value>

--- a/src/maps/empiricalPolicy.ts
+++ b/src/maps/empiricalPolicy.ts
@@ -8,6 +8,7 @@ export const mapEmpiricalPolicyResponseToEmpiricalPolicy: MapFunction<EmpiricalP
     retries: source.retries,
     retryDelay: source.retry_delay,
     maxRetries: source.max_retries,
+    retryJitterFactor: source.retry_jitter_factor,
     retryDelaySeconds: source.retry_delay_seconds,
   })
 }
@@ -17,6 +18,7 @@ export const mapEmpiricalPolicyToEmpiricalPolicyResponse: MapFunction<EmpiricalP
     retries: source.retries,
     retry_delay: source.retryDelay,
     max_retries: source.maxRetries,
+    retry_jitter_factor: source.retryJitterFactor,
     retry_delay_seconds: source.retryDelaySeconds,
   }
 }

--- a/src/models/EmpiricalPolicy.ts
+++ b/src/models/EmpiricalPolicy.ts
@@ -1,19 +1,30 @@
 export interface IEmpiricalPolicy {
   retries: number | null,
   retryDelay: number | null,
+  retryJitterFactor: number | null,
+  /**
+   * @deprecated
+   * Use `retries` instead
+   */
   maxRetries: number | null,
+  /**
+   * @deprecated
+   * Use `retryDelay` instead
+   */
   retryDelaySeconds: number | null,
 }
 
 export class EmpiricalPolicy implements IEmpiricalPolicy {
   public retries: number | null
   public retryDelay: number | null
+  public retryJitterFactor: number | null
   public maxRetries: number | null
   public retryDelaySeconds: number | null
 
   public constructor(empiricalPolicy: IEmpiricalPolicy) {
     this.retries = empiricalPolicy.retries
     this.retryDelay = empiricalPolicy.retryDelay
+    this.retryJitterFactor = empiricalPolicy.retryJitterFactor
     this.maxRetries = empiricalPolicy.maxRetries
     this.retryDelaySeconds = empiricalPolicy.retryDelaySeconds
   }

--- a/src/models/api/EmpiricalPolicyResponse.ts
+++ b/src/models/api/EmpiricalPolicyResponse.ts
@@ -3,4 +3,5 @@ export type EmpiricalPolicyResponse = {
   retry_delay: number | null,
   max_retries: number | null,
   retry_delay_seconds: number | null,
+  retry_jitter_factor: number | null,
 }


### PR DESCRIPTION
Deprecates `max_retries` and `retry_delay_seconds` fields, adds `retry_jitter_factor` field. 