### PR TITLE
Update `TagFilter` to support `any_`

### DIFF
--- a/src/compositions/filters.ts
+++ b/src/compositions/filters.ts
@@ -111,6 +111,7 @@ export function useTagFilter(defaultValue: MaybeReactive<TagFilter> = {}): UseFi
   const filter: Filter<TagFilter> = reactive({
     operator: toRef(defaultValueReactive, 'operator'),
     name: toRef(defaultValueReactive, 'name'),
+    anyName: toRef(defaultValueReactive, 'anyName'),
     isNull: toRef(defaultValueReactive, 'isNull'),
   })
 
@@ -120,6 +121,7 @@ export function useTagFilter(defaultValue: MaybeReactive<TagFilter> = {}): UseFi
 const tagFilterSchema: RouteQueryParamsSchema<TagFilter> = {
   operator: OperatorRouteParam,
   name: [StringRouteParam],
+  anyName: [StringRouteParam],
   isNull: BooleanRouteParam,
 }
 

--- a/src/maps/dashboard.ts
+++ b/src/maps/dashboard.ts
@@ -8,8 +8,7 @@ export const mapWorkspaceDashboardFilterToTaskRunsFilter: MapFunction<WorkspaceD
   return {
     flowRuns: {
       tags: {
-        operator: 'or',
-        name: source.tags,
+        anyName: source.tags,
       },
       parentTaskRunIdNull: source.hideSubflows ? true : undefined,
     },
@@ -29,8 +28,7 @@ export const mapWorkspaceDashboardFilterToTaskRunsHistoryFilter: MapFunction<Wor
     historyIntervalSeconds: timeSpanInSeconds / 20,
     flowRuns: {
       tags: {
-        operator: 'or',
-        name: source.tags,
+        anyName: source.tags,
       },
       parentTaskRunIdNull: source.hideSubflows ? true : undefined,
     },
@@ -45,8 +43,7 @@ export const mapWorkspaceDashboardFilterToFlowRunsFilter: MapFunction<WorkspaceD
       expectedStartTimeAfter: startDate,
       expectedStartTimeBefore: endDate,
       tags: {
-        operator: 'or',
-        name: source.tags,
+        anyName: source.tags,
       },
       parentTaskRunIdNull: source.hideSubflows ? true : undefined,
     },

--- a/src/maps/filters.ts
+++ b/src/maps/filters.ts
@@ -133,6 +133,7 @@ export const mapTagFilter: MapFunction<TagFilter, TagFilterRequest> = function(s
   return {
     ...toOperator(source.operator),
     ...toAll(source.name),
+    ...toAny(source.anyName),
     ...toIsNull(source.isNull),
   }
 }

--- a/src/models/Filters.ts
+++ b/src/models/Filters.ts
@@ -11,6 +11,7 @@ export function isOperation(value: string): value is Operation {
 export type TagFilter = {
   operator?: Operation,
   name?: string[],
+  anyName?: string[],
   isNull?: boolean,
 }
 

--- a/src/models/api/Filters.ts
+++ b/src/models/api/Filters.ts
@@ -34,7 +34,7 @@ export type LessThan = { le_?: number }
 export type OperationRequest = 'and_' | 'or_'
 export type OperatorRequest = { operator?: OperationRequest }
 
-export type TagFilterRequest = OperatorRequest & All & IsNull
+export type TagFilterRequest = OperatorRequest & All & IsNull & Any
 
 export type StateFilterRequest = OperatorRequest & { type?: Any } & { name?: Any }
 


### PR DESCRIPTION
# Description
`TagFilter['name']` maps to an `all_` filter but we want to use `any_` for most things. Rather than changing the default for `name` I'm adding a `anyName` filter than can be used. 

Corrected instances where `name` was incorrectly used with an `operation` rather than using an `any` filter. 