### PR TITLE
Bugfix: Ensure selected flows list is filtered on individual delete action

### DIFF
--- a/src/components/FlowList.vue
+++ b/src/components/FlowList.vue
@@ -64,7 +64,7 @@
 
       <template #action="{ row }">
         <div class="flow-list__action">
-          <FlowMenu size="xs" :flow="row" flat @delete="refresh" />
+          <FlowMenu size="xs" :flow="row" flat @delete="refresh(row.id)" />
         </div>
       </template>
 
@@ -188,8 +188,11 @@
 
   const selectedFlows = ref<Flow[]>([])
 
-  function refresh(): void {
-    subscription.refresh()
+  function refresh(flowId?: string): void {
+    if (flowId) {
+      selectedFlows.value = selectedFlows.value.filter(flow => flow.id !== flowId)
+    }
+ subscription.refresh()
   }
 
   const emit = defineEmits<{


### PR DESCRIPTION
Should fix an issue where the selection is never updated and further actions can't find the flow.