### PR TITLE
Enhancement: Work pool name validation rule

### DIFF
--- a/src/components/WorkPoolCreateWizardStepInformation.vue
+++ b/src/components/WorkPoolCreateWizardStepInformation.vue
@@ -50,6 +50,10 @@
   const { defineValidate } = useWizardStep()
   const { validate } = useValidationObserver()
   const { state, error } = useValidation(name, 'Work pool name', value => {
+    if (value?.toLowerCase().startsWith('prefect')) {
+      return 'Name cannot start with "prefect"'
+    }
+
     if (value) {
       return true
     }

--- a/src/components/WorkPoolCreateWizardStepInformation.vue
+++ b/src/components/WorkPoolCreateWizardStepInformation.vue
@@ -51,7 +51,7 @@
   const { validate } = useValidationObserver()
   const { state, error } = useValidation(name, 'Work pool name', value => {
     if (value?.toLowerCase().startsWith('prefect')) {
-      return 'Name cannot start with "prefect"'
+      return 'Work pools starting with "prefect" are reserved for internal use.'
     }
 
     if (value) {


### PR DESCRIPTION
Short cuts an existing API-side validation rule by surfacing the internal name restriction directly in the work pool creation form.

<img width="2476" alt="Screenshot 2024-12-08 at 7 33 29 PM" src="https://github.com/user-attachments/assets/c680a880-0cc8-49a3-9d76-86e3f2d5ae4d">
