### PR TITLE
Refactor the flow run delete modal to be more resilient

### DIFF
--- a/src/components/ConfirmDeleteModal.vue
+++ b/src/components/ConfirmDeleteModal.vue
@@ -29,16 +29,12 @@
 <script lang="ts" setup>
   const show = defineModel<boolean>('showModal', { required: true })
 
-  withDefaults(defineProps<{
+  const { label, name, loading, action = 'Delete' } = defineProps<{
     label?: string,
     name?: string,
     loading?: boolean,
     action?: 'Delete' | 'Remove',
-  }>(), {
-    name: '',
-    label: undefined,
-    action: 'Delete',
-  })
+  }>()
 
   const emits = defineEmits<{
     (event: 'delete'): void,

--- a/src/components/ConfirmDeleteModal.vue
+++ b/src/components/ConfirmDeleteModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-modal v-model:showModal="internalValue">
+  <p-modal v-model:showModal="show">
     <template #icon>
       <p-icon icon="ExclamationCircleIcon" class="delete-modal__icon" />
     </template>
@@ -17,7 +17,7 @@
     </span>
     <template #actions>
       <slot name="actions">
-        <p-button variant="destructive" @click="handleDeleteClick">
+        <p-button variant="destructive" :loading @click="handleDeleteClick">
           {{ action }}
         </p-button>
       </slot>
@@ -27,12 +27,12 @@
 
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
+  const show = defineModel<boolean>('showModal', { required: true })
 
-  const props = withDefaults(defineProps<{
-    showModal: boolean,
+  withDefaults(defineProps<{
     label?: string,
     name?: string,
+    loading?: boolean,
     action?: 'Delete' | 'Remove',
   }>(), {
     name: '',
@@ -41,22 +41,12 @@
   })
 
   const emits = defineEmits<{
-    (event: 'update:showModal', value: boolean): void,
     (event: 'delete'): void,
   }>()
 
-  const internalValue = computed({
-    get() {
-      return props.showModal
-    },
-    set(value: boolean) {
-      emits('update:showModal', value)
-    },
-  })
-
   const handleDeleteClick = (): void => {
     emits('delete')
-    internalValue.value = false
+    show.value = false
   }
 </script>
 

--- a/src/components/FlowRunsDeleteButton.vue
+++ b/src/components/FlowRunsDeleteButton.vue
@@ -2,17 +2,19 @@
   <Transition name="flow-runs-delete-button-transition">
     <p-button v-if="selected.length > 0" icon="TrashIcon" small @click="open" />
   </Transition>
+
   <ConfirmDeleteModal
     v-model:showModal="showModal"
     name="selected flow runs"
     label="Flow runs"
+    :loading
     @delete="() => deleteFlowRuns(selected)"
   />
 </template>
 
 <script lang="ts" setup>
   import { showToast } from '@prefecthq/prefect-design'
-  import { computed } from 'vue'
+  import { computed, ref } from 'vue'
   import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
@@ -29,8 +31,11 @@
   const { showModal, open, close } = useShowModal()
 
   const api = useWorkspaceApi()
+  const loading = ref(false)
 
   const deleteFlowRuns = async (flowRuns: string[]): Promise<void> => {
+    loading.value = true
+
     const toastMessage = computed(() => {
       if (flowRuns.length === 1) {
         return 'Flow run deleted'
@@ -38,17 +43,37 @@
       return `${flowRuns.length} flow runs deleted`
     })
 
+    const promises = flowRuns.map(flowRunId => deleteFlowRun(flowRunId))
+    const values = await Promise.allSettled(promises)
+    const errors = values.filter(value => value.status === 'rejected').map(value => value.reason)
+
+    if (errors.length > 0) {
+      if (errors.length === 1) {
+        const message = getApiErrorMessage(errors[0], localization.error.delete('Flow Run'))
+        showToast(message, 'error')
+      } else {
+        showToast(`${errors.length} flow runs failed to delete`, 'error')
+      }
+
+      loading.value = false
+      return
+    }
+
+    showToast(toastMessage, 'success')
+    emit('delete')
     close()
+  }
 
+  async function deleteFlowRun(flowRunId: string, retries = 0): Promise<void> {
     try {
-      const deleteFlowRuns = flowRuns.map(api.flowRuns.deleteFlowRun)
-      await Promise.all(deleteFlowRuns)
-
-      showToast(toastMessage, 'success')
-      emit('delete')
+      await api.flowRuns.deleteFlowRun(flowRunId)
     } catch (error) {
-      const message = getApiErrorMessage(error, localization.error.delete('Flow Run'))
-      showToast(message, 'error')
+      if (retries < 2) {
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        return deleteFlowRun(flowRunId, retries + 1)
+      }
+
+      throw error
     }
   }
 </script>


### PR DESCRIPTION
# Description
Adds some retrying to the flow run delete modal and updates the confirm delete modal to use defineModal. 

Closes https://github.com/PrefectHQ/prefect/issues/16102