### PR TITLE
fix: Fixes JSON parsing error when updating Deployment Job Variables

### DIFF
--- a/src/components/DeploymentForm.vue
+++ b/src/components/DeploymentForm.vue
@@ -169,6 +169,9 @@
       }
     }
 
+    // nb: job variables are optional. If inputted as empty, set to {}
+    const jobVariablesJSON = jobVariables.value ? JSON.parse(jobVariables.value) : {}
+
     if (props.mode === 'duplicate') {
       const deploymentCreate: DeploymentCreate = {
         name: name.value,
@@ -179,7 +182,7 @@
         parameters: parameters.value,
         tags: tags.value,
         enforceParameterSchema: enforceParameterSchema.value,
-        jobVariables: JSON.parse(jobVariables.value),
+        jobVariables: jobVariablesJSON,
         parameterOpenApiSchema: props.deployment.parameterOpenApiSchema,
         manifestPath: props.deployment.manifestPath,
         path: props.deployment.path,
@@ -195,6 +198,8 @@
       }
       emit('submit', deploymentCreate)
     } else {
+
+
       const deploymentUpdate: DeploymentUpdateV2 = {
         description: description.value,
         workPoolName: workPoolName.value,
@@ -202,7 +207,7 @@
         parameters: parameters.value,
         tags: tags.value,
         enforceParameterSchema: enforceParameterSchema.value,
-        jobVariables: JSON.parse(jobVariables.value),
+        jobVariables: jobVariablesJSON,
         concurrencyLimit: concurrencyLimit.value,
         concurrencyOptions: concurrencyLimitCollisionStrategy.value ? { collisionStrategy: concurrencyLimitCollisionStrategy.value } : null,
       }


### PR DESCRIPTION
When inputting Job Variables as empty (optional), a JSON parsing error will occur.
This PR fixes that error by defaulting to `{}` when passing empty.

Note: There is an API error where passing `{}` `undefined` or `null` in the `job_variables` field will not override the previous entry. This PR only addresses the FE error

Before: 
https://github.com/user-attachments/assets/461c12e4-b5fc-42ba-9343-46842455cb71

After:
https://github.com/user-attachments/assets/aa7944a6-f4b3-4c80-97b9-a65e4e8090f8

