### PR TITLE
Deployment schedules - add active label and fix spacing

### DIFF
--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -212,6 +212,5 @@
   flex-row
   justify-between
   items-center
-  mb-2
 }
 </style>

--- a/src/components/ScheduleFormModal.vue
+++ b/src/components/ScheduleFormModal.vue
@@ -5,7 +5,9 @@
       <p-button-group v-model="scheduleForm" :options="scheduleFormOptions" small />
     </p-label>
 
-    <p-toggle v-model="internalActive" />
+    <p-label label="Active">
+      <p-toggle v-model="internalActive" />
+    </p-label>
 
     <template v-if="scheduleForm == 'rrule'">
       <p>


### PR DESCRIPTION
| What do | **Before** | **After** |
| ---- | ---- | ---- |
| Adds `Active` label to schedule form | <img width="499" alt="image" src="https://github.com/user-attachments/assets/1a5c6bf6-5e6b-4e04-bdf5-908aec1a4a1f"> | <img width="485" alt="image" src="https://github.com/user-attachments/assets/81f2b47a-7478-45a7-8176-e9b23e4a30e4"> |
| Remove inconsistent space under schedules label/heading | <img width="246" alt="image" src="https://github.com/user-attachments/assets/40309e84-ec84-4a42-aa0a-c647729a6cfe"> | <img width="273" alt="image" src="https://github.com/user-attachments/assets/d8fd7fa2-0593-42d1-bed5-b7af0133d66a"> |
