### PR TITLE
Fix deployment.concurrency_limit always null.

### DIFF
--- a/src/maps/deployment.ts
+++ b/src/maps/deployment.ts
@@ -37,7 +37,7 @@ export const mapDeploymentResponseToDeployment: MapFunction<DeploymentResponse, 
     can: createObjectLevelCan(),
     status: this.map('ServerDeploymentStatus', source.status, 'DeploymentStatus'),
     disabled: source.disabled ?? false,
-    concurrencyLimit: source.concurrency_limit,
+    concurrencyLimit: source.concurrency_limit ?? source.global_concurrency_limit?.limit ?? null,
   })
 }
 

--- a/src/models/api/DeploymentResponse.ts
+++ b/src/models/api/DeploymentResponse.ts
@@ -1,3 +1,4 @@
+import { ConcurrencyV2Response } from '@/models/api/ConcurrencyV2Response'
 import { CreatedOrUpdatedByResponse } from '@/models/api/CreatedOrUpdatedByResponse'
 import { DeploymentScheduleResponse } from '@/models/api/DeploymentScheduleResponse'
 import { ScheduleResponse } from '@/models/api/ScheduleResponse'
@@ -36,4 +37,5 @@ export type DeploymentResponse = {
   status: ServerDeploymentStatus,
   disabled?: boolean,
   concurrency_limit: number | null,
+  global_concurrency_limit: ConcurrencyV2Response | null,
 }


### PR DESCRIPTION
https://github.com/PrefectHQ/prefect/pull/15426 includes some API changes that results in the deployment details always showing the concurrency limit as None. 

That PR:
- adds a full GCL/concurrencylimitv2 onto deployment responses that have a concurrency limit
- makes the top-level concurrency_limit value always null -- would remove but keeping it for backwards compatibility. 

The changes here should be backwards compatible in that it uses `concurrency_limit` if present else falls back to the nested limit value else null.