### PR TITLE
Add context for notification actions

### DIFF
--- a/src/automations/components/AutomationActionDescription.vue
+++ b/src/automations/components/AutomationActionDescription.vue
@@ -7,13 +7,13 @@
 <script lang="ts" setup>
   import { computed } from 'vue'
   import AutomationActionDescriptionChangeFlowRunState from '@/automations/components/AutomationActionDescriptionChangeFlowRunState.vue'
-  import AutomationActionDescriptionDefault from '@/automations/components/AutomationActionDescriptionDefault.vue'
   import AutomationActionDescriptionPauseResumeAutomation from '@/automations/components/AutomationActionDescriptionPauseResumeAutomation.vue'
   import AutomationActionDescriptionPauseResumeDeployment from '@/automations/components/AutomationActionDescriptionPauseResumeDeployment.vue'
   import AutomationActionDescriptionPauseResumeWorkPool from '@/automations/components/AutomationActionDescriptionPauseResumeWorkPool.vue'
   import AutomationActionDescriptionPauseResumeWorkQueue from '@/automations/components/AutomationActionDescriptionPauseResumeWorkQueue.vue'
   import AutomationActionDescriptionResumeFlowRun from '@/automations/components/AutomationActionDescriptionResumeFlowRun.vue'
   import AutomationActionDescriptionRunDeployment from '@/automations/components/AutomationActionDescriptionRunDeployment.vue'
+  import AutomationActionSendNotification from '@/automations/components/AutomationActionDescriptionSendNotification.vue'
   import AutomationActionDescriptionSuspendCancelFlowRun from '@/automations/components/AutomationActionDescriptionSuspendCancelFlowRun.vue'
   import { AutomationAction } from '@/automations/types/actions'
   import { withProps } from '@/utilities'
@@ -62,7 +62,7 @@
           action: props.action,
         })
       case 'send-notification':
-        return withProps(AutomationActionDescriptionDefault, {
+        return withProps(AutomationActionSendNotification, {
           action: props.action,
         })
 

--- a/src/automations/components/AutomationActionDescriptionSendNotification.vue
+++ b/src/automations/components/AutomationActionDescriptionSendNotification.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="automation-action-description-send-notification">
+    Send {{ indefiniteArticle() }} {{ blockDocument?.blockType.name.toLocaleLowerCase() ?? '' }} notification using
+    <BlockIconText :block-document-id="action.blockDocumentId" />
+    {{ recipients }}
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { AutomationActionSendNotification } from '@/automations/types/actions'
+  import { BlockIconText } from '@/components'
+  import { useBlockDocument } from '@/compositions'
+
+  const props = defineProps<{
+    action: AutomationActionSendNotification,
+  }>()
+
+  const { blockDocument } = useBlockDocument(() => props.action.blockDocumentId)
+
+  const indefiniteArticle = (): string => {
+    return ['a', 'e', 'i', 'o', 'u'].includes(blockDocument.value?.blockType.name[0].toLowerCase() ?? '') ? 'an' : 'a'
+  }
+
+  const recipients = computed(() => {
+    if (blockDocument.value?.blockType.name === 'Email') {
+      try {
+        return `to ${JSON.parse(blockDocument.value.data.emails as string).join(', ')}`
+      } catch (error) {
+        return ''
+      }
+    }
+    return ''
+  })
+</script>
+
+<style>
+.automation-action-description-send-notification { @apply
+  flex
+  flex-wrap
+  gap-2
+  items-center
+}
+</style>


### PR DESCRIPTION
Added a description component for notification actions. 

Will conditionally parse email recipients and display as well

<img width="501" alt="image" src="https://github.com/user-attachments/assets/221a4168-442a-4a78-acfa-494c5f41479b" />

<img width="551" alt="image" src="https://github.com/user-attachments/assets/f0e6b4d0-5dd2-45d4-9699-0b6f8c31a7d3" />
