### PR TITLE
BugFix:  Enable block refs in work pool base job config

### DIFF
--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -182,8 +182,8 @@ export function getSchemaValueDefinition(property: SchemaProperty, value: Schema
   if (property.allOf) {
     return getSchemaValueAllOfDefinition(property as SchemaPropertyAllOf, value)
   }
-
-  throw new Error('Schema property missing allOf and anyOf definitions')
+  console.error('Schema property missing allOf and anyOf definitions', property, value)
+  return null
 }
 
 /*


### PR DESCRIPTION
Adding a block reference to a work pool base template causes an error, which results in the edit page (& in the OSS UI the job config) not loading correctly. 

Removing the "throw error" and instead returning null and logging an error if we are missing anyof or allof in schemas fixes the display issue.  

@znicholasbrown - I'd like a review for you here as I am unsure if there was a deliberate reason for the thrown error and if there may be some side effects of removing it?

For reviewers a work Pool to demo on - https://app.stg.prefect.dev/account/9a67b081-4f14-4035-b000-1f715f46231b/workspace/a63a76bd-e6b4-42a5-8cb2-d2fcf233a57b/work-pools/work-pool/process/edit

Related issues:
https://linear.app/prefect/issue/OSS-5764/base-job-configuration-section-ui-of-custom-work-pool-disappears-when
https://github.com/PrefectHQ/prefect/issues/13189
https://github.com/PrefectHQ/prefect/issues/15678