### PR TITLE
Add a tooltip describing the duration of the activity column on deployment table

### DIFF
--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -144,7 +144,6 @@
   import { ClassValue } from '@/types'
   import { deploymentSortOptions } from '@/types/SortOptionTypes'
 
-
   const props = defineProps<{
     filter?: DeploymentsFilter,
     prefix?: string,

--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -42,6 +42,13 @@
         </div>
       </template>
 
+      <template #activity-heading="{ column }">
+        <div class="flex items-center gap-1">
+          {{ column.label }}
+          <ExtraInfoTooltip description="Runs from the past week." size="small" />
+        </div>
+      </template>
+
       <template #action-heading>
         <span />
       </template>
@@ -128,13 +135,15 @@
     DeploymentTagsInput,
     DeploymentDisableToggle,
     DeploymentStatusBadge,
-    DeploymentScheduleTags
+    DeploymentScheduleTags,
+    ExtraInfoTooltip
   } from '@/components'
   import { useCan, useDeploymentsPaginationFilterFromRoute, useWorkspaceRoutes, useDeployments, useComponent } from '@/compositions'
   import { Deployment } from '@/models'
   import { DeploymentsFilter } from '@/models/Filters'
   import { ClassValue } from '@/types'
   import { deploymentSortOptions } from '@/types/SortOptionTypes'
+
 
   const props = defineProps<{
     filter?: DeploymentsFilter,

--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -45,7 +45,7 @@
       <template #activity-heading="{ column }">
         <div class="flex items-center gap-1">
           {{ column.label }}
-          <ExtraInfoTooltip description="Runs from the past week." size="small" />
+          <ExtraInfoTooltip description="Runs from the past week" size="small" />
         </div>
       </template>
 

--- a/src/components/ExtraInfoTooltip.vue
+++ b/src/components/ExtraInfoTooltip.vue
@@ -1,6 +1,6 @@
 <template>
   <p-tooltip :text="description" avoid-collisions>
-    <p-icon icon="InformationCircleIcon" class="extra-info-tooltip__icon" />
+    <p-icon :size="size" icon="InformationCircleIcon" class="extra-info-tooltip__icon" />
     <template #content>
       <slot />
     </template>
@@ -10,6 +10,7 @@
 <script lang="ts" setup>
   defineProps<{
     description?: string,
+    size?: 'small' | 'default' | 'large',
   }>()
 </script>
 


### PR DESCRIPTION
This PR adds a tooltip to the activity column header on the deployments page's table to add more information about what the activity column is showing you.

| **Before** | **After** |
| ---- | ---- |
| <img width="864" alt="image" src="https://github.com/user-attachments/assets/50c32649-36dd-47ab-b7ef-4c0bc01a50ad"> | <img width="862" alt="image" src="https://github.com/user-attachments/assets/719ca227-bf99-48dd-874b-ec7b5d396bde"> |


Closes CLOUD-42