### PR TITLE
[ Deployment versions ] Significantly narrow model fields

### DIFF
--- a/src/maps/deployment.ts
+++ b/src/maps/deployment.ts
@@ -117,7 +117,6 @@ function mapDeploymentConcurrencyOptionsToDeploymentApiConcurrencyOptions(source
   }
 }
 
-
 export const mapDeploymentVersionResponseToDeploymentVersion: MapFunction<DeploymentVersionResponse, DeploymentVersion> = function(source) {
   return new DeploymentVersion({
     id: source.id,
@@ -126,29 +125,19 @@ export const mapDeploymentVersionResponseToDeploymentVersion: MapFunction<Deploy
     updated: this.map('string', source.updated, 'Date'),
     updatedBy: this.map('CreatedOrUpdatedByResponse', source.updated_by, 'CreatedOrUpdatedBy'),
     name: source.name,
-    versionInfo: this.map('DeploymentVersionInfoResponse', source.version_info, 'DeploymentVersionInfo'),
-    description: source.description,
-    flowId: source.flow_id,
     deploymentId: source.deployment_id,
-    paused: source.paused,
+    description: source.description,
+    versionInfo: this.map('DeploymentVersionInfoResponse', source.version_info, 'DeploymentVersionInfo'),
+    tags: source.tags ? sortStringArray(source.tags) : null,
+    labels: source.labels,
+    entrypoint: source.entrypoint,
+    pullSteps: source.pull_steps,
     parameters: source.parameters,
     parameterOpenApiSchema: schemaV2Mapper.map('SchemaResponse', source.parameter_openapi_schema ?? {}, 'Schema'),
-    tags: source.tags ? sortStringArray(source.tags) : null,
-    manifestPath: source.manifest_path,
-    path: source.path,
-    entrypoint: source.entrypoint,
-    storageDocumentId: source.storage_document_id,
-    infrastructureDocumentId: source.infrastructure_document_id,
     jobVariables: source.job_variables,
     workQueueName: source.work_queue_name,
     workPoolName: source.work_pool_name,
     enforceParameterSchema: source.enforce_parameter_schema,
-    pullSteps: source.pull_steps,
-    can: createObjectLevelCan(),
-    status: this.map('ServerDeploymentStatus', source.status, 'DeploymentStatus'),
-    disabled: source.disabled ?? false,
-    globalConcurrencyLimit: this.map('ConcurrencyV2LimitResponse', source.global_concurrency_limit, 'ConcurrencyV2Limit'),
-    concurrencyOptions: source.concurrency_options == null ? null : mapDeploymentApiConcurrencyOptionsToDeploymentConcurrencyOptions(source.concurrency_options),
   })
 }
 

--- a/src/models/DeploymentVersion.ts
+++ b/src/models/DeploymentVersion.ts
@@ -1,77 +1,70 @@
-import { ConcurrencyV2Limit } from '@/models/ConcurrencyV2Limit'
 import { CreatedOrUpdatedBy } from '@/models/CreatedOrUpdatedBy'
-import { DeploymentConcurrencyOptions, IDeployment } from '@/models/Deployment'
-import { DeploymentStatus } from '@/models/DeploymentStatus'
 import { DeploymentVersionInfo } from '@/models/DeploymentVersionInfo'
-import { ObjectLevelCan } from '@/models/ObjectLevelCan'
 import { SchemaValuesV2, SchemaV2 } from '@/schemas'
 
-export type IDeploymentVersion = Omit<IDeployment, 'versionId' | 'version' | 'schedules'> & {
+export type IDeploymentVersion = {
+  id: string,
+  created: Date,
+  createdBy: CreatedOrUpdatedBy | null,
+  updated: Date,
+  updatedBy: CreatedOrUpdatedBy | null,
+  name: string,
   deploymentId: string,
+  description: string | null,
   versionInfo: DeploymentVersionInfo,
+  tags: string[] | null,
+  labels: Record<string, string>,
+  entrypoint: string | null,
+  pullSteps: unknown,
+  parameters: SchemaValuesV2,
+  parameterOpenApiSchema: SchemaV2,
+  jobVariables: Record<string, unknown> | null,
+  workQueueName: string | null,
+  workPoolName: string | null,
+  enforceParameterSchema: boolean,
 }
 
 export class DeploymentVersion implements IDeploymentVersion {
   public readonly id: string
   public readonly deploymentId: string
   public readonly kind = 'deployment-version'
-  public created: Date
-  public createdBy: CreatedOrUpdatedBy | null
-  public updated: Date
-  public updatedBy: CreatedOrUpdatedBy | null
-  public name: string
-  public versionInfo: DeploymentVersionInfo
-  public description: string | null
-  public readonly flowId: string
-  public paused: boolean
-  public parameters: SchemaValuesV2
-  public parameterOpenApiSchema: SchemaV2
-  public tags: string[] | null
-  public manifestPath: string | null
-  public path: string | null
-  public entrypoint: string | null
-  public storageDocumentId: string | null
-  public infrastructureDocumentId: string | null
-  public jobVariables: Record<string, unknown> | null
-  public workQueueName: string | null
-  public workPoolName: string | null
-  public enforceParameterSchema: boolean
-  public pullSteps: unknown
-  public can: ObjectLevelCan<'deployment'>
-  public status: DeploymentStatus
-  public disabled: boolean
-  public globalConcurrencyLimit: ConcurrencyV2Limit | null
-  public concurrencyOptions: DeploymentConcurrencyOptions | null
+  public readonly created: Date
+  public readonly createdBy: CreatedOrUpdatedBy | null
+  public readonly updated: Date
+  public readonly updatedBy: CreatedOrUpdatedBy | null
+  public readonly name: string
+  public readonly description: string | null
+  public readonly versionInfo: DeploymentVersionInfo
+  public readonly tags: string[]
+  public readonly labels: Record<string, string>
+  public readonly entrypoint: string | null
+  public readonly pullSteps: unknown
+  public readonly parameters: SchemaValuesV2
+  public readonly parameterOpenApiSchema: SchemaV2
+  public readonly jobVariables: Record<string, unknown> | null
+  public readonly workQueueName: string | null
+  public readonly workPoolName: string | null
+  public readonly enforceParameterSchema: boolean
 
   public constructor(deploymentVersion: IDeploymentVersion) {
     this.id = deploymentVersion.id
     this.deploymentId = deploymentVersion.deploymentId
-    this.versionInfo = deploymentVersion.versionInfo
     this.created = deploymentVersion.created
     this.createdBy = deploymentVersion.createdBy
     this.updated = deploymentVersion.updated
     this.updatedBy = deploymentVersion.updatedBy
     this.name = deploymentVersion.name
     this.description = deploymentVersion.description
-    this.flowId = deploymentVersion.flowId
-    this.paused = deploymentVersion.paused
+    this.versionInfo = deploymentVersion.versionInfo
+    this.tags = deploymentVersion.tags ?? []
+    this.labels = deploymentVersion.labels
+    this.entrypoint = deploymentVersion.entrypoint
+    this.pullSteps = deploymentVersion.pullSteps
     this.parameters = deploymentVersion.parameters
     this.parameterOpenApiSchema = deploymentVersion.parameterOpenApiSchema
-    this.tags = deploymentVersion.tags
-    this.manifestPath = deploymentVersion.manifestPath
-    this.path = deploymentVersion.path
-    this.entrypoint = deploymentVersion.entrypoint
-    this.storageDocumentId = deploymentVersion.storageDocumentId
-    this.infrastructureDocumentId = deploymentVersion.infrastructureDocumentId
     this.jobVariables = deploymentVersion.jobVariables
     this.workQueueName = deploymentVersion.workQueueName
     this.workPoolName = deploymentVersion.workPoolName
     this.enforceParameterSchema = deploymentVersion.enforceParameterSchema
-    this.pullSteps = deploymentVersion.pullSteps
-    this.can = deploymentVersion.can
-    this.status = deploymentVersion.status
-    this.disabled = deploymentVersion.disabled
-    this.globalConcurrencyLimit = deploymentVersion.globalConcurrencyLimit
-    this.concurrencyOptions = deploymentVersion.concurrencyOptions
   }
 }

--- a/src/models/api/DeploymentVersionResponse.ts
+++ b/src/models/api/DeploymentVersionResponse.ts
@@ -31,3 +31,11 @@ export type DeploymentVersionResponse = {
   enforce_parameter_schema: boolean,
   pull_steps: unknown,
 }
+
+export type DeploymentVersionPaginationResponse = {
+  results: DeploymentVersionResponse[],
+  count: number,
+  limit: number,
+  pages: number,
+  page: number,
+}

--- a/src/models/api/DeploymentVersionResponse.ts
+++ b/src/models/api/DeploymentVersionResponse.ts
@@ -1,4 +1,6 @@
-import { DeploymentResponse } from '@/index'
+import { CreatedOrUpdatedByResponse } from '@/index'
+import { SchemaResponseV2, SchemaValuesV2 } from '@/schemas'
+import { DateString } from '@/types/dates'
 
 export type DeploymentVersionInfoResponse = {
   type: string,
@@ -8,7 +10,24 @@ export type DeploymentVersionInfoResponse = {
   url: string | null,
 } & Record<string, unknown>
 
-export type DeploymentVersionResponse = Omit<DeploymentResponse, 'version_id' | 'version'> & {
+export type DeploymentVersionResponse = {
+  id: string,
+  created: DateString,
+  created_by: CreatedOrUpdatedByResponse | null,
+  updated: DateString,
+  updated_by: CreatedOrUpdatedByResponse | null,
+  name: string,
   deployment_id: string,
+  description: string | null,
   version_info: DeploymentVersionInfoResponse,
+  parameters: SchemaValuesV2,
+  tags: string[] | null,
+  labels: Record<string, string>,
+  entrypoint: string | null,
+  parameter_openapi_schema: SchemaResponseV2 | null,
+  job_variables: Record<string, unknown> | null,
+  work_queue_name: string | null,
+  work_pool_name: string | null,
+  enforce_parameter_schema: boolean,
+  pull_steps: unknown,
 }


### PR DESCRIPTION
We realized we don't want to carry around un-versionable information so this removes the extension from the deployment model 

cc @devinvillarosa @chrisguidry 