### PR TITLE
feat(Artifact): add rich artifact type for HTML/JS content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@prefecthq/prefect-ui-library",
             "version": "3.14.4",
             "dependencies": {
-                "@prefecthq/graphs": "^3.0.6",
+                "@prefecthq/graphs": "^3.0.8",
                 "axios": "^1.12.2",
                 "cronstrue": "^3.3.0",
                 "d3": "7.9.0",
@@ -75,7 +75,6 @@
             "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
             "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@csstools/css-calc": "^2.1.3",
                 "@csstools/css-color-parser": "^3.0.9",
@@ -88,8 +87,7 @@
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.27.1",
@@ -129,7 +127,6 @@
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
             "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -162,7 +159,6 @@
                 }
             ],
             "license": "MIT-0",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -182,7 +178,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -206,7 +201,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@csstools/color-helpers": "^5.1.0",
                 "@csstools/css-calc": "^2.1.4"
@@ -748,7 +742,6 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
             "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/utils": "^0.2.9"
             }
@@ -758,7 +751,6 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
             "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/core": "^1.6.0",
                 "@floating-ui/utils": "^0.2.9"
@@ -768,15 +760,13 @@
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
             "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@floating-ui/vue": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.6.tgz",
             "integrity": "sha512-XFlUzGHGv12zbgHNk5FN2mUB7ROul3oG2ENdTpWdE+qMFxyNxWSRmsoyhiEnpmabNm6WnUvR1OvJfUfN4ojC1A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/dom": "^1.0.0",
                 "@floating-ui/utils": "^0.2.9",
@@ -789,7 +779,6 @@
             "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "vue-demi-fix": "bin/vue-demi-fix.js",
                 "vue-demi-switch": "bin/vue-demi-switch.js"
@@ -813,8 +802,7 @@
         "node_modules/@fontsource-variable/inconsolata": {
             "version": "5.0.18",
             "resolved": "https://registry.npmjs.org/@fontsource-variable/inconsolata/-/inconsolata-5.0.18.tgz",
-            "integrity": "sha512-tnpqD9NOKGJlYvf9/wjy6CNAZUpiNIf5OCdQnUEd5rHMepPx8Jkv4XzWgNuU88npVoDGn7qHnv05lAcyZ7Qpqw==",
-            "peer": true
+            "integrity": "sha512-tnpqD9NOKGJlYvf9/wjy6CNAZUpiNIf5OCdQnUEd5rHMepPx8Jkv4XzWgNuU88npVoDGn7qHnv05lAcyZ7Qpqw=="
         },
         "node_modules/@fontsource-variable/inter": {
             "version": "5.2.7",
@@ -829,7 +817,6 @@
             "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-2.1.5.tgz",
             "integrity": "sha512-IpqR72sFqFs55kyKfFS7tN+Ww6odFNeH/7UxycIOrlVYfj4WUGAdzQtLBnJspucSeqWFQsKM0g0YrgU655BEfA==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "vue": ">= 3"
             }
@@ -874,7 +861,6 @@
             "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.7.0.tgz",
             "integrity": "sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@swc/helpers": "^0.5.0"
             }
@@ -884,7 +870,6 @@
             "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.0.tgz",
             "integrity": "sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@swc/helpers": "^0.5.0"
             }
@@ -1038,6 +1023,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.3.2.tgz",
             "integrity": "sha512-yteq6ptAxA09EcwU9D9hl7qr5yWIqy+c2PsXkTDkc76vTAwIamLY3KxLq2aR5y1U4L4O6aHFJd26uNhHcuTPmw==",
+            "peer": true,
             "dependencies": {
                 "@types/css-font-loading-module": "^0.0.7"
             },
@@ -1077,6 +1063,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.3.2.tgz",
             "integrity": "sha512-Pta3ee8MtJ3yKxGXzglBWgwbEOKMB6Eth+FpLTjL0rgxiqTB550YX6jsNEQQAzcGjCBlO3rC/IF57UZ2go/X6w==",
+            "peer": true,
             "dependencies": {
                 "@pixi/color": "7.3.2",
                 "@pixi/constants": "7.3.2",
@@ -1097,6 +1084,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.3.2.tgz",
             "integrity": "sha512-cY5AnZ3TWt5GYGx4e5AQ2/2U9kP+RorBg/O30amJ+8e9bFk9rS8cjh/DDq/hc4lql96BkXAInTl40eHnAML5lQ==",
+            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.3.2"
             }
@@ -1105,6 +1093,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.3.2.tgz",
             "integrity": "sha512-Moca9epu8jk1wIQCdVYjhz2pD9Ol21m50wvWUKvpgt9yM/AjkCLSDt8HO/PmTpavDrkhx5pVVWeDDA6FyUNaGA==",
+            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.3.2",
                 "@pixi/display": "7.3.2"
@@ -1175,6 +1164,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.3.2.tgz",
             "integrity": "sha512-PhU6j1yub4tH/s+/gqByzgZ3mLv1mfb6iGXbquycg3+WypcxHZn0opFtI/axsazaQ9SEaWxw1m3i40WG5ANH5g==",
+            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.3.2",
                 "@pixi/display": "7.3.2",
@@ -1184,12 +1174,14 @@
         "node_modules/@pixi/math": {
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.3.2.tgz",
-            "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w=="
+            "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w==",
+            "peer": true
         },
         "node_modules/@pixi/mesh": {
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.3.2.tgz",
             "integrity": "sha512-LFkt7ELYXQLgbgHpjl68j6JD5ejUwma8zoPn2gqSBbY+6pK/phjvV1Wkh76muF46VvNulgXF0+qLIDdCsfrDaA==",
+            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.3.2",
                 "@pixi/display": "7.3.2"
@@ -1271,6 +1263,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.3.2.tgz",
             "integrity": "sha512-IpWTKXExJNXVcY7ITopJ+JW48DahdbCo/81D2IYzBImq3jyiJM2Km5EoJgvAM5ZQ3Ev3KPPIBzYLD+HoPWcxdw==",
+            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.3.2",
                 "@pixi/display": "7.3.2"
@@ -1308,6 +1301,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.3.2.tgz",
             "integrity": "sha512-LdtNj+K5tPB/0UcDcO52M/C7xhwFTGFhtdF42fPhRuJawM23M3zm1Y8PapXv+mury+IxCHT1w30YlAi0qTVpKQ==",
+            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.3.2",
                 "@pixi/sprite": "7.3.2"
@@ -1317,6 +1311,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.3.2.tgz",
             "integrity": "sha512-p8KLgtZSPowWU/Zj+GVtfsUT8uGYo4TtKKYbLoWuxkRA5Pc1+4C9/rV/EOSFfoZIdW5C+iFg5VxRgBllUQf+aA==",
+            "peer": true,
             "peerDependencies": {
                 "@pixi/assets": "7.3.2",
                 "@pixi/core": "7.3.2",
@@ -1329,6 +1324,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.3.2.tgz",
             "integrity": "sha512-IYhBWEPOvqUtlHkS5/c1Hseuricj5jrrGd21ivcvHmcnK/x2m+CRGvvzeBp1mqoYBnDbQVrD2wSXSe4Dv9tEJA==",
+            "peer": true,
             "peerDependencies": {
                 "@pixi/core": "7.3.2",
                 "@pixi/display": "7.3.2",
@@ -1369,6 +1365,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.3.2.tgz",
             "integrity": "sha512-KhNvj9YcY7Zi2dTKZgDpx8C6OxKKR541vwtG6JgdBZZYDeMBOIghN2Vi5zn4diW5BhDfHBmdSJ1wZXEtE2MDwg==",
+            "peer": true,
             "dependencies": {
                 "@pixi/color": "7.3.2",
                 "@pixi/constants": "7.3.2",
@@ -1429,9 +1426,9 @@
             }
         },
         "node_modules/@prefecthq/graphs": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-3.0.6.tgz",
-            "integrity": "sha512-ogsGwLkIVJfODTwASYnD5pKLelsS3hQtC1ZYDBGXHEI6cZn/sYkeuY2BAh7UbJj7EIBswUoYMfbltOpPJ7U2SA==",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-3.0.8.tgz",
+            "integrity": "sha512-UiEA4GyOxchjOhTw9KEnGWdMKVA9IT4R3o1eAuP1+yIeWtfHhA0ioBfLYgqQyCHW/Fo4sVdEY1qV48ygHlVLdg==",
             "license": "ISC",
             "dependencies": {
                 "@fontsource-variable/inter": "^5.1.1",
@@ -1483,7 +1480,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-2.1.1.tgz",
             "integrity": "sha512-fAri44rG4bB6aWQUTIpnqz0+sIeVyMhzNgOiZfVpZkJHqXAD8BIoE3DhzHrH5bbydlcYYMTsbRCMqDjWv1WJgQ==",
-            "peer": true,
             "dependencies": {
                 "d3": "7.9.0",
                 "date-fns": "^2.30.0",
@@ -1500,7 +1496,6 @@
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
             "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.21.0"
             },
@@ -1819,7 +1814,6 @@
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
             "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.8.0"
             }
@@ -1828,7 +1822,6 @@
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.4.2.tgz",
             "integrity": "sha512-8QPrypskfBa7QIMuKHg2TA7BqES6vhBrDLOv8Unb6FcFyd3TjKbc6lcmb9UPQHxfl24sXoJ41ux/H7qQQvfaSQ==",
-            "peer": true,
             "peerDependencies": {
                 "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
             }
@@ -1837,7 +1830,6 @@
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.7.tgz",
             "integrity": "sha512-QE7X69iQI+ZXwldE+rzasvbJiyV/ju1FGHH0Qn2W3FKbuYtqp8LKcy6iSw79fVUT5/Vvf+0XgLCeYVG+UV6hOw==",
-            "peer": true,
             "dependencies": {
                 "mini-svg-data-uri": "^1.2.3"
             },
@@ -1849,7 +1841,6 @@
             "version": "0.5.13",
             "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.13.tgz",
             "integrity": "sha512-ADGcJ8dX21dVVHIwTRgzrcunY6YY9uSlAHHGVKvkA+vLc5qLwEszvKts40lx7z0qc4clpjclwLeK5rVCV2P/uw==",
-            "peer": true,
             "dependencies": {
                 "lodash.castarray": "^4.4.0",
                 "lodash.isplainobject": "^4.0.6",
@@ -1865,7 +1856,6 @@
             "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.2.tgz",
             "integrity": "sha512-Qzz4EgzMbO5gKrmqUondCjiHcuu4B1ftHb0pjCut661lXZdGoHeze9f/M8iwsK1t5LGR6aNuNGU7mxkowaW6RQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
@@ -1876,7 +1866,6 @@
             "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.2.tgz",
             "integrity": "sha512-z4swzjdhzCh95n9dw9lTvw+t3iwSkYRlVkYkra3C9mul/m5fTzHR7KmtkwH4qXMTXGJUbngtC/bz2cHQIHkO8g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@tanstack/virtual-core": "3.13.2"
             },
@@ -2246,6 +2235,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.4.0.tgz",
             "integrity": "sha512-gUuVEAK4/u6F9wRLznPUU4WGUacSEBDPoC2TrBkw3GAnOLHBL45QdfHOXp1kJ4ypBGLxTOB+t7NJLpKoC3gznQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.11.0"
             }
@@ -2272,15 +2262,13 @@
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
             "license": "MIT",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/@types/web-bluetooth": {
             "version": "0.0.20",
             "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
             "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "7.4.0",
@@ -2322,6 +2310,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
             "integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.4.0",
                 "@typescript-eslint/types": "7.4.0",
@@ -2697,7 +2686,6 @@
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.21.tgz",
             "integrity": "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.28.3",
                 "@vue/compiler-core": "3.5.21",
@@ -2715,7 +2703,6 @@
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
             "integrity": "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.5.21",
                 "@vue/shared": "3.5.21"
@@ -2734,8 +2721,7 @@
         "node_modules/@vue/devtools-api": {
             "version": "6.6.1",
             "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.1.tgz",
-            "integrity": "sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA==",
-            "peer": true
+            "integrity": "sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA=="
         },
         "node_modules/@vue/eslint-config-typescript": {
             "version": "13.0.0",
@@ -2802,7 +2788,6 @@
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.21.tgz",
             "integrity": "sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vue/shared": "3.5.21"
             }
@@ -2812,7 +2797,6 @@
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.21.tgz",
             "integrity": "sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vue/reactivity": "3.5.21",
                 "@vue/shared": "3.5.21"
@@ -2823,7 +2807,6 @@
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.21.tgz",
             "integrity": "sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vue/reactivity": "3.5.21",
                 "@vue/runtime-core": "3.5.21",
@@ -2836,7 +2819,6 @@
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.21.tgz",
             "integrity": "sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vue/compiler-ssr": "3.5.21",
                 "@vue/shared": "3.5.21"
@@ -2856,7 +2838,6 @@
             "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
             "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/web-bluetooth": "^0.0.20",
                 "@vueuse/metadata": "10.11.1",
@@ -2873,7 +2854,6 @@
             "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "vue-demi-fix": "bin/vue-demi-fix.js",
                 "vue-demi-switch": "bin/vue-demi-switch.js"
@@ -2899,7 +2879,6 @@
             "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
             "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
@@ -2909,7 +2888,6 @@
             "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
             "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "vue-demi": ">=0.14.8"
             },
@@ -2923,7 +2901,6 @@
             "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "vue-demi-fix": "bin/vue-demi-fix.js",
                 "vue-demi-switch": "bin/vue-demi-switch.js"
@@ -2949,6 +2926,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
             "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2970,7 +2948,6 @@
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
             "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -3052,7 +3029,6 @@
             "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
             "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.0.0"
             },
@@ -3293,6 +3269,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -3459,7 +3436,6 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
             "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
-            "peer": true,
             "dependencies": {
                 "clsx": "2.0.0"
             },
@@ -3471,7 +3447,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
             "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3480,7 +3455,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
             "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3637,7 +3611,6 @@
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
             "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@asamuzakjp/css-color": "^3.2.0",
                 "rrweb-cssom": "^0.8.0"
@@ -3650,15 +3623,13 @@
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
             "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/d3": {
             "version": "7.9.0",
@@ -3952,6 +3923,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -4034,7 +4006,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
             "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-            "peer": true,
             "dependencies": {
                 "whatwg-mimetype": "^4.0.0",
                 "whatwg-url": "^14.0.0"
@@ -4047,6 +4018,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
             "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/kossnocorp"
@@ -4086,8 +4058,7 @@
         "node_modules/decimal.js": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-            "peer": true
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
         },
         "node_modules/deep-eql": {
             "version": "5.0.2",
@@ -4134,8 +4105,7 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
             "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/delaunator": {
             "version": "5.0.0",
@@ -4233,7 +4203,6 @@
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
             "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
             "license": "(MPL-2.0 OR Apache-2.0)",
-            "peer": true,
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -4501,6 +4470,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
             "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -4658,6 +4628,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
             "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "array-includes": "^3.1.6",
                 "array.prototype.flat": "^1.3.1",
@@ -4732,6 +4703,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.24.0.tgz",
             "integrity": "sha512-9SkJMvF8NGMT9aQCwFc5rj8Wo1XWSMSHk36i7ZwdI614BU7sIOR28ZjuFPKp8YGymZN12BSEbiSwa7qikp+PBw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "globals": "^13.24.0",
@@ -5419,7 +5391,6 @@
             "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
             "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
             "license": "BSD-3-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -5428,7 +5399,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
             "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-            "peer": true,
             "dependencies": {
                 "whatwg-encoding": "^3.1.1"
             },
@@ -5441,7 +5411,6 @@
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -5455,7 +5424,6 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
@@ -5763,8 +5731,7 @@
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-            "peer": true
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
         },
         "node_modules/is-regex": {
             "version": "1.1.4",
@@ -5923,7 +5890,6 @@
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
             "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.1.0",
                 "data-urls": "^5.0.0",
@@ -5963,7 +5929,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
             "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -6051,8 +6016,7 @@
         "node_modules/lodash.castarray": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
-            "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
-            "peer": true
+            "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q=="
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -6067,8 +6031,7 @@
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "peer": true
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -6112,7 +6075,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
             "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-            "peer": true,
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -6177,7 +6139,6 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
             "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
-            "peer": true,
             "bin": {
                 "mini-svg-data-uri": "cli.js"
             }
@@ -6357,8 +6318,7 @@
             "version": "2.2.22",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
             "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
@@ -6534,7 +6494,6 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
             "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-            "peer": true,
             "dependencies": {
                 "entities": "^4.4.0"
             },
@@ -6731,6 +6690,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -6848,7 +6808,6 @@
             "version": "6.0.10",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
             "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -6928,7 +6887,6 @@
             "resolved": "https://registry.npmjs.org/radix-vue/-/radix-vue-1.9.17.tgz",
             "integrity": "sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/dom": "^1.6.7",
                 "@floating-ui/vue": "^1.1.0",
@@ -6957,7 +6915,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "nanoid": "bin/nanoid.js"
             },
@@ -7109,8 +7066,7 @@
             "version": "0.7.1",
             "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
             "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
@@ -7162,7 +7118,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-            "peer": true,
             "dependencies": {
                 "xmlchars": "^2.2.0"
             },
@@ -7555,8 +7510,7 @@
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-            "peer": true
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
         },
         "node_modules/synckit": {
             "version": "0.8.5",
@@ -7578,6 +7532,7 @@
             "version": "3.4.17",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
             "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+            "peer": true,
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -7614,7 +7569,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
             "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-            "peer": true,
             "peerDependencies": {
                 "tailwindcss": ">=3.0.0 || insiders"
             }
@@ -7726,6 +7680,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -7768,7 +7723,6 @@
             "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
             "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tldts-core": "^6.1.86"
             },
@@ -7780,8 +7734,7 @@
             "version": "6.1.86",
             "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
             "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -7799,7 +7752,6 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
             "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "tldts": "^6.1.32"
             },
@@ -7811,7 +7763,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
             "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -7939,6 +7890,7 @@
             "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8057,6 +8009,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
             "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -8183,6 +8136,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8363,7 +8317,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
             "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-            "peer": true,
             "dependencies": {
                 "xml-name-validator": "^5.0.0"
             },
@@ -8375,7 +8328,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
             "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8384,7 +8336,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -8393,7 +8344,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
             "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-            "peer": true,
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -8405,7 +8355,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
             "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8414,7 +8363,6 @@
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
             "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
-            "peer": true,
             "dependencies": {
                 "tr46": "^5.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -8593,7 +8541,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
             "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -8622,8 +8569,7 @@
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-            "peer": true
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
         },
         "node_modules/yallist": {
             "version": "4.0.0",
@@ -8671,7 +8617,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
             "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-            "peer": true,
             "requires": {
                 "@csstools/css-calc": "^2.1.3",
                 "@csstools/css-color-parser": "^3.0.9",
@@ -8683,8 +8628,7 @@
                 "lru-cache": {
                     "version": "10.4.3",
                     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-                    "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-                    "peer": true
+                    "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
                 }
             }
         },
@@ -8709,8 +8653,7 @@
         "@babel/runtime": {
             "version": "7.28.4",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-            "peer": true
+            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="
         },
         "@babel/types": {
             "version": "7.28.4",
@@ -8724,21 +8667,18 @@
         "@csstools/color-helpers": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
-            "peer": true
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="
         },
         "@csstools/css-calc": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
             "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-            "peer": true,
             "requires": {}
         },
         "@csstools/css-color-parser": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
             "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
-            "peer": true,
             "requires": {
                 "@csstools/color-helpers": "^5.1.0",
                 "@csstools/css-calc": "^2.1.4"
@@ -8974,7 +8914,6 @@
             "version": "1.6.9",
             "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
             "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-            "peer": true,
             "requires": {
                 "@floating-ui/utils": "^0.2.9"
             }
@@ -8983,7 +8922,6 @@
             "version": "1.6.13",
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
             "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-            "peer": true,
             "requires": {
                 "@floating-ui/core": "^1.6.0",
                 "@floating-ui/utils": "^0.2.9"
@@ -8992,14 +8930,12 @@
         "@floating-ui/utils": {
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-            "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-            "peer": true
+            "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
         },
         "@floating-ui/vue": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.6.tgz",
             "integrity": "sha512-XFlUzGHGv12zbgHNk5FN2mUB7ROul3oG2ENdTpWdE+qMFxyNxWSRmsoyhiEnpmabNm6WnUvR1OvJfUfN4ojC1A==",
-            "peer": true,
             "requires": {
                 "@floating-ui/dom": "^1.0.0",
                 "@floating-ui/utils": "^0.2.9",
@@ -9010,7 +8946,6 @@
                     "version": "0.14.10",
                     "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
                     "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-                    "peer": true,
                     "requires": {}
                 }
             }
@@ -9018,8 +8953,7 @@
         "@fontsource-variable/inconsolata": {
             "version": "5.0.18",
             "resolved": "https://registry.npmjs.org/@fontsource-variable/inconsolata/-/inconsolata-5.0.18.tgz",
-            "integrity": "sha512-tnpqD9NOKGJlYvf9/wjy6CNAZUpiNIf5OCdQnUEd5rHMepPx8Jkv4XzWgNuU88npVoDGn7qHnv05lAcyZ7Qpqw==",
-            "peer": true
+            "integrity": "sha512-tnpqD9NOKGJlYvf9/wjy6CNAZUpiNIf5OCdQnUEd5rHMepPx8Jkv4XzWgNuU88npVoDGn7qHnv05lAcyZ7Qpqw=="
         },
         "@fontsource-variable/inter": {
             "version": "5.2.7",
@@ -9030,7 +8964,6 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-2.1.5.tgz",
             "integrity": "sha512-IpqR72sFqFs55kyKfFS7tN+Ww6odFNeH/7UxycIOrlVYfj4WUGAdzQtLBnJspucSeqWFQsKM0g0YrgU655BEfA==",
-            "peer": true,
             "requires": {}
         },
         "@humanwhocodes/config-array": {
@@ -9060,7 +8993,6 @@
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.7.0.tgz",
             "integrity": "sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==",
-            "peer": true,
             "requires": {
                 "@swc/helpers": "^0.5.0"
             }
@@ -9069,7 +9001,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.0.tgz",
             "integrity": "sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==",
-            "peer": true,
             "requires": {
                 "@swc/helpers": "^0.5.0"
             }
@@ -9181,6 +9112,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.3.2.tgz",
             "integrity": "sha512-yteq6ptAxA09EcwU9D9hl7qr5yWIqy+c2PsXkTDkc76vTAwIamLY3KxLq2aR5y1U4L4O6aHFJd26uNhHcuTPmw==",
+            "peer": true,
             "requires": {
                 "@types/css-font-loading-module": "^0.0.7"
             }
@@ -9213,6 +9145,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.3.2.tgz",
             "integrity": "sha512-Pta3ee8MtJ3yKxGXzglBWgwbEOKMB6Eth+FpLTjL0rgxiqTB550YX6jsNEQQAzcGjCBlO3rC/IF57UZ2go/X6w==",
+            "peer": true,
             "requires": {
                 "@pixi/color": "7.3.2",
                 "@pixi/constants": "7.3.2",
@@ -9229,12 +9162,14 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.3.2.tgz",
             "integrity": "sha512-cY5AnZ3TWt5GYGx4e5AQ2/2U9kP+RorBg/O30amJ+8e9bFk9rS8cjh/DDq/hc4lql96BkXAInTl40eHnAML5lQ==",
+            "peer": true,
             "requires": {}
         },
         "@pixi/events": {
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.3.2.tgz",
             "integrity": "sha512-Moca9epu8jk1wIQCdVYjhz2pD9Ol21m50wvWUKvpgt9yM/AjkCLSDt8HO/PmTpavDrkhx5pVVWeDDA6FyUNaGA==",
+            "peer": true,
             "requires": {}
         },
         "@pixi/extensions": {
@@ -9288,17 +9223,20 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.3.2.tgz",
             "integrity": "sha512-PhU6j1yub4tH/s+/gqByzgZ3mLv1mfb6iGXbquycg3+WypcxHZn0opFtI/axsazaQ9SEaWxw1m3i40WG5ANH5g==",
+            "peer": true,
             "requires": {}
         },
         "@pixi/math": {
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.3.2.tgz",
-            "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w=="
+            "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w==",
+            "peer": true
         },
         "@pixi/mesh": {
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.3.2.tgz",
             "integrity": "sha512-LFkt7ELYXQLgbgHpjl68j6JD5ejUwma8zoPn2gqSBbY+6pK/phjvV1Wkh76muF46VvNulgXF0+qLIDdCsfrDaA==",
+            "peer": true,
             "requires": {}
         },
         "@pixi/mesh-extras": {
@@ -9356,6 +9294,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.3.2.tgz",
             "integrity": "sha512-IpWTKXExJNXVcY7ITopJ+JW48DahdbCo/81D2IYzBImq3jyiJM2Km5EoJgvAM5ZQ3Ev3KPPIBzYLD+HoPWcxdw==",
+            "peer": true,
             "requires": {}
         },
         "@pixi/sprite-animated": {
@@ -9380,18 +9319,21 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.3.2.tgz",
             "integrity": "sha512-LdtNj+K5tPB/0UcDcO52M/C7xhwFTGFhtdF42fPhRuJawM23M3zm1Y8PapXv+mury+IxCHT1w30YlAi0qTVpKQ==",
+            "peer": true,
             "requires": {}
         },
         "@pixi/text-bitmap": {
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.3.2.tgz",
             "integrity": "sha512-p8KLgtZSPowWU/Zj+GVtfsUT8uGYo4TtKKYbLoWuxkRA5Pc1+4C9/rV/EOSFfoZIdW5C+iFg5VxRgBllUQf+aA==",
+            "peer": true,
             "requires": {}
         },
         "@pixi/text-html": {
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.3.2.tgz",
             "integrity": "sha512-IYhBWEPOvqUtlHkS5/c1Hseuricj5jrrGd21ivcvHmcnK/x2m+CRGvvzeBp1mqoYBnDbQVrD2wSXSe4Dv9tEJA==",
+            "peer": true,
             "requires": {}
         },
         "@pixi/ticker": {
@@ -9417,6 +9359,7 @@
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.3.2.tgz",
             "integrity": "sha512-KhNvj9YcY7Zi2dTKZgDpx8C6OxKKR541vwtG6JgdBZZYDeMBOIghN2Vi5zn4diW5BhDfHBmdSJ1wZXEtE2MDwg==",
+            "peer": true,
             "requires": {
                 "@pixi/color": "7.3.2",
                 "@pixi/constants": "7.3.2",
@@ -9465,9 +9408,9 @@
             }
         },
         "@prefecthq/graphs": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-3.0.6.tgz",
-            "integrity": "sha512-ogsGwLkIVJfODTwASYnD5pKLelsS3hQtC1ZYDBGXHEI6cZn/sYkeuY2BAh7UbJj7EIBswUoYMfbltOpPJ7U2SA==",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-3.0.8.tgz",
+            "integrity": "sha512-UiEA4GyOxchjOhTw9KEnGWdMKVA9IT4R3o1eAuP1+yIeWtfHhA0ioBfLYgqQyCHW/Fo4sVdEY1qV48ygHlVLdg==",
             "requires": {
                 "@fontsource-variable/inter": "^5.1.1",
                 "@pixi-essentials/cull": "2.0.0",
@@ -9510,7 +9453,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@prefecthq/vue-charts/-/vue-charts-2.1.1.tgz",
             "integrity": "sha512-fAri44rG4bB6aWQUTIpnqz0+sIeVyMhzNgOiZfVpZkJHqXAD8BIoE3DhzHrH5bbydlcYYMTsbRCMqDjWv1WJgQ==",
-            "peer": true,
             "requires": {
                 "d3": "7.9.0",
                 "date-fns": "^2.30.0",
@@ -9521,7 +9463,6 @@
                     "version": "2.30.0",
                     "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
                     "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-                    "peer": true,
                     "requires": {
                         "@babel/runtime": "^7.21.0"
                     }
@@ -9695,7 +9636,6 @@
             "version": "0.5.15",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
             "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.8.0"
             }
@@ -9704,14 +9644,12 @@
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.4.2.tgz",
             "integrity": "sha512-8QPrypskfBa7QIMuKHg2TA7BqES6vhBrDLOv8Unb6FcFyd3TjKbc6lcmb9UPQHxfl24sXoJ41ux/H7qQQvfaSQ==",
-            "peer": true,
             "requires": {}
         },
         "@tailwindcss/forms": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.7.tgz",
             "integrity": "sha512-QE7X69iQI+ZXwldE+rzasvbJiyV/ju1FGHH0Qn2W3FKbuYtqp8LKcy6iSw79fVUT5/Vvf+0XgLCeYVG+UV6hOw==",
-            "peer": true,
             "requires": {
                 "mini-svg-data-uri": "^1.2.3"
             }
@@ -9720,7 +9658,6 @@
             "version": "0.5.13",
             "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.13.tgz",
             "integrity": "sha512-ADGcJ8dX21dVVHIwTRgzrcunY6YY9uSlAHHGVKvkA+vLc5qLwEszvKts40lx7z0qc4clpjclwLeK5rVCV2P/uw==",
-            "peer": true,
             "requires": {
                 "lodash.castarray": "^4.4.0",
                 "lodash.isplainobject": "^4.0.6",
@@ -9731,14 +9668,12 @@
         "@tanstack/virtual-core": {
             "version": "3.13.2",
             "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.2.tgz",
-            "integrity": "sha512-Qzz4EgzMbO5gKrmqUondCjiHcuu4B1ftHb0pjCut661lXZdGoHeze9f/M8iwsK1t5LGR6aNuNGU7mxkowaW6RQ==",
-            "peer": true
+            "integrity": "sha512-Qzz4EgzMbO5gKrmqUondCjiHcuu4B1ftHb0pjCut661lXZdGoHeze9f/M8iwsK1t5LGR6aNuNGU7mxkowaW6RQ=="
         },
         "@tanstack/vue-virtual": {
             "version": "3.13.2",
             "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.2.tgz",
             "integrity": "sha512-z4swzjdhzCh95n9dw9lTvw+t3iwSkYRlVkYkra3C9mul/m5fTzHR7KmtkwH4qXMTXGJUbngtC/bz2cHQIHkO8g==",
-            "peer": true,
             "requires": {
                 "@tanstack/virtual-core": "3.13.2"
             }
@@ -10096,6 +10031,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.4.0.tgz",
             "integrity": "sha512-gUuVEAK4/u6F9wRLznPUU4WGUacSEBDPoC2TrBkw3GAnOLHBL45QdfHOXp1kJ4ypBGLxTOB+t7NJLpKoC3gznQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "undici-types": "~7.11.0"
             }
@@ -10121,14 +10057,12 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "@types/web-bluetooth": {
             "version": "0.0.20",
             "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
-            "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
-            "peer": true
+            "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "7.4.0",
@@ -10154,6 +10088,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
             "integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@typescript-eslint/scope-manager": "7.4.0",
                 "@typescript-eslint/types": "7.4.0",
@@ -10403,7 +10338,6 @@
             "version": "3.5.21",
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.21.tgz",
             "integrity": "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==",
-            "peer": true,
             "requires": {
                 "@babel/parser": "^7.28.3",
                 "@vue/compiler-core": "3.5.21",
@@ -10420,7 +10354,6 @@
             "version": "3.5.21",
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
             "integrity": "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==",
-            "peer": true,
             "requires": {
                 "@vue/compiler-dom": "3.5.21",
                 "@vue/shared": "3.5.21"
@@ -10439,8 +10372,7 @@
         "@vue/devtools-api": {
             "version": "6.6.1",
             "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.1.tgz",
-            "integrity": "sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA==",
-            "peer": true
+            "integrity": "sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA=="
         },
         "@vue/eslint-config-typescript": {
             "version": "13.0.0",
@@ -10481,7 +10413,6 @@
             "version": "3.5.21",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.21.tgz",
             "integrity": "sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==",
-            "peer": true,
             "requires": {
                 "@vue/shared": "3.5.21"
             }
@@ -10490,7 +10421,6 @@
             "version": "3.5.21",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.21.tgz",
             "integrity": "sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==",
-            "peer": true,
             "requires": {
                 "@vue/reactivity": "3.5.21",
                 "@vue/shared": "3.5.21"
@@ -10500,7 +10430,6 @@
             "version": "3.5.21",
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.21.tgz",
             "integrity": "sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==",
-            "peer": true,
             "requires": {
                 "@vue/reactivity": "3.5.21",
                 "@vue/runtime-core": "3.5.21",
@@ -10512,7 +10441,6 @@
             "version": "3.5.21",
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.21.tgz",
             "integrity": "sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==",
-            "peer": true,
             "requires": {
                 "@vue/compiler-ssr": "3.5.21",
                 "@vue/shared": "3.5.21"
@@ -10527,7 +10455,6 @@
             "version": "10.11.1",
             "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
             "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
-            "peer": true,
             "requires": {
                 "@types/web-bluetooth": "^0.0.20",
                 "@vueuse/metadata": "10.11.1",
@@ -10539,7 +10466,6 @@
                     "version": "0.14.10",
                     "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
                     "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-                    "peer": true,
                     "requires": {}
                 }
             }
@@ -10547,14 +10473,12 @@
         "@vueuse/metadata": {
             "version": "10.11.1",
             "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
-            "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
-            "peer": true
+            "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw=="
         },
         "@vueuse/shared": {
             "version": "10.11.1",
             "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
             "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
-            "peer": true,
             "requires": {
                 "vue-demi": ">=0.14.8"
             },
@@ -10563,7 +10487,6 @@
                     "version": "0.14.10",
                     "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
                     "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-                    "peer": true,
                     "requires": {}
                 }
             }
@@ -10572,7 +10495,8 @@
             "version": "8.10.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
             "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-jsx": {
             "version": "5.3.2",
@@ -10584,8 +10508,7 @@
         "agent-base": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "peer": true
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
         },
         "ajv": {
             "version": "6.12.6",
@@ -10647,7 +10570,6 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
             "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.0.0"
             }
@@ -10799,6 +10721,7 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
             "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -10905,7 +10828,6 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
             "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
-            "peer": true,
             "requires": {
                 "clsx": "2.0.0"
             },
@@ -10913,16 +10835,14 @@
                 "clsx": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-                    "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-                    "peer": true
+                    "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
                 }
             }
         },
         "clsx": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-            "peer": true
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
         },
         "color-convert": {
             "version": "2.0.1",
@@ -11036,7 +10956,6 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
             "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-            "peer": true,
             "requires": {
                 "@asamuzakjp/css-color": "^3.2.0",
                 "rrweb-cssom": "^0.8.0"
@@ -11045,16 +10964,14 @@
                 "rrweb-cssom": {
                     "version": "0.8.0",
                     "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-                    "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-                    "peer": true
+                    "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="
                 }
             }
         },
         "csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "peer": true
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "d3": {
             "version": "7.9.0",
@@ -11264,7 +11181,8 @@
         "d3-selection": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+            "peer": true
         },
         "d3-shape": {
             "version": "3.2.0",
@@ -11323,7 +11241,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
             "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-            "peer": true,
             "requires": {
                 "whatwg-mimetype": "^4.0.0",
                 "whatwg-url": "^14.0.0"
@@ -11332,7 +11249,8 @@
         "date-fns": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
+            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+            "peer": true
         },
         "date-fns-tz": {
             "version": "3.2.0",
@@ -11357,8 +11275,7 @@
         "decimal.js": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-            "peer": true
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
         },
         "deep-eql": {
             "version": "5.0.2",
@@ -11391,8 +11308,7 @@
         "defu": {
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-            "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-            "peer": true
+            "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
         },
         "delaunator": {
             "version": "5.0.0",
@@ -11465,7 +11381,6 @@
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
             "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
-            "peer": true,
             "requires": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -11674,6 +11589,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
             "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -11798,6 +11714,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
             "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "array-includes": "^3.1.6",
                 "array.prototype.flat": "^1.3.1",
@@ -11859,6 +11776,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.24.0.tgz",
             "integrity": "sha512-9SkJMvF8NGMT9aQCwFc5rj8Wo1XWSMSHk36i7ZwdI614BU7sIOR28ZjuFPKp8YGymZN12BSEbiSwa7qikp+PBw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "globals": "^13.24.0",
@@ -12338,14 +12256,12 @@
         "highlight.js": {
             "version": "11.11.1",
             "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-            "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-            "peer": true
+            "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="
         },
         "html-encoding-sniffer": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
             "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-            "peer": true,
             "requires": {
                 "whatwg-encoding": "^3.1.1"
             }
@@ -12354,7 +12270,6 @@
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "peer": true,
             "requires": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -12364,7 +12279,6 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "peer": true,
             "requires": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
@@ -12572,8 +12486,7 @@
         "is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-            "peer": true
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
         },
         "is-regex": {
             "version": "1.1.4",
@@ -12686,7 +12599,6 @@
             "version": "25.0.1",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
             "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
-            "peer": true,
             "requires": {
                 "cssstyle": "^4.1.0",
                 "data-urls": "^5.0.0",
@@ -12714,8 +12626,7 @@
                 "xml-name-validator": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-                    "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-                    "peer": true
+                    "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
                 }
             }
         },
@@ -12784,8 +12695,7 @@
         "lodash.castarray": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
-            "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
-            "peer": true
+            "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q=="
         },
         "lodash.debounce": {
             "version": "4.0.8",
@@ -12800,8 +12710,7 @@
         "lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "peer": true
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
         },
         "lodash.merge": {
             "version": "4.6.2",
@@ -12839,8 +12748,7 @@
         "marked": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-            "peer": true
+            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
         },
         "math-intrinsics": {
             "version": "1.1.0",
@@ -12883,8 +12791,7 @@
         "mini-svg-data-uri": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
-            "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
-            "peer": true
+            "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg=="
         },
         "minimatch": {
             "version": "3.1.2",
@@ -13012,8 +12919,7 @@
         "nwsapi": {
             "version": "2.2.22",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
-            "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
-            "peer": true
+            "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ=="
         },
         "object-assign": {
             "version": "4.1.1",
@@ -13135,7 +13041,6 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
             "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-            "peer": true,
             "requires": {
                 "entities": "^4.4.0"
             }
@@ -13277,6 +13182,7 @@
             "version": "8.5.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
             "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "peer": true,
             "requires": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -13333,7 +13239,6 @@
             "version": "6.0.10",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
             "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
-            "peer": true,
             "requires": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -13383,7 +13288,6 @@
             "version": "1.9.17",
             "resolved": "https://registry.npmjs.org/radix-vue/-/radix-vue-1.9.17.tgz",
             "integrity": "sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ==",
-            "peer": true,
             "requires": {
                 "@floating-ui/dom": "^1.6.7",
                 "@floating-ui/vue": "^1.1.0",
@@ -13401,8 +13305,7 @@
                 "nanoid": {
                     "version": "5.1.3",
                     "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.3.tgz",
-                    "integrity": "sha512-zAbEOEr7u2CbxwoMRlz/pNSpRP0FdAU4pRaYunCdEezWohXFs+a0Xw7RfkKaezMsmSM1vttcLthJtwRnVtOfHQ==",
-                    "peer": true
+                    "integrity": "sha512-zAbEOEr7u2CbxwoMRlz/pNSpRP0FdAU4pRaYunCdEezWohXFs+a0Xw7RfkKaezMsmSM1vttcLthJtwRnVtOfHQ=="
                 }
             }
         },
@@ -13508,8 +13411,7 @@
         "rrweb-cssom": {
             "version": "0.7.1",
             "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-            "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
-            "peer": true
+            "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="
         },
         "run-parallel": {
             "version": "1.2.0",
@@ -13544,7 +13446,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-            "peer": true,
             "requires": {
                 "xmlchars": "^2.2.0"
             }
@@ -13814,8 +13715,7 @@
         "symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-            "peer": true
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
         },
         "synckit": {
             "version": "0.8.5",
@@ -13831,6 +13731,7 @@
             "version": "3.4.17",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
             "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+            "peer": true,
             "requires": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -13871,7 +13772,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
             "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-            "peer": true,
             "requires": {}
         },
         "tapable": {
@@ -13945,7 +13845,8 @@
                     "version": "4.0.3",
                     "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
                     "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 }
             }
         },
@@ -13971,7 +13872,6 @@
             "version": "6.1.86",
             "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
             "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-            "peer": true,
             "requires": {
                 "tldts-core": "^6.1.86"
             }
@@ -13979,8 +13879,7 @@
         "tldts-core": {
             "version": "6.1.86",
             "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-            "peer": true
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
         },
         "to-regex-range": {
             "version": "5.0.1",
@@ -13994,7 +13893,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
             "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-            "peer": true,
             "requires": {
                 "tldts": "^6.1.32"
             }
@@ -14003,7 +13901,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
             "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
-            "peer": true,
             "requires": {
                 "punycode": "^2.3.1"
             }
@@ -14100,7 +13997,8 @@
             "version": "5.9.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
             "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-            "devOptional": true
+            "devOptional": true,
+            "peer": true
         },
         "uglify-js": {
             "version": "3.17.4",
@@ -14181,6 +14079,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
             "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -14202,7 +14101,8 @@
                     "version": "4.0.3",
                     "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
                     "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 }
             }
         },
@@ -14324,7 +14224,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
             "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-            "peer": true,
             "requires": {
                 "xml-name-validator": "^5.0.0"
             },
@@ -14332,22 +14231,19 @@
                 "xml-name-validator": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-                    "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-                    "peer": true
+                    "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
                 }
             }
         },
         "webidl-conversions": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "peer": true
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
         },
         "whatwg-encoding": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
             "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-            "peer": true,
             "requires": {
                 "iconv-lite": "0.6.3"
             }
@@ -14355,14 +14251,12 @@
         "whatwg-mimetype": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-            "peer": true
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
         },
         "whatwg-url": {
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
             "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
-            "peer": true,
             "requires": {
                 "tr46": "^5.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -14486,7 +14380,6 @@
             "version": "8.18.3",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
             "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-            "peer": true,
             "requires": {}
         },
         "xml-name-validator": {
@@ -14498,8 +14391,7 @@
         "xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-            "peer": true
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
         },
         "yallist": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "src"
     ],
     "dependencies": {
-        "@prefecthq/graphs": "^3.0.6",
+        "@prefecthq/graphs": "^3.0.8",
         "axios": "^1.12.2",
         "cronstrue": "^3.3.0",
         "d3": "7.9.0",

--- a/src/components/ArtifactDataRich.vue
+++ b/src/components/ArtifactDataRich.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="artifact-data-rich">
+    <iframe
+      :srcdoc="processedHtml"
+      :sandbox="sandboxAttribute"
+      class="artifact-data-rich__iframe"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { RichArtifact } from '@/models'
+
+  const props = defineProps<{
+    artifact: RichArtifact,
+  }>()
+
+  const sandboxAttribute = computed(() => {
+    return props.artifact.data.sandbox.join(' ')
+  })
+
+  // Inject CSP meta tag if provided
+  const processedHtml = computed(() => {
+    const html = props.artifact.data.html
+    const csp = props.artifact.data.csp
+
+    if (!csp) return html
+
+    const cspTag = `<meta http-equiv="Content-Security-Policy" content="${csp}">`
+
+    // Inject into <head> if present, otherwise prepend
+    if (html.includes('<head>')) {
+      return html.replace('<head>', `<head>${cspTag}`)
+    }
+    return `${cspTag}${html}`
+  })
+</script>
+
+<style>
+.artifact-data-rich { @apply
+  w-full
+}
+
+.artifact-data-rich__iframe { @apply
+  w-full
+  min-h-[400px]
+  border
+  border-default
+  rounded
+}
+</style>

--- a/src/components/ArtifactDataRich.vue
+++ b/src/components/ArtifactDataRich.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="artifact-data-rich">
+    <iframe
+      :srcdoc="processedHtml"
+      :sandbox="sandboxAttribute"
+      class="artifact-data-rich__iframe"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { RichArtifact } from '@/models'
+
+  const props = defineProps<{
+    artifact: RichArtifact,
+  }>()
+
+  const sandboxAttribute = computed(() => {
+    const sandbox = props.artifact.data.sandbox ?? ['allow-scripts']
+    return sandbox.join(' ')
+  })
+
+  // Inject CSP meta tag if provided
+  const processedHtml = computed(() => {
+    const html = props.artifact.data.html
+    const csp = props.artifact.data.csp
+
+    if (!csp) return html
+
+    const cspTag = `<meta http-equiv="Content-Security-Policy" content="${csp}">`
+
+    // Inject into <head> if present, otherwise prepend
+    if (html.includes('<head>')) {
+      return html.replace('<head>', `<head>${cspTag}`)
+    }
+    return `${cspTag}${html}`
+  })
+</script>
+
+<style>
+.artifact-data-rich { @apply
+  w-full
+}
+
+.artifact-data-rich__iframe { @apply
+  w-full
+  min-h-[400px]
+  border
+  border-default
+  rounded
+}
+</style>

--- a/src/components/ArtifactDataView.vue
+++ b/src/components/ArtifactDataView.vue
@@ -10,6 +10,7 @@
   import ArtifactDataImage from '@/components/ArtifactDataImage.vue'
   import ArtifactDataMarkdown from '@/components/ArtifactDataMarkdown.vue'
   import ArtifactDataResult from '@/components/ArtifactDataResult.vue'
+  import ArtifactDataRich from '@/components/ArtifactDataRich.vue'
   import ArtifactDataTable from '@/components/ArtifactDataTable.vue'
   import ArtifactDataUnknown from '@/components/ArtifactDataUnknown.vue'
   import { Artifact } from '@/models'
@@ -34,6 +35,8 @@
         return ArtifactDataProgress
       case 'image':
         return ArtifactDataImage
+      case 'rich':
+        return ArtifactDataRich
       case 'unknown':
       default:
         return ArtifactDataUnknown

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export { default as ArtifactCollectionsEmptyState } from './ArtifactCollectionsE
 export { default as ArtifactDataMarkdown } from './ArtifactDataMarkdown.vue'
 export { default as ArtifactDataRaw } from './ArtifactDataRaw.vue'
 export { default as ArtifactDataResult } from './ArtifactDataResult.vue'
+export { default as ArtifactDataRich } from './ArtifactDataRich.vue'
 export { default as ArtifactDataUnknown } from './ArtifactDataUnknown.vue'
 export { default as ArtifactDataView } from './ArtifactDataView.vue'
 export { default as ArtifactDescription } from './ArtifactDescription.vue'

--- a/src/models/Artifact.ts
+++ b/src/models/Artifact.ts
@@ -6,6 +6,7 @@ export const artifactTypes = [
   'table',
   'progress',
   'image',
+  'rich',
   'unknown',
 ] as const
 
@@ -18,6 +19,7 @@ export const artifactTypeIconMap = {
   result: 'ArtifactResult',
   progress: 'ArtifactProgress',
   image: 'ArtifactImage',
+  rich: 'Artifact',
   unknown: 'Artifact',
 } as const satisfies Record<ArtifactType | 'default', Icon>
 
@@ -26,9 +28,14 @@ export type ProgressArtifactData = number
 export type MarkdownArtifactData = string
 export type TableArtifactData = string
 export type ImageArtifactData = string
+export type RichArtifactData = {
+  html: string
+  sandbox: string[]
+  csp?: string
+}
 export type UnknownArtifactData = unknown
 
-export type ArtifactData = ResultArtifactData | MarkdownArtifactData | TableArtifactData | ProgressArtifactData | ImageArtifactData | UnknownArtifactData
+export type ArtifactData = ResultArtifactData | MarkdownArtifactData | TableArtifactData | ProgressArtifactData | ImageArtifactData | RichArtifactData | UnknownArtifactData
 export type ArtifactMetadata = Record<string, string>
 
 export interface IArtifact {
@@ -67,6 +74,11 @@ export type ProgressArtifact = IArtifact & {
 export type ImageArtifact = IArtifact & {
   type: 'image',
   data: ImageArtifactData,
+}
+
+export type RichArtifact = IArtifact & {
+  type: 'rich',
+  data: RichArtifactData,
 }
 
 export type UnknownArtifact = IArtifact & {

--- a/src/models/Artifact.ts
+++ b/src/models/Artifact.ts
@@ -6,6 +6,7 @@ export const artifactTypes = [
   'table',
   'progress',
   'image',
+  'rich',
   'unknown',
 ] as const
 
@@ -18,6 +19,7 @@ export const artifactTypeIconMap = {
   result: 'ArtifactResult',
   progress: 'ArtifactProgress',
   image: 'ArtifactImage',
+  rich: 'Artifact',
   unknown: 'Artifact',
 } as const satisfies Record<ArtifactType | 'default', Icon>
 
@@ -26,9 +28,14 @@ export type ProgressArtifactData = number
 export type MarkdownArtifactData = string
 export type TableArtifactData = string
 export type ImageArtifactData = string
+export type RichArtifactData = {
+  html: string
+  sandbox?: string[]
+  csp?: string
+}
 export type UnknownArtifactData = unknown
 
-export type ArtifactData = ResultArtifactData | MarkdownArtifactData | TableArtifactData | ProgressArtifactData | ImageArtifactData | UnknownArtifactData
+export type ArtifactData = ResultArtifactData | MarkdownArtifactData | TableArtifactData | ProgressArtifactData | ImageArtifactData | RichArtifactData | UnknownArtifactData
 export type ArtifactMetadata = Record<string, string>
 
 export interface IArtifact {
@@ -67,6 +74,11 @@ export type ProgressArtifact = IArtifact & {
 export type ImageArtifact = IArtifact & {
   type: 'image',
   data: ImageArtifactData,
+}
+
+export type RichArtifact = IArtifact & {
+  type: 'rich',
+  data: RichArtifactData,
 }
 
 export type UnknownArtifact = IArtifact & {


### PR DESCRIPTION
Adds a `rich` artifact type that renders arbitrary HTML/JS in a sandboxed iframe. Users can create interactive visualizations, charts, or custom HTML as artifacts.

Default sandbox is `allow-scripts` only (JS runs but isolated from parent origin). Users can customize sandbox permissions or add CSP restrictions as needed.

## Release Order
```
graphs#701
    ↓
prefect-ui-library (this PR) — bump @prefecthq/graphs after graphs#701 merges
    ↓
prefect#19726 (bump @prefecthq/prefect-ui-library)
```

**Depends on:** PrefectHQ/graphs#701 — merge and release graphs first, then bump the dependency here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)