### PR TITLE
Fix: Flow run delete modal stuck in loading state after first time deleting runs

### DIFF
--- a/src/components/FlowRunsDeleteButton.vue
+++ b/src/components/FlowRunsDeleteButton.vue
@@ -59,6 +59,7 @@
       return
     }
 
+    loading.value = false
     showToast(toastMessage, 'success')
     emit('delete')
     close()


### PR DESCRIPTION
# Description
Loading state was never turned off when closing the modal so it would be stuck in the loading state. 