### PR TITLE
Make sure we always use the installed p-link and not the imported one

### DIFF
--- a/src/components/FlowRunBreadCrumbs.vue
+++ b/src/components/FlowRunBreadCrumbs.vue
@@ -12,7 +12,6 @@
 </template>
 
 <script lang="ts" setup>
-  import { PLink } from '@prefecthq/prefect-design'
   import { useRouteParam } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
   import FlowRouterLink from '@/components/FlowRouterLink.vue'
@@ -33,7 +32,7 @@
       return 'span'
     }
 
-    return PLink
+    return 'p-link'
   })
 </script>
 

--- a/src/components/SchemaPropertyBlockKeyValue.vue
+++ b/src/components/SchemaPropertyBlockKeyValue.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { PKeyValue, PLink } from '@prefecthq/prefect-design'
+  import { PKeyValue } from '@prefecthq/prefect-design'
   import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'

--- a/src/components/ToastParameterValidationError.vue
+++ b/src/components/ToastParameterValidationError.vue
@@ -1,7 +1,3 @@
 <template>
   <span>There was an error validating your parameters. If the issue persists please <p-link href="https://github.com/PrefectHQ/prefect/issues/new/choose">report an issue.</p-link></span>
 </template>
-
-<script setup lang="ts">
-  import { PLink } from '@prefecthq/prefect-design'
-</script>


### PR DESCRIPTION
# Description
Since we're overriding p-link in cloud we need to make sure we use the app registered and not the imported version from PLink