### PR TITLE
Fix PrefectHQ/prefect#17398: Fix JsonInput not updating when a space …

### DIFF
--- a/src/components/JsonInput.vue
+++ b/src/components/JsonInput.vue
@@ -15,7 +15,7 @@
    */
   import { ref, watch } from 'vue'
   import { stringify } from '@/utilities/json'
-  import { removeWhitespace } from '@/utilities/strings'
+  import { removeUnquotedWhitespace } from '@/utilities/strings'
 
   const props = defineProps<{
     minLines?: number,
@@ -43,7 +43,7 @@
   })
 
   function matches(valueA: string | undefined, valueB: string | undefined): boolean {
-    return removeWhitespace(valueA ?? '') === removeWhitespace(valueB ?? '')
+    return removeUnquotedWhitespace(valueA ?? '') === removeUnquotedWhitespace(valueB ?? '')
   }
 
   const format = (): void => {

--- a/src/utilities/strings.ts
+++ b/src/utilities/strings.ts
@@ -79,3 +79,15 @@ export function isValidEmailAddress(value: unknown): boolean {
 export function removeWhitespace(value: string): string {
   return value.replace(/\s/g, '')
 }
+
+export function removeUnquotedWhitespace(value: string): string {
+  // Split into quoted segments and non-quoted segments
+  return (value ?? '').split(/(\"[^"]*\")/g).map(segment => {
+      
+    if (segment.startsWith('"') && segment.endsWith('"')) {
+      return segment
+    }
+    // Remove whitespace from non-quoted parts
+    return segment.replace(/\s+/g, '')
+  }).join('')
+}


### PR DESCRIPTION
…is inserted inside quotes

The issue occurred when whitespace (e.g., a space) was added inside the quotes in JsonInput, and the component failed to update its value accordingly. Specifically, if the last key press was a space, the value was not updated, preventing users from adding prefixes.

As a result, triggers that depended on the updated value were not properly activated. For example, inserting a \n inside the value didn't trigger the error message " must be valid JSON".

Fix:

Replaced removeAllWhitespace() with removeUnquotedWhitespace() to ensure proper whitespace handling within quoted values.

Closes PrefectHQ/prefect#17398