### PR TITLE
Fix cache key collisions with `createCacheKeyFunction` and bust global cache

### DIFF
--- a/src/utilities/cache.ts
+++ b/src/utilities/cache.ts
@@ -1,5 +1,5 @@
 // this can be used to cache bust between releases. Incrementing this will remove all caches using the previous version
-const globalCacheVersion = 4
+const globalCacheVersion = 5
 const globalCachePrefix = 'cache-key'
 const globalCacheKeyPrefix = `${globalCachePrefix}-${globalCacheVersion}`
 
@@ -10,7 +10,7 @@ export function getCacheKey(label: string): string {
 type CacheKeyFunction = (key: string) => string
 
 export function createCacheKeyFunction(version: number, prefix: string): CacheKeyFunction {
-  const cachePrefix = `${globalCacheKeyPrefix}-${prefix}`
+  const cachePrefix = `${globalCacheKeyPrefix}-${prefix}___`
   const cachePrefixWithVersion = `${cachePrefix}-${version}`
 
   clearOldFeatureCacheKeys(cachePrefix, cachePrefixWithVersion)


### PR DESCRIPTION
# Description
Fixes an issue where using `createCacheKeyFunction(1, 'foo')` and `createCacheKeyFunction(1, 'foo-bar')` the keys would conflict as `foo-bar` matches the `foo` key. Adding a unique suffix to keys prevents this from happening. Now the `createCacheKeyFunction` will add a triple underscore (`___`) between the key and the version so that keys won't overlap. 