### PR TITLE
BugFix: Refresh run subscription on quick run for runs with parameters

### DIFF
--- a/src/components/QuickRunParametersModal.vue
+++ b/src/components/QuickRunParametersModal.vue
@@ -39,7 +39,7 @@
   import { h, ref } from 'vue'
   import { useRouter } from 'vue-router'
   import { ToastFlowRunCreate } from '@/components'
-  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import { useWorkspaceApi, useWorkspaceRoutes, useNextFlowRun } from '@/compositions'
   import { localization } from '@/localization'
   import { Deployment, DeploymentFlowRunCreate } from '@/models'
   import { SchemaFormV2, SchemaValuesV2 } from '@/schemas'
@@ -59,6 +59,12 @@
   const enforceParameterSchema = ref(props.deployment.enforceParameterSchema)
   const parameters = ref<SchemaValuesV2>({ ...props.deployment.parameters })
 
+  const { subscription: nextRunSubscription } = useNextFlowRun(() => ({
+    deployments: {
+      id: [props.deployment.id],
+    },
+  }))
+
   async function submit(): Promise<void> {
     loading.value = true
 
@@ -73,7 +79,7 @@
 
     try {
       const flowRun = await api.deployments.createDeploymentFlowRun(props.deployment.id, values)
-
+      nextRunSubscription.refresh()
       const toastMessage = h(ToastFlowRunCreate, { flowRun, flowRunRoute: routes.flowRun, router, immediate: true })
       showToast(toastMessage, 'success')
     } catch (error) {


### PR DESCRIPTION
Currently the UI refreshes when a run is kicked off using quick run but that only works for runs with no parameters.  This PR updates the quick run parameter modal to add a subscription refresh so that the UI also updates for runs with parameters. This makes the behavior consistent across deployments and runs. 

Current behavior - no update so I can't see my new run

https://github.com/user-attachments/assets/3ab923f7-4e2e-4580-b1c5-df0bec80489e

Updated behavior

https://github.com/user-attachments/assets/51a7a065-4448-4422-835a-36c98de09665

