### PR TITLE
Configure dependabot to consolidate dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Configure dependabot to group all dependency updates into a single weekly PR instead of creating separate PRs for each package update.