### PR TITLE
Bugfix: Don't show parameters override section when schema doesn't exist

### DIFF
--- a/src/components/DeploymentScheduleCard.vue
+++ b/src/components/DeploymentScheduleCard.vue
@@ -21,9 +21,9 @@
 
 
 <script lang="ts" setup>
+  import { computed } from 'vue'
   import { DeploymentScheduleMenu, DeploymentScheduleToggle } from '@/components'
   import { Deployment, DeploymentSchedule } from '@/models'
-  import { computed } from 'vue'
 
   const props = defineProps<{
     deployment: Deployment,
@@ -50,6 +50,7 @@
   py-2
   flex
   flex-row
+  gap-2
   text-sm
   w-full
   justify-between

--- a/src/components/DeploymentScheduleToggle.vue
+++ b/src/components/DeploymentScheduleToggle.vue
@@ -44,7 +44,7 @@
   const updateSchedule = async (value: boolean): Promise<void> => {
     loading.value = true
     try {
-      await api.deploymentSchedules.updateDeploymentSchedule(props.deployment.id, props.schedule.id, { active: value })
+      await api.deploymentSchedules.updateDeploymentSchedule(props.deployment.id, props.schedule.id, { slug: props.schedule.slug, active: value })
       showToast(value ? localization.success.activateDeploymentSchedule : localization.success.pauseDeploymentSchedule, 'success')
       emit('update', value)
     } catch (error) {

--- a/src/components/ScheduleFormModal.vue
+++ b/src/components/ScheduleFormModal.vue
@@ -30,9 +30,9 @@
 
     <FlowRunJobVariableOverridesLabeledInput v-if="can.access.deploymentScheduleFlowRunInfraOverrides" v-model="internalJobVariables" />
 
-    <p-divider />
-
     <template v-if="schemaHasParameters">
+      <p-divider />
+
       <SchemaInputV2 v-model:values="internalParameters" :schema="internalSchema" :errors="errors" :kinds="['none', 'json']">
         <template #default="{ kind, setKind }">
           <div class="schedule-form-modal__parameters-container">
@@ -64,6 +64,8 @@
     useValidation,
     useValidationObserver
   } from '@prefecthq/vue-compositions'
+  import merge from 'lodash.merge'
+  import { computed, ref, watch } from 'vue'
   import CronScheduleForm from '@/components/CronScheduleForm.vue'
   import FlowRunJobVariableOverridesLabeledInput from '@/components/FlowRunJobVariableOverridesLabeledInput.vue'
   import IntervalScheduleForm from '@/components/IntervalScheduleForm.vue'
@@ -83,8 +85,6 @@
   import { SchemaInputV2, SchemaV2, SchemaValuesV2 } from '@/schemas'
   import { useSchemaValidation } from '@/schemas/compositions/useSchemaValidation'
   import { isEmptyObject, isEmptyString, isNull, isSlug, omit, stringify, timeout } from '@/utilities'
-  import merge from 'lodash.merge'
-  import { computed, ref, watch } from 'vue'
 
   defineOptions({
     inheritAttrs: false,

--- a/src/components/ScheduleFormModal.vue
+++ b/src/components/ScheduleFormModal.vue
@@ -58,10 +58,16 @@
 </template>
 
 <script lang="ts" setup>
+  import { ButtonGroupOption } from '@prefecthq/prefect-design'
+  import {
+    ValidationRule,
+    useValidation,
+    useValidationObserver
+  } from '@prefecthq/vue-compositions'
   import CronScheduleForm from '@/components/CronScheduleForm.vue'
   import FlowRunJobVariableOverridesLabeledInput from '@/components/FlowRunJobVariableOverridesLabeledInput.vue'
   import IntervalScheduleForm from '@/components/IntervalScheduleForm.vue'
-  import { useCan, useShowModal, useWorkspaceApi } from '@/compositions'
+  import { useCan, useShowModal } from '@/compositions'
   import { localization } from '@/localization'
   import {
     CronSchedule,
@@ -77,12 +83,6 @@
   import { SchemaInputV2, SchemaV2, SchemaValuesV2 } from '@/schemas'
   import { useSchemaValidation } from '@/schemas/compositions/useSchemaValidation'
   import { isEmptyObject, isEmptyString, isNull, isSlug, omit, stringify, timeout } from '@/utilities'
-  import { ButtonGroupOption } from '@prefecthq/prefect-design'
-  import {
-    ValidationRule,
-    useValidation,
-    useValidationObserver
-  } from '@prefecthq/vue-compositions'
   import merge from 'lodash.merge'
   import { computed, ref, watch } from 'vue'
 
@@ -105,7 +105,7 @@
     jobVariables: Record<string, unknown> | undefined,
     deploymentParameters: SchemaValuesV2,
     scheduleParameters?: SchemaValuesV2 | null,
-    parameterOpenApiSchema: SchemaV2,
+    parameterOpenApiSchema?: SchemaV2 | null,
     deployment?: Deployment,
     deploymentScheduleId?: string,
   }>()
@@ -152,7 +152,7 @@
   const internalParameters = ref<SchemaValuesV2>(props.scheduleParameters ?? {})
   const selectedProperties = ref<string[]>(Object.keys(internalParameters.value))
   const properties = computed(
-    () => props.parameterOpenApiSchema.properties ?? {},
+    () => props.parameterOpenApiSchema?.properties ?? {},
   )
   const propertyNames = computed(() => Object.keys(properties.value))
   const propertiesToOmit = computed(() => propertyNames.value.filter(
@@ -187,7 +187,7 @@
   })
 
   const schemaHasParameters = computed(
-    () => !isEmptyObject(props.parameterOpenApiSchema.properties),
+    () => !isEmptyObject(props.parameterOpenApiSchema?.properties ?? {}),
   )
 
   const { errors, validate: validateParameters } = useSchemaValidation(


### PR DESCRIPTION
This PR updates the models that use parameter schemas to allow them to be null (this matches the backend implementation) and then conditionally hides the parameters override form based on that.

Also fixes a minor bug where the slug was being reset when toggling the schedule and addresses a few minor visual bugs.


Tested using the following script for an extant deployment:
```py
import asyncio
from prefect import flow
from prefect.client.schemas.actions import DeploymentUpdate
from prefect.client.orchestration import get_client

from typing import Optional

@flow
def no_params():
    print("Hello, world!")

async def main():
    async with get_client() as my_client:
        deployment = await my_client.read_deployment(
            deployment_id="c9477e9b-5bf0-487d-b2a0-43ef15668572"
        )

        await my_client.update_deployment(
            deployment_id=deployment.id,
            deployment=DeploymentUpdate(
                parameter_openapi_schema=None,
            )
        )

if __name__ == "__main__":
    asyncio.run(main())


```

Note that this is required to test fully since the default behavior in the client is to create a fully-valid parameter schema so this bypasses that behavior by setting the schema to null explicitly through the API. See [this thread](https://github.com/PrefectHQ/prefect/issues/17695#issuecomment-2773038717) for more context