### PR TITLE
[Feature] Allow the specification of parameter overrides per schedule

### DIFF
--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -120,19 +120,19 @@
 </template>
 
 <script lang="ts" setup>
-  import { showToast } from '@prefecthq/prefect-design'
-  import { computed } from 'vue'
-  import { AutomationAction, CreateAutomationQuery } from '..'
   import AutomationIconText from '@/automations/components/AutomationIconText.vue'
-  import { BlockIconText, DeploymentStatusBadge, DeploymentSchedulesFieldset } from '@/components'
+  import { BlockIconText, DeploymentSchedulesFieldset, DeploymentStatusBadge } from '@/components'
   import DeploymentServiceLevelAgreementCard from '@/components/DeploymentServiceLevelAgreementCard.vue'
   import DeploymentToggle from '@/components/DeploymentToggle.vue'
   import FormattedDate from '@/components/FormattedDate.vue'
-  import { useWorkspaceApi, useCan, useWorkspaceRoutes } from '@/compositions'
+  import { useCan, useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { useAutomationsByRelatedResource } from '@/compositions/useAutomationsByRelatedResource'
   import { localization } from '@/localization'
   import { Deployment, DeploymentScheduleCompatible } from '@/models'
   import { ServiceLevelAgreement } from '@/models/ServiceLevelAgreement'
+  import { showToast } from '@prefecthq/prefect-design'
+  import { computed } from 'vue'
+  import { AutomationAction, CreateAutomationQuery } from '..'
 
   const props = defineProps<{
     deployment: Deployment,
@@ -154,7 +154,12 @@
     }
 
     try {
-      await api.deploymentSchedules.createDeploymentSchedule(props.deployment.id, { active: updatedSchedule.active, schedule: updatedSchedule.schedule, jobVariables: updatedSchedule.jobVariables, parameters: updatedSchedule.parameters })
+      await api.deploymentSchedules.createDeploymentSchedule(props.deployment.id, {
+        active: updatedSchedule.active,
+        schedule: updatedSchedule.schedule,
+        jobVariables: updatedSchedule.jobVariables,
+        parameters: updatedSchedule.parameters,
+      })
       showToast(localization.success.updateDeploymentSchedule, 'success')
       emit('update')
     } catch (error) {

--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -154,7 +154,7 @@
     }
 
     try {
-      await api.deploymentSchedules.createDeploymentSchedule(props.deployment.id, { active: updatedSchedule.active, schedule: updatedSchedule.schedule, jobVariables: updatedSchedule.jobVariables })
+      await api.deploymentSchedules.createDeploymentSchedule(props.deployment.id, { active: updatedSchedule.active, schedule: updatedSchedule.schedule, jobVariables: updatedSchedule.jobVariables, parameters: updatedSchedule.parameters })
       showToast(localization.success.updateDeploymentSchedule, 'success')
       emit('update')
     } catch (error) {

--- a/src/components/DeploymentScheduleMenu.vue
+++ b/src/components/DeploymentScheduleMenu.vue
@@ -52,7 +52,7 @@
 
   const scheduleFormModalRef = ref<ScheduleFormModalMethods | null>(null)
 
-  const parameters = computed(() => props.schedule.parameters ?? props.deployment.parameters)
+  const parameters = computed(() => props.schedule.parameters ?? {})
 
   const openEditModal = (): void => {
     scheduleFormModalRef.value?.publicOpen?.()
@@ -71,7 +71,16 @@
     }
 
     try {
-      await api.deploymentSchedules.updateDeploymentSchedule(props.deployment.id, props.schedule.id, { active: updatedSchedule.active, schedule: updatedSchedule.schedule, jobVariables: updatedSchedule.jobVariables })
+      await api.deploymentSchedules.updateDeploymentSchedule(
+        props.deployment.id,
+        props.schedule.id,
+        {
+          active: updatedSchedule.active,
+          schedule: updatedSchedule.schedule,
+          jobVariables: updatedSchedule.jobVariables,
+          parameters: updatedSchedule.parameters,
+        },
+      )
       showToast(localization.success.updateDeploymentSchedule, 'success')
       emit('update', updatedSchedule)
     } catch (error) {

--- a/src/components/DeploymentScheduleMenu.vue
+++ b/src/components/DeploymentScheduleMenu.vue
@@ -8,9 +8,9 @@
   <ScheduleFormModal
     ref="scheduleFormModalRef"
     v-bind="schedule"
-    :parameters="parameters"
+    :deployment-parameters="deployment.parameters"
+    :schedule-parameters="schedule.parameters"
     :parameter-open-api-schema="deployment.parameterOpenApiSchema"
-    :enforce-parameter-schema="deployment.enforceParameterSchema"
     @submit="updateSchedule"
   />
 
@@ -51,8 +51,6 @@
   const { showModal: showConfirmDeleteModal, open: openConfirmDeleteModal, close: closeConfirmDeleteModal } = useShowModal()
 
   const scheduleFormModalRef = ref<ScheduleFormModalMethods | null>(null)
-
-  const parameters = computed(() => props.schedule.parameters ?? {})
 
   const openEditModal = (): void => {
     scheduleFormModalRef.value?.publicOpen?.()

--- a/src/components/DeploymentScheduleMenu.vue
+++ b/src/components/DeploymentScheduleMenu.vue
@@ -5,7 +5,14 @@
     <p-overflow-menu-item v-if="deployment.can.delete" label="Delete" @click="openConfirmDeleteModal" />
   </p-icon-button-menu>
 
-  <ScheduleFormModal ref="scheduleFormModalRef" v-bind="schedule" @submit="updateSchedule" />
+  <ScheduleFormModal
+    ref="scheduleFormModalRef"
+    v-bind="schedule"
+    :parameters="parameters"
+    :parameter-open-api-schema="deployment.parameterOpenApiSchema"
+    :enforce-parameter-schema="deployment.enforceParameterSchema"
+    @submit="updateSchedule"
+  />
 
   <ConfirmDeleteModal
     v-model:showModal="showConfirmDeleteModal"
@@ -16,14 +23,14 @@
 </template>
 
 <script lang="ts" setup>
-  import { showToast } from '@prefecthq/prefect-design'
-  import { ref } from 'vue'
   import { ConfirmDeleteModal, CopyOverflowMenuItem, ScheduleFormModal } from '@/components'
   import { ScheduleFormModalMethods } from '@/components/ScheduleFormModal.vue'
-  import { useWorkspaceApi, useShowModal } from '@/compositions'
+  import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
   import { Deployment, DeploymentSchedule, DeploymentScheduleCompatible } from '@/models'
   import { deleteItem } from '@/utilities'
+  import { showToast } from '@prefecthq/prefect-design'
+  import { computed, ref } from 'vue'
 
   defineOptions({
     inheritAttrs: false,
@@ -44,6 +51,8 @@
   const { showModal: showConfirmDeleteModal, open: openConfirmDeleteModal, close: closeConfirmDeleteModal } = useShowModal()
 
   const scheduleFormModalRef = ref<ScheduleFormModalMethods | null>(null)
+
+  const parameters = computed(() => props.schedule.parameters ?? props.deployment.parameters)
 
   const openEditModal = (): void => {
     scheduleFormModalRef.value?.publicOpen?.()

--- a/src/components/DeploymentSchedulesFieldset.vue
+++ b/src/components/DeploymentSchedulesFieldset.vue
@@ -4,7 +4,16 @@
       <DeploymentScheduleCard :deployment="deployment" :deployment-schedule="deploymentSchedule" @update="emits('update')" />
     </template>
 
-    <ScheduleFormModal v-if="deployment.can.update" :active="null" :schedule="null" :job-variables="{}" @submit="createSchedule">
+    <ScheduleFormModal
+      v-if="deployment.can.update"
+      :active="null"
+      :schedule="null"
+      :job-variables="{}"
+      :parameters="deployment.parameters"
+      :parameter-open-api-schema="deployment.parameterOpenApiSchema"
+      :enforce-parameter-schema="deployment.enforceParameterSchema"
+      @submit="createSchedule"
+    >
       <template #default="{ open }">
         <p-button size="sm" icon="PlusIcon" :disabled="deployment.disabled" @click="open">
           Schedule

--- a/src/components/DeploymentSchedulesFieldset.vue
+++ b/src/components/DeploymentSchedulesFieldset.vue
@@ -9,7 +9,8 @@
       :active="null"
       :schedule="null"
       :job-variables="{}"
-      :parameters="{}"
+      :deployment-parameters="deployment.parameters"
+      :schedule-parameters="{}"
       :parameter-open-api-schema="deployment.parameterOpenApiSchema"
       @submit="createSchedule"
     >

--- a/src/components/DeploymentSchedulesFieldset.vue
+++ b/src/components/DeploymentSchedulesFieldset.vue
@@ -9,9 +9,8 @@
       :active="null"
       :schedule="null"
       :job-variables="{}"
-      :parameters="deployment.parameters"
+      :parameters="{}"
       :parameter-open-api-schema="deployment.parameterOpenApiSchema"
-      :enforce-parameter-schema="deployment.enforceParameterSchema"
       @submit="createSchedule"
     >
       <template #default="{ open }">

--- a/src/components/ScheduleFieldset.vue
+++ b/src/components/ScheduleFieldset.vue
@@ -12,7 +12,6 @@
           :job-variables="{}"
           :parameters="{}"
           :parameter-open-api-schema="{}"
-          :enforce-parameter-schema="null"
           @submit="updateSchedule"
         >
           <template #default="{ open }">

--- a/src/components/ScheduleFieldset.vue
+++ b/src/components/ScheduleFieldset.vue
@@ -6,7 +6,15 @@
 
     <template v-if="!readonly">
       <div class="schedule-fieldset__buttons">
-        <ScheduleFormModal :active="null" :schedule="internalValue" :job-variables="{}" @submit="updateSchedule">
+        <ScheduleFormModal
+          :active="null"
+          :schedule="internalValue"
+          :job-variables="{}"
+          :parameters="{}"
+          :parameter-open-api-schema="{}"
+          :enforce-parameter-schema="null"
+          @submit="updateSchedule"
+        >
           <template #default="{ open }">
             <p-button size="sm" icon="PencilIcon" class="schedule-fieldset__button" :disabled="loading" @click="open">
               {{ internalValue ? 'Edit' : 'Add' }}
@@ -30,9 +38,9 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
   import ScheduleFormModal from '@/components/ScheduleFormModal.vue'
   import { DeploymentScheduleCompatible, Schedule } from '@/models'
+  import { computed } from 'vue'
 
   const props = defineProps<{
     modelValue: Schedule | null,

--- a/src/components/ScheduleFieldset.vue
+++ b/src/components/ScheduleFieldset.vue
@@ -10,7 +10,8 @@
           :active="null"
           :schedule="internalValue"
           :job-variables="{}"
-          :parameters="{}"
+          :deployment-parameters="{}"
+          :schedule-parameters="{}"
           :parameter-open-api-schema="{}"
           @submit="updateSchedule"
         >

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -150,6 +150,7 @@ export const en = {
     artifacts: 'Artifacts',
     artifactsEmptyState: 'Artifacts are byproducts of your runs; they can be anything from a markdown string to a table.',
     parameters: 'Parameters',
+    parameterOverrides: 'Parameter Overrides',
     addTagPlaceholder: 'Add tag (press enter to submit)',
     descriptionPlaceholder: 'Add a description (supports Markdown)',
     parentRun: 'Parent Run',

--- a/src/maps/deploymentSchedule.ts
+++ b/src/maps/deploymentSchedule.ts
@@ -1,5 +1,5 @@
-import { DeploymentScheduleResponse } from '@/models/api/DeploymentScheduleResponse'
 import { DeploymentSchedule } from '@/models/DeploymentSchedule'
+import { DeploymentScheduleResponse } from '@/models/api/DeploymentScheduleResponse'
 import { MapFunction } from '@/services/Mapper'
 
 export const mapDeploymentScheduleResponseToDeploymentSchedule: MapFunction<DeploymentScheduleResponse, DeploymentSchedule> = function(source) {
@@ -10,5 +10,6 @@ export const mapDeploymentScheduleResponseToDeploymentSchedule: MapFunction<Depl
     active: source.active,
     schedule: this.map('ScheduleResponse', source.schedule, 'Schedule'),
     jobVariables: source.job_variables ?? {},
+    parameters: source.parameters ?? {},
   })
 }

--- a/src/maps/deploymentScheduleCreate.ts
+++ b/src/maps/deploymentScheduleCreate.ts
@@ -1,5 +1,5 @@
-import { DeploymentScheduleCreateRequest } from '@/models/api/DeploymentScheduleCreateRequest'
 import { DeploymentScheduleCreate } from '@/models/DeploymentScheduleCreate'
+import { DeploymentScheduleCreateRequest } from '@/models/api/DeploymentScheduleCreateRequest'
 import { MapFunction } from '@/services/Mapper'
 
 export const mapDeploymentScheduleCreateToDeploymentScheduleCreateRequest: MapFunction<DeploymentScheduleCreate, DeploymentScheduleCreateRequest> = function(source) {
@@ -7,5 +7,6 @@ export const mapDeploymentScheduleCreateToDeploymentScheduleCreateRequest: MapFu
     active: source.active,
     schedule: this.map('Schedule', source.schedule, 'ScheduleRequest'),
     job_variables: source.jobVariables,
+    parameters: source.parameters,
   }
 }

--- a/src/maps/deploymentScheduleUpdate.ts
+++ b/src/maps/deploymentScheduleUpdate.ts
@@ -7,5 +7,6 @@ export const mapDeploymentScheduleUpdateToDeploymentScheduleUpdateRequest: MapFu
     active: source.active,
     schedule: this.map('Schedule', source.schedule, 'ScheduleRequest'),
     job_variables: source.jobVariables,
+    parameters: source.parameters,
   }
 }

--- a/src/mocks/deploymentSchedule.ts
+++ b/src/mocks/deploymentSchedule.ts
@@ -14,6 +14,7 @@ export const randomDeploymentSchedules: MockFunction<DeploymentSchedule[], [Part
       active: random() > 0.25,
       schedule: this.create('schedule'),
       jobVariables: {},
+      parameters: {},
       ...overrides,
     }
   }

--- a/src/models/DeploymentSchedule.ts
+++ b/src/models/DeploymentSchedule.ts
@@ -1,5 +1,5 @@
-import { Schedule } from '@/models/Schedule'
-
+import type { Schedule } from '@/models/Schedule'
+import type { SchemaValuesV2 } from '@/schemas'
 
 export interface IDeploymentSchedule {
   id: string,
@@ -8,6 +8,7 @@ export interface IDeploymentSchedule {
   active: boolean,
   schedule: Schedule,
   jobVariables: Record<string, unknown>,
+  parameters: SchemaValuesV2 | null,
 }
 
 export class DeploymentSchedule implements IDeploymentSchedule {
@@ -17,6 +18,7 @@ export class DeploymentSchedule implements IDeploymentSchedule {
   public active: boolean
   public schedule: Schedule
   public jobVariables: Record<string, unknown>
+  public parameters: SchemaValuesV2 | null
 
   public constructor(deploymentSchedule: IDeploymentSchedule) {
     this.id = deploymentSchedule.id
@@ -25,6 +27,7 @@ export class DeploymentSchedule implements IDeploymentSchedule {
     this.active = deploymentSchedule.active
     this.schedule = deploymentSchedule.schedule
     this.jobVariables = deploymentSchedule.jobVariables
+    this.parameters = deploymentSchedule.parameters
   }
 
 }

--- a/src/models/DeploymentScheduleCompatible.ts
+++ b/src/models/DeploymentScheduleCompatible.ts
@@ -1,7 +1,9 @@
-import { Schedule } from '@/models/Schedule'
+import type { Schedule } from '@/models/Schedule'
+import type { SchemaValuesV2 } from '@/schemas'
 
 export type DeploymentScheduleCompatible = {
   active: boolean | null,
   schedule: Schedule | null,
   jobVariables: Record<string, unknown> | undefined,
+  parameters: SchemaValuesV2,
 }

--- a/src/models/DeploymentScheduleCompatible.ts
+++ b/src/models/DeploymentScheduleCompatible.ts
@@ -5,5 +5,5 @@ export type DeploymentScheduleCompatible = {
   active: boolean | null,
   schedule: Schedule | null,
   jobVariables: Record<string, unknown> | undefined,
-  parameters: SchemaValuesV2,
+  parameters?: SchemaValuesV2,
 }

--- a/src/models/DeploymentScheduleCreate.ts
+++ b/src/models/DeploymentScheduleCreate.ts
@@ -1,7 +1,9 @@
-import { Schedule } from '@/models/Schedule'
+import type { Schedule } from '@/models/Schedule'
+import type { SchemaValuesV2 } from '@/schemas'
 
 export type DeploymentScheduleCreate = {
   active: boolean,
   schedule: Schedule,
   jobVariables?: Record<string, unknown>,
+  parameters?: SchemaValuesV2,
 }

--- a/src/models/DeploymentScheduleUpdate.ts
+++ b/src/models/DeploymentScheduleUpdate.ts
@@ -1,7 +1,9 @@
 import { Schedule } from '@/models/Schedule'
+import { SchemaValuesV2 } from '@/schemas'
 
 export type DeploymentScheduleUpdate = {
   active?: boolean,
   schedule?: Schedule,
   jobVariables?: Record<string, unknown>,
+  parameters?: SchemaValuesV2,
 }

--- a/src/models/api/DeploymentScheduleCreateRequest.ts
+++ b/src/models/api/DeploymentScheduleCreateRequest.ts
@@ -1,7 +1,8 @@
 import { ScheduleResponse } from '@/models'
-
+import { SchemaValuesV2 } from '@/schemas'
 export type DeploymentScheduleCreateRequest = {
   active: boolean,
   schedule: ScheduleResponse,
   job_variables?: Record<string, unknown>,
+  parameters?: SchemaValuesV2,
 }

--- a/src/models/api/DeploymentScheduleResponse.ts
+++ b/src/models/api/DeploymentScheduleResponse.ts
@@ -1,5 +1,6 @@
-import { ScheduleResponse } from '@/models/api/ScheduleResponse'
-import { DateString } from '@/types/dates'
+import type { ScheduleResponse } from '@/models/api/ScheduleResponse'
+import type { SchemaValuesV2 } from '@/schemas'
+import type { DateString } from '@/types/dates'
 
 
 export type DeploymentScheduleResponse = {
@@ -9,4 +10,5 @@ export type DeploymentScheduleResponse = {
   active: boolean,
   schedule: ScheduleResponse,
   job_variables?: Record<string, unknown> | null,
+  parameters?: SchemaValuesV2 | null,
 }

--- a/src/models/api/DeploymentScheduleUpdateRequest.ts
+++ b/src/models/api/DeploymentScheduleUpdateRequest.ts
@@ -1,7 +1,9 @@
 import { ScheduleResponse } from '@/models'
+import { SchemaValuesV2 } from '@/schemas'
 
 export type DeploymentScheduleUpdateRequest = {
   active?: boolean,
   schedule?: ScheduleResponse,
   job_variables?: Record<string, unknown>,
+  parameters?: SchemaValuesV2,
 }


### PR DESCRIPTION
This PR updates the `ScheduleFormModal` to provide an input for parameter overrides for an individual schedule.

By default, schedules start with no overrides, but users can choose which parameters should be overridden. After choosing a parameter to override, the form will update to include fields for that parameter with the default value defined on the base deployment.

Here's what it looks like in action:


https://github.com/user-attachments/assets/7e971ccc-7a93-4748-bf0d-d82697681e26


Closes OSS-6191