### PR TITLE
Add tooltip for deployment concurrency limit minimum client version requirement

### DIFF
--- a/src/components/DeploymentConcurrencyVersionTooltip.vue
+++ b/src/components/DeploymentConcurrencyVersionTooltip.vue
@@ -1,0 +1,12 @@
+<template>
+  <ExtraInfoTooltip>
+    To enforce this limit, make sure your workers are using
+    <p-code inline>
+      prefect>=3.0.2
+    </p-code>.
+  </ExtraInfoTooltip>
+</template>
+
+<script setup lang="ts">
+  import ExtraInfoTooltip from '@/components/ExtraInfoTooltip.vue'
+</script>

--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -85,7 +85,14 @@
 
     <p-key-value label="Path" :value="deployment.path" :alternate="alternate" />
 
-    <p-key-value label="Concurrency Limit" :value="deployment.concurrencyLimit" :alternate="alternate" />
+    <p-key-value :value="deployment.concurrencyLimit" :alternate="alternate">
+      <template #label>
+        <div class="flex gap-1 items-center">
+          <span>Concurrency Limit</span>
+          <DeploymentConcurrencyVersionTooltip />
+        </div>
+      </template>
+    </p-key-value>
 
     <p-divider />
 
@@ -119,6 +126,7 @@
   import { AutomationAction, CreateAutomationQuery } from '..'
   import AutomationIconText from '@/automations/components/AutomationIconText.vue'
   import { BlockIconText, DeploymentStatusBadge, DeploymentSchedulesFieldset } from '@/components'
+  import DeploymentConcurrencyVersionTooltip from '@/components/DeploymentConcurrencyVersionTooltip.vue'
   import DeploymentToggle from '@/components/DeploymentToggle.vue'
   import FormattedDate from '@/components/FormattedDate.vue'
   import { useWorkspaceApi, useCan, useWorkspaceRoutes } from '@/compositions'

--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -32,6 +32,12 @@
     </p-label>
 
     <p-label label="Concurrency Limit (Optional)" :state="concurrencyLimitState" :message="concurrencyLimitError">
+      <template #label>
+        <div class="flex gap-1 items-center">
+          Concurrency Limit (Optional)
+          <DeploymentConcurrencyVersionTooltip />
+        </div>
+      </template>
       <p-number-input v-model="concurrencyLimit" :state="concurrencyLimitState" placeholder="Unlimited" />
     </p-label>
 
@@ -86,6 +92,7 @@
   import { useValidation, useValidationObserver } from '@prefecthq/vue-compositions'
   import { computed, h, ref } from 'vue'
   import { JobVariableOverridesInput, WorkPoolCombobox, WorkPoolQueueCombobox } from '@/components'
+  import DeploymentConcurrencyVersionTooltip from '@/components/DeploymentConcurrencyVersionTooltip.vue'
   import ToastParameterValidationError from '@/components/ToastParameterValidationError.vue'
   import { localization } from '@/localization'
   import { Deployment, deploymentCollisionStrategies, DeploymentUpdateV2 } from '@/models'

--- a/src/components/ExtraInfoTooltip.vue
+++ b/src/components/ExtraInfoTooltip.vue
@@ -9,7 +9,7 @@
 
 <script lang="ts" setup>
   defineProps<{
-    description: string,
+    description?: string,
   }>()
 </script>
 

--- a/src/components/ExtraInfoTooltip.vue
+++ b/src/components/ExtraInfoTooltip.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-tooltip :text="description">
+  <p-tooltip :text="description" avoid-collisions>
     <p-icon icon="InformationCircleIcon" class="extra-info-tooltip__icon" />
     <template #content>
       <slot />

--- a/src/components/FlowRunJobVariableOverridesLabeledInput.vue
+++ b/src/components/FlowRunJobVariableOverridesLabeledInput.vue
@@ -3,7 +3,7 @@
     <template #label>
       <span class="flow-run-job-variable-overrides-labeled-input__label">
         Job Variables (Optional)
-        <ExtraInfoTooltip description="what">
+        <ExtraInfoTooltip>
           To use flow run job variables, make sure your workers are using
           <p-code inline>
             prefect>=2.16.4


### PR DESCRIPTION
This PR adds a tooltip to the deployment concurrency limit input and kvp labels denoting minimum required prefect version that workers must use in order to properly enforce the limits. 

| | **Before** | **After** |
| ---- | ---- | ---- |
| On details | <img width="279" alt="image" src="https://github.com/user-attachments/assets/2c22ca99-afb0-4ee3-9f0c-611d1930aa88"> | <img width="465" alt="image" src="https://github.com/user-attachments/assets/1884ad67-2b25-495f-9712-f26d0a9a23ff"> |
| On edit/duplicate | <img width="438" alt="image" src="https://github.com/user-attachments/assets/0eba2993-1701-4068-9377-52fa7ce1cf99"> | <img width="560" alt="image" src="https://github.com/user-attachments/assets/035ffdfe-8aca-4017-a9e3-b956bc7ff099"> |

