### PR TITLE
Enhancement: Schema date-time parameter timezone selection

### DIFF
--- a/src/schemas/components/SchemaFormPropertyDateTime.vue
+++ b/src/schemas/components/SchemaFormPropertyDateTime.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="schema-form-property-date-time">
-    <p-date-input v-model="value" show-time clearable />
+    <div class="schema-form-property-date-time__input-container">
+      <p-date-input v-model="value" show-time clearable class="schema-form-property-date-time__date-input" />
+      <TimezoneSelect v-model="timezone" class="schema-form-property-date-time__timezone-select" hide-unset />
+    </div>
     <p-code v-if="normalizedValue">
       {{ normalizedValue }}
     </p-code>
@@ -10,7 +13,8 @@
 <script lang="ts" setup>
   import { isNotNullish } from '@prefecthq/prefect-design'
   import { formatDate } from 'date-fns'
-  import { computed } from 'vue'
+  import { computed, onBeforeMount, ref, watchEffect } from 'vue'
+  import { TimezoneSelect } from '@/components'
   import { isInvalidDate } from '@/utilities'
 
   const props = defineProps<{
@@ -22,10 +26,22 @@
   }>()
 
   const DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+
   // Note that this handles fractional seconds
   const TIMEZONE_REGEX = /(\.\d{1,9})?([+-]\d{2}:?\d{2}|Z)$/
 
+  const timezone = ref<string>('UTC')
   const normalizedValue = computed(() => getNormalizedValue(props.value))
+
+  watchEffect(() => {
+    console.log('timezone', timezone.value)
+  })
+
+  onBeforeMount(() => {
+    if (isNotNullish(props.value)) {
+      timezone.value = getTimezoneNameFromString(props.value) ?? 'UTC'
+    }
+  })
 
   const value = computed({
     get() {
@@ -57,6 +73,16 @@
     return value.replace(TIMEZONE_REGEX, '$1')
   }
 
+  function getTimezoneNameFromString(value: string): string | null {
+    const date = new Date(value)
+
+    if (isInvalidDate(date)) {
+      return null
+    }
+
+    return date.toLocaleString('en-US', { timeZoneName: 'short' }).split(' ')[3]
+  }
+
   function getNormalizedValue(value: Date | string | null | undefined): string | null | undefined {
     if (value instanceof Date) {
       return formatDate(value, DATE_FORMAT)
@@ -76,3 +102,26 @@
     return value
   }
 </script>
+
+<style>
+.schema-form-property-date-time { @apply
+  flex
+  flex-col
+  gap-2
+}
+
+.schema-form-property-date-time__input-container { @apply
+  flex
+  gap-2
+}
+
+.schema-form-property-date-time__date-input { @apply
+  grow
+  shrink-0
+}
+
+.schema-form-property-date-time__timezone-select { @apply
+  w-1/4
+  shrink-0
+}
+</style>

--- a/src/schemas/components/SchemaFormPropertyDateTime.vue
+++ b/src/schemas/components/SchemaFormPropertyDateTime.vue
@@ -101,20 +101,8 @@
     const timezones = Intl.supportedValuesOf('timeZone')
 
     const matchingTimezone = timezones.find(tz => {
-      const tzDate = new Date()
-      const tzOffset = tzDate.toLocaleString('en-US', { timeZone: tz, timeZoneName: 'short' })
-      const tzOffsetMatch = tzOffset.match(TIMEZONE_OFFSET_REGEX)
-      if (!tzOffsetMatch) {
-        return false
-      }
-
-      const [tzOffsetStr] = tzOffsetMatch
-      if (tzOffsetStr === 'Z') {
-        return offsetMinutes === 0
-      }
-
-      const [tzHours, tzMinutes] = tzOffsetStr.replace('+', '').split(':').map(Number)
-      const tzOffsetMinutes = tzHours * 60 + (tzHours >= 0 ? tzMinutes : -tzMinutes)
+      const tzOffsetMs = getTimezoneOffset(tz)
+      const tzOffsetMinutes = Math.round(tzOffsetMs / millisecondsInMinute)
 
       return tzOffsetMinutes === offsetMinutes
     })

--- a/src/schemas/components/SchemaFormPropertyDateTime.vue
+++ b/src/schemas/components/SchemaFormPropertyDateTime.vue
@@ -14,7 +14,7 @@
   import { isNotNullish } from '@prefecthq/prefect-design'
   import { formatDate } from 'date-fns'
   import { getTimezoneOffset } from 'date-fns-tz'
-  import { computed, onBeforeMount, ref, watchEffect } from 'vue'
+  import { computed, onBeforeMount, ref } from 'vue'
   import { TimezoneSelect } from '@/components'
   import { selectedTimezone, isInvalidDate, millisecondsInMinute, minutesInHour } from '@/utilities'
 
@@ -33,10 +33,6 @@
 
   const timezone = ref<string>('UTC')
   const normalizedValue = computed(() => getNormalizedValue(props.value))
-
-  watchEffect(() => {
-    console.log('timezone', timezone.value)
-  })
 
   onBeforeMount(() => {
     if (isNotNullish(props.value)) {


### PR DESCRIPTION
This PR enhances the date-time schema property input to:

1. Explicitly use the preferred timezone of the application (as dictated by the user) as the timezone default
2. Provide first-class support for timezone selection
3. Attempt to interpret default parameter values such that the initial timezone matches what's in code
4. Show the resulting timestamp that would get sent with a run inline - no guessing or waiting for the run to start