### PR TITLE
Add a factory for creating cache keys

### DIFF
--- a/src/utilities/cache.ts
+++ b/src/utilities/cache.ts
@@ -1,24 +1,41 @@
 // this can be used to cache bust between releases. Incrementing this will remove all caches using the previous version
-const cacheVersion = 4
-const cachePrefix = 'cache-key'
-const cacheKeyPrefix = `${cachePrefix}-${cacheVersion}`
+const globalCacheVersion = 4
+const globalCachePrefix = 'cache-key'
+const globalCacheKeyPrefix = `${globalCachePrefix}-${globalCacheVersion}`
+const cacheKeyPrefixes = new Set<string>()
 
 export function getCacheKey(label: string): string {
-  return `${cacheKeyPrefix}:${label}`
+  return `${globalCacheKeyPrefix}:${label}`
 }
 
 type CacheKeyFunction = (key: string) => string
 
 export function createCacheKeyFunction(version: number, prefix: string): CacheKeyFunction {
-  return (key: string) => `${cachePrefix}-${cacheVersion}-${prefix}-${version}-${key}`
+  const cachePrefix = `${globalCacheKeyPrefix}-${prefix}-${version}`
+
+  cacheKeyPrefixes.add(cachePrefix)
+
+  return (key: string) => `${cachePrefix}-${key}`
 }
 
 export function isCacheKey(key: string): boolean {
-  return key.startsWith(cachePrefix)
+  return key.startsWith(globalCachePrefix)
 }
 
 export function isOldCacheKey(key: string): boolean {
-  return isCacheKey(key) && !key.startsWith(cacheKeyPrefix)
+  if (!isCacheKey(key)) {
+    return false
+  }
+
+  const matchesGlobalKeyPrefix = key.startsWith(globalCacheKeyPrefix)
+
+  if (!matchesGlobalKeyPrefix) {
+    return true
+  }
+
+  const matchesCacheKey = Array.from(cacheKeyPrefixes.values()).some(prefix => key.startsWith(prefix))
+
+  return !matchesCacheKey
 }
 
 export function clearOldCacheKeys(): void {

--- a/src/utilities/cache.ts
+++ b/src/utilities/cache.ts
@@ -7,6 +7,12 @@ export function getCacheKey(label: string): string {
   return `${cacheKeyPrefix}:${label}`
 }
 
+type CacheKeyFunction = (key: string) => string
+
+export function createCacheKeyFunction(version: number, prefix: string): CacheKeyFunction {
+  return (key: string) => `${cachePrefix}-${cacheVersion}-${prefix}-${version}-${key}`
+}
+
 export function isCacheKey(key: string): boolean {
   return key.startsWith(cachePrefix)
 }


### PR DESCRIPTION
# Description
We have the `getCacheKey` utility which allows us to cache bust but its all or nothing. Most likely if we ever need this we won't want to bust everything but rather everything related to a specific feature. 

The new `createCacheKeyFunction` will allow us to create unique `getCacheKey` utilities with feature specific prefixes that can be versioned individually. Versioning a feature specific cache key will bust just keys for that feature. Versioning the global cache key will bust everything across features. 