### PR TITLE
Add support for properties with "additionalProperties" to schemas v1

### DIFF
--- a/src/components/SchemaFormPropertyAnyOf.vue
+++ b/src/components/SchemaFormPropertyAnyOf.vue
@@ -7,7 +7,11 @@
     <p-button-group v-model="selected" :options="options" small />
 
     <p-label class="schema-form-property-any-of__fields p-background" :description="description">
-      <template v-if="isObject">
+      <template v-if="displayedDefinition.meta && displayedDefinition.meta.component">
+        <SchemaFormProperty :property="displayedDefinition" :prop-key="propKey" />
+      </template>
+
+      <template v-else-if="isObject">
         <p-content>
           <template v-for="(subProperty, key) in displayedDefinition.properties" :key="key">
             <SchemaFormProperty :prop-key="`${propKey}.${key}`" :property="subProperty!" />

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -280,6 +280,13 @@ function findObjectDefinitionIndex(definitions: Schema[], value: object | null):
   }, [0, 0])
 
   if (keysInCommon === 0) {
+    const indexOfDefinitionWithAdditionalProperties = definitions.findIndex(definition => definition.additionalProperties)
+
+    // Since we were unable to find a definition with a matching set of keys, we'll use the definition with additionalProperties if one exists.
+    if (indexOfDefinitionWithAdditionalProperties !== -1) {
+      return indexOfDefinitionWithAdditionalProperties
+    }
+
     return null
   }
 

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -69,6 +69,7 @@ export type SchemaProperty = {
   multipleOf?: number,
   pattern?: string,
   properties?: SchemaProperties,
+  additionalProperties?: SchemaProperty | boolean,
   required?: string[],
   title?: string,
   type?: SchemaType,


### PR DESCRIPTION
# Description
Makes sure that if a property schema has "additionalProperties" defined that they are not stripped from the mapped value. Falls back to using a json input if no more specific input can be determined (even if the input is type object)