### PR TITLE
Disable input on update mode

### DIFF
--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -4,8 +4,8 @@
       General
     </h3>
 
-    <p-label label="Name" :state="nameState" :message="nameError" :disabled="mode === 'update'">
-      <p-text-input v-model="name" />
+    <p-label label="Name" :state="nameState" :message="nameError">
+      <p-text-input v-model="name" :disabled="mode === 'update'" />
     </p-label>
 
     <p-label label="Description (Optional)">


### PR DESCRIPTION
The disabled attribute was on the label and not the input. Moving it down to the input added the expected behavior.

<img width="1260" alt="image" src="https://github.com/user-attachments/assets/1462207c-a6eb-4f3a-a7e9-7fe440533457" />
