### PR TITLE
Bugfix: Wrap array example placeholders in quotes

### DIFF
--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -107,18 +107,11 @@ export function getSchemaPropertyPlaceholder(property: SchemaProperty): string |
   }
 
   if (typeof placeholder === 'string') {
-    if (property.format === 'json-string') {
-      return `"${placeholder}"`
-    }
     return placeholder
   }
 
   if (isArray(placeholder) && property.meta?.component !== JsonInput) {
-    if (property.format === 'json-string') {
-      return `"${placeholder.join(', ')}"`
-    }
-
-    return placeholder.join(', ')
+    return `"${placeholder.join(', ')}"`
   }
 
   return stringify(placeholder)

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -107,10 +107,17 @@ export function getSchemaPropertyPlaceholder(property: SchemaProperty): string |
   }
 
   if (typeof placeholder === 'string') {
+    if (property.format === 'json-string') {
+      return `"${placeholder}"`
+    }
     return placeholder
   }
 
   if (isArray(placeholder) && property.meta?.component !== JsonInput) {
+    if (property.format === 'json-string') {
+      return `"${placeholder.join(', ')}"`
+    }
+
     return placeholder.join(', ')
   }
 


### PR DESCRIPTION
Should fix the confusing state of examples for json-string formatted properties being invalid as-written.

Before:

![image](https://github.com/user-attachments/assets/fb1c71b8-b11b-4dfe-b480-059528bdc343)

![image](https://github.com/user-attachments/assets/3e273384-9f9c-4f86-a132-5cc91bcb3331)

After:

<img width="672" alt="image" src="https://github.com/user-attachments/assets/60c60dd9-ba26-482f-846f-7640d9141c6c">
