### PR TITLE
enhancement: Updates DeploymentVersionInfo typings

### DIFF
--- a/src/mocks/deploymentVersion.ts
+++ b/src/mocks/deploymentVersion.ts
@@ -13,11 +13,11 @@ export const randomDeploymentVersion: MockFunction<DeploymentVersion, [Partial<D
     updatedBy: this.create('createdOrUpdatedBy'),
     name: this.create('noun'),
     versionInfo: {
-      type: 'vcs:github',
+      type: 'vcs:github' as const,
       version: this.create('string'),
-      base: this.create('string'),
       branch: this.create('string'),
       url: this.create('url'),
+      repository: this.create('string'),
     },
     tags: this.createMany('noun', this.create('number', [0, 5])),
     labels: {},

--- a/src/models/DeploymentVersionInfo.ts
+++ b/src/models/DeploymentVersionInfo.ts
@@ -1,7 +1,36 @@
-export type DeploymentVersionInfo = {
-  type: string,
-  base: string | null,
-  branch: string | null,
+// Ref: prefect repo src/prefect/versioning/py
+
+type SimpleVersionInfo = {
+  type: 'prefect:simple',
   version: string,
-  url: string | null,
-} & Record<string, unknown>
+  branch?: string | null,
+  url?: string | null,
+}
+
+type GithubVersionInfo = {
+  type: 'vcs:github',
+  version: string,
+  branch: string,
+  url: string,
+  repository: string,
+}
+
+type GitVersionInfo = {
+  type: 'vcs:git',
+  version: string,
+  branch: string,
+  url: string,
+  repository: string,
+}
+
+type DockerVersionInfo = {
+  type: 'container:docker',
+  version: string,
+  branch: string,
+  url: string,
+  image_name: string,
+  registry: string,
+  image: string,
+}
+
+export type DeploymentVersionInfo = SimpleVersionInfo | GithubVersionInfo | GitVersionInfo | DockerVersionInfo


### PR DESCRIPTION
Updates `DeploymentVersionInfo` typings based on https://github.com/PrefectHQ/prefect/pull/17466/files#diff-5d7c787de39ee975944bbbcb963838ce5408514afdd9e456f0657e2db52965d1R11-R55.

Making this update so that we can use TS type narrowing based on the `type` field.

Will hold on from merging until the PR attached is merged
