### PR TITLE
Show automation toggle to all users but disabled for users without manage_automations scope

### DIFF
--- a/src/automations/components/AutomationToggle.vue
+++ b/src/automations/components/AutomationToggle.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-toggle v-if="can.update.automation" v-model="internalValue" :state="state" />
+  <p-toggle v-model="internalValue" :disabled="!can.update.automation" :state="state" />
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
# Description
Closes https://github.com/PrefectHQ/prefect/issues/15429

This follows what we already do for deployments by disabling the toggle rather than removing it for users without permission to update it. 