### PR TITLE
Fix FlowRunMenu components subscribing to the flow run multiple times

### DIFF
--- a/src/components/FlowRunCancelButton.vue
+++ b/src/components/FlowRunCancelButton.vue
@@ -17,8 +17,8 @@
 
   <FlowRunCancelModal
     v-model:showModal="showModal"
-    :flow-run-id="flowRun.id"
-    @change="showModal"
+    :flow-run="flowRun"
+    @update="emit('update')"
   />
 </template>
 
@@ -34,22 +34,24 @@
     inheritAttrs: false,
   })
 
-  const props = defineProps<{
+  const { flowRun } = defineProps<{
     flowRun: FlowRun,
   }>()
+
+  const emit = defineEmits(['update'])
 
   const can = useCan()
   const { showModal, open } = useShowModal()
 
   const canCancel = computed(() => {
-    if (!can.update.flow_run || !props.flowRun.stateType) {
+    if (!can.update.flow_run || !flowRun.stateType) {
       return false
     }
-    return isStuckStateType(props.flowRun.stateType)
+    return isStuckStateType(flowRun.stateType)
   })
 
   const disableCancel = computed(() => {
-    if (!props.flowRun.deploymentId && canCancel.value) {
+    if (!flowRun.deploymentId && canCancel.value) {
       return true
     }
     return false

--- a/src/components/FlowRunResumeButton.vue
+++ b/src/components/FlowRunResumeButton.vue
@@ -3,7 +3,7 @@
     Resume
   </p-button>
 
-  <FlowRunResumeModal v-model:showModal="showModal" :flow-run-id="flowRun.id" />
+  <FlowRunResumeModal v-model:showModal="showModal" :flow-run @update="emit('update')" />
 </template>
 
   <script lang="ts" setup>
@@ -17,19 +17,21 @@
     inheritAttrs: false,
   })
 
-  const props = defineProps<{
+  const { flowRun } = defineProps<{
     flowRun: FlowRun,
   }>()
+
+  const emit = defineEmits(['update'])
 
   const attrs = useAttrs()
   const can = useCan()
   const { showModal, open } = useShowModal()
 
   const canResume = computed(() => {
-    if (!can.update.flow_run || !props.flowRun.stateType) {
+    if (!can.update.flow_run || !flowRun.stateType) {
       return false
     }
 
-    return isPausedStateType(props.flowRun.stateType)
+    return isPausedStateType(flowRun.stateType)
   })
   </script>

--- a/src/components/FlowRunRetryButton.vue
+++ b/src/components/FlowRunRetryButton.vue
@@ -9,7 +9,8 @@
     <FlowRunRetryModal
       v-model:showModal="showModal"
       v-model:retryingRun="retryingRun"
-      :flow-run="flowRun"
+      :flow-run
+      @update="emit('update')"
     />
   </p-button>
 </template>
@@ -21,19 +22,21 @@
   import { useShowModal } from '@/compositions/useShowModal'
   import { FlowRun, isTerminalStateType } from '@/models'
 
-  const props = defineProps<{
+  const { flowRun } = defineProps<{
     flowRun: FlowRun,
   }>()
+
+  const emit = defineEmits(['update'])
 
   const can = useCan()
   const { showModal, open } = useShowModal()
 
   const canRetry = computed(() => {
-    if (!can.update.flow_run || !props.flowRun.stateType || !props.flowRun.deploymentId) {
+    if (!can.update.flow_run || !flowRun.stateType || !flowRun.deploymentId) {
       return false
     }
 
-    return isTerminalStateType(props.flowRun.stateType)
+    return isTerminalStateType(flowRun.stateType)
   })
 
   const retryingRun = ref(false)

--- a/src/components/FlowRunSuspendButton.vue
+++ b/src/components/FlowRunSuspendButton.vue
@@ -7,8 +7,8 @@
     Suspend
     <FlowRunSuspendModal
       v-model:showModal="showModal"
-      :flow-run-id="flowRun.id"
-      @change="showModal"
+      :flow-run="flowRun"
+      @update="emit('update')"
     />
   </p-button>
 </template>
@@ -19,18 +19,20 @@
   import { useCan, useShowModal } from '@/compositions'
   import { FlowRun, isRunningStateType } from '@/models'
 
-  const props = defineProps<{
+  const { flowRun } = defineProps<{
     flowRun: FlowRun,
   }>()
+
+  const emit = defineEmits(['update'])
 
   const can = useCan()
   const { showModal, open } = useShowModal()
 
   const canSuspend = computed(() => {
-    if (!can.update.flow_run || !props.flowRun.stateType || !props.flowRun.deploymentId) {
+    if (!can.update.flow_run || !flowRun.stateType || !flowRun.deploymentId) {
       return false
     }
 
-    return isRunningStateType(props.flowRun.stateType)
+    return isRunningStateType(flowRun.stateType)
   })
 </script>

--- a/src/components/PageHeadingFlowRun.vue
+++ b/src/components/PageHeadingFlowRun.vue
@@ -33,10 +33,10 @@
     <template #actions>
       <template v-if="flowRun">
         <template v-if="media.sm">
-          <FlowRunSuspendButton :flow-run />
-          <FlowRunResumeButton :flow-run />
-          <FlowRunRetryButton :flow-run />
-          <FlowRunCancelButton :flow-run />
+          <FlowRunSuspendButton :flow-run @update="refresh" />
+          <FlowRunResumeButton :flow-run @update="refresh" />
+          <FlowRunRetryButton :flow-run @update="refresh" />
+          <FlowRunCancelButton :flow-run @update="refresh" />
         </template>
         <FlowRunMenu :flow-run :show-all="!media.sm" @delete="emit('delete')" />
       </template>
@@ -75,9 +75,7 @@
 
   const routes = useWorkspaceRoutes()
 
-  const emit = defineEmits<{
-    (event: 'delete'): void,
-  }>()
+  const emit = defineEmits(['delete'])
 
   // It doesn't seem like we should need to coalesce here but
   // the flow run model dictates the flow run name can be null
@@ -86,7 +84,7 @@
     { text: flowRun.value?.name ?? '' },
   ])
 
-  const { flowRun } = useFlowRun(() => props.flowRunId, { interval: 30_000 })
+  const { flowRun, subscription } = useFlowRun(() => props.flowRunId, { interval: 30_000 })
 
   const isPending = computed(() => flowRun.value?.stateType ? isPendingStateType(flowRun.value.stateType) : true)
 
@@ -95,6 +93,10 @@
       id: [props.flowRunId],
     },
   }))
+
+  function refresh(): void {
+    subscription.refresh()
+  }
 </script>
 
 <style>


### PR DESCRIPTION
# Description
The `FlowRunMenu` component accepts a `FlowRun` but some of the modal components accepts just the id and then created their own subscriptions. We already have events set up for things like refreshing so there isn't any reason these component should do their own subscribing. 

This was causing api request spam on the new runs page in cloud because for some reason the batch processor wasn't grouping the requests together (likely due to slightly different intervals due to a rendering waterfall). 