### PR TITLE
Update block document properties to look at `examples` in addition to `example`

### DIFF
--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -100,7 +100,7 @@ export function getSchemaPropertyAttrs(property: SchemaProperty): SchemaProperty
 }
 
 export function getSchemaPropertyPlaceholder(property: SchemaProperty): string | undefined {
-  const placeholder = property.default ?? property.example
+  const placeholder = property.default ?? property.example ?? property.examples?.at(0)
 
   if (!placeholder) {
     return undefined

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -52,6 +52,9 @@ export type SchemaProperty = {
   anyOf?: Schema[],
   allOf?: Schema[],
   example?: string,
+  // swagger says this should be an object, but our block schemas are string[] currently
+  // https://swagger.io/docs/specification/v3_0/adding-examples/
+  examples?: string[],
   alias?: string,
   default?: unknown,
   description?: string,


### PR DESCRIPTION
# Description
As of today many block document schemas were updated and have `examples: string[]` rather than `example: string`. I'm not confident that `string[]` is even valid based on [swagger.io's docs](https://swagger.io/docs/specification/v3_0/adding-examples/) which say it should be a record. But this should get examples showing again. 