### PR TITLE
fix(FlowRunFilteredList): reset pagination to page 1 when state filter changes

### DIFF
--- a/src/components/FlowRunFilteredList.vue
+++ b/src/components/FlowRunFilteredList.vue
@@ -52,7 +52,7 @@
 <script lang="ts" setup>
   import { useDebouncedRef, useLocalStorage } from '@prefecthq/vue-compositions'
   import merge from 'lodash.merge'
-  import { computed, ref } from 'vue'
+  import { computed, ref, watch } from 'vue'
   import {
     ResultsCount,
     StateNameSelect,
@@ -87,6 +87,19 @@
     },
     limit,
   }), props.prefix)
+
+  // Reset pagination to page 1 whenever the flow run state filter changes.
+  // This prevents showing an empty or incorrect page when the result set changes.
+  watch(
+    () => filter.flowRuns?.state?.name,
+    (newState, oldState) => {
+    // Use JSON.stringify for deep comparison since the value may be an array.
+      if (JSON.stringify(newState) !== JSON.stringify(oldState)) {
+        filter.page = 1
+      }
+    },
+  { deep: true }
+  )
 
   const { flowRuns, count, pages, subscription, errored, error } = usePaginatedFlowRuns(filter, {
     interval: 30000,


### PR DESCRIPTION
Closes #3105

Prefect main repo [issue-19480](https://github.com/PrefectHQ/prefect/issues/19480).

Added a watcher in `FlowRunFilteredList.vue` to monitor changes to `filter.flowRuns.state.name`. When the filter changes, `filter.page` is reset to `1`.

This ensures users always start from the first page of filtered results, avoiding empty or misleading pages.

- Go to a Work Pool with many runs
- Navigate to page 3+
- Change the state filter
- Verify URL updates to `runs.page=1` and correct results are shown