### PR TITLE
Deployment schedule active out of sync edit modal and cards

### DIFF
--- a/src/components/DeploymentScheduleCard.vue
+++ b/src/components/DeploymentScheduleCard.vue
@@ -1,19 +1,19 @@
 <template>
   <p-list-item class="deployment-schedule-card">
-    <p-tooltip :text="internalValue.schedule?.toString({ verbose: true })">
+    <p-tooltip :text="deploymentSchedule.schedule.toString({ verbose: true })">
       <div class="deployment-schedule-card__content">
-        {{ internalValue.schedule?.toString({ verbose: false }) }}
+        {{ deploymentSchedule.schedule.toString({ verbose: false }) }}
       </div>
     </p-tooltip>
     <div class="deployment-schedule-card__action">
-      <DeploymentScheduleToggle :deployment="deployment" :schedule="deploymentSchedule" @update="updateActiveStatus" />
+      <DeploymentScheduleToggle :deployment="deployment" :schedule="deploymentSchedule" @update="$emit('update')" />
       <DeploymentScheduleMenu
         class="deployment-schedule__menu"
         small
         :deployment="deployment"
         :schedule="deploymentSchedule"
-        @update="scheduleUpdated"
-        @delete="emit('update')"
+        @update="$emit('update')"
+        @delete="$emit('update')"
       />
     </div>
   </p-list-item>
@@ -21,34 +21,17 @@
 
 
 <script lang="ts" setup>
-  import { ref, watch } from 'vue'
   import { DeploymentScheduleMenu, DeploymentScheduleToggle } from '@/components'
-  import { Deployment, DeploymentSchedule, DeploymentScheduleCompatible } from '@/models'
+  import { Deployment, DeploymentSchedule } from '@/models'
 
-  const props = defineProps<{
+  defineProps<{
     deployment: Deployment,
     deploymentSchedule: DeploymentSchedule,
   }>()
 
-  const emit = defineEmits<{
+  defineEmits<{
     (event: 'update'): void,
   }>()
-
-  const internalValue = ref<DeploymentScheduleCompatible>({ active: props.deploymentSchedule.active, schedule: props.deploymentSchedule.schedule, jobVariables: props.deploymentSchedule.jobVariables })
-
-  const updateActiveStatus = (value: boolean): void => {
-    internalValue.value.active = value
-    emit('update')
-  }
-
-  const scheduleUpdated = (schedule: DeploymentScheduleCompatible): void => {
-    internalValue.value = schedule
-  }
-
-  const updateInternalState = (): void => {
-    internalValue.value = { active: props.deploymentSchedule.active, schedule: props.deploymentSchedule.schedule, jobVariables: props.deploymentSchedule.jobVariables }
-  }
-  watch(() => props.deploymentSchedule, updateInternalState)
 </script>
 
 <style>

--- a/src/components/DeploymentScheduleMenu.vue
+++ b/src/components/DeploymentScheduleMenu.vue
@@ -5,7 +5,7 @@
     <p-overflow-menu-item v-if="deployment.can.delete" label="Delete" @click="openConfirmDeleteModal" />
   </p-icon-button-menu>
 
-  <ScheduleFormModal ref="scheduleFormModalRef" v-bind="compatSchedule" @submit="updateSchedule" />
+  <ScheduleFormModal ref="scheduleFormModalRef" v-bind="schedule" @submit="updateSchedule" />
 
   <ConfirmDeleteModal
     v-model:showModal="showConfirmDeleteModal"
@@ -45,12 +45,6 @@
   }>()
 
   const api = useWorkspaceApi()
-
-  const compatSchedule = ref<DeploymentScheduleCompatible>({
-    active: props.schedule.active,
-    schedule: props.schedule.schedule,
-    jobVariables: props.schedule.jobVariables,
-  })
 
   const { showModal: showConfirmDeleteModal, open: openConfirmDeleteModal, close: closeConfirmDeleteModal } = useShowModal()
 

--- a/src/components/ScheduleFormModal.vue
+++ b/src/components/ScheduleFormModal.vue
@@ -1,6 +1,6 @@
 <template>
   <slot :open="open" :close="close" />
-  <p-modal v-model:showModal="showModal" :title="schedule ? 'Edit schedule' : 'Add schedule'">
+  <p-modal v-model:showModal="showModal" :title="schedule ? 'Edit schedule' : 'Add schedule'" @update:show-modal="resetIfFalse">
     <p-label label="Schedule type">
       <p-button-group v-model="scheduleForm" :options="scheduleFormOptions" small />
     </p-label>
@@ -122,6 +122,12 @@
     internalJobVariables.value = props.jobVariables ? stringify(props.jobVariables) : undefined
   }
   watch(() => props.schedule, updateInternalState)
+
+  function resetIfFalse(val: boolean): void {
+    if (!val) {
+      updateInternalState()
+    }
+  }
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
This PR fixes some data inconsistency issues between the deployment schedule cards and the edit schedule modal. In particular, the active/inactive toggle state is not in-sync between the following UI elements following updates from either one. This is mostly due to overuse of component-local state that should instead be derived from props. 

| Minimal card view | Edit modal |
| ---- | ---- |
| <img width="251" alt="image" src="https://github.com/user-attachments/assets/2f46cbf0-9491-474f-9137-1025e0e233dd"> | <img width="589" alt="image" src="https://github.com/user-attachments/assets/de0fb04b-a841-4c4c-b6aa-0d08939aede1"> |


Closes CLOUD-358