### PR TITLE
fix: use correct format for block document references in schema form

### DIFF
--- a/src/schemas/components/SchemaFormPropertyBlockDocument.vue
+++ b/src/schemas/components/SchemaFormPropertyBlockDocument.vue
@@ -23,7 +23,7 @@
 
   const value = computed({
     get() {
-      return props.value?.$ref ?? null
+      return props.value?.$ref?.block_document_id ?? null
     },
     set(value) {
       if (isNullish(value)) {
@@ -32,7 +32,9 @@
       }
 
       emit('update:value', {
-        $ref: value,
+        $ref: {
+          block_document_id: value,
+        },
       })
     },
   })

--- a/src/schemas/types/schemaValues.ts
+++ b/src/schemas/types/schemaValues.ts
@@ -81,11 +81,13 @@ export function isPrefectKindWorkspaceVariable(value: unknown): value is Prefect
 }
 
 export type BlockDocumentReferenceValue = {
-  $ref: string,
+  $ref: {
+    block_document_id: string,
+  },
 }
 
 export function isBlockDocumentReferenceValue(value: unknown): value is BlockDocumentReferenceValue {
-  return isRecord(value) && isString(value.$ref)
+  return isRecord(value) && isRecord(value.$ref) && isString(value.$ref.block_document_id)
 }
 
 export function asBlockDocumentReferenceValue(value: unknown): BlockDocumentReferenceValue | undefined {

--- a/src/schemas/utilities/properties.ts
+++ b/src/schemas/utilities/properties.ts
@@ -101,7 +101,7 @@ export async function getInitialIndexForSchemaPropertyAnyOfValue({ value, proper
 }
 
 async function getBlockDocumentReferenceDefinitionIndex(value: BlockDocumentReferenceValue, definitions: SchemaProperty[], api: CreateApi): Promise<number> {
-  const blockDocument = await api.blockDocuments.getBlockDocument(value.$ref)
+  const blockDocument = await api.blockDocuments.getBlockDocument(value.$ref.block_document_id)
 
   const definition = definitions.find(definition => definition.blockTypeSlug === blockDocument.blockType.slug)
 

--- a/src/services/schemas/properties/SchemaPropertyBlock.ts
+++ b/src/services/schemas/properties/SchemaPropertyBlock.ts
@@ -3,6 +3,17 @@ import { BlockDocumentReferenceValue, BlockDocumentValue, isBlockDocumentReferen
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue } from '@/types/schemas'
+import { isRecord, isString } from '@/utilities'
+
+// The form stores block values as { blockDocumentId: string } without blockTypeSlug
+// because SchemaFormInput.vue uses `${propKey}.blockDocumentId` as the field key
+type PartialBlockDocumentValue = {
+  blockDocumentId: string | null,
+}
+
+function isPartialBlockDocumentValue(value: SchemaValue): value is PartialBlockDocumentValue {
+  return isRecord(value) && 'blockDocumentId' in value && (isString(value.blockDocumentId) || value.blockDocumentId === null)
+}
 
 export class SchemaPropertyBlock extends SchemaPropertyService {
 
@@ -18,21 +29,33 @@ export class SchemaPropertyBlock extends SchemaPropertyService {
   }
 
   protected request(value: SchemaValue): unknown {
-    if (!isBlockDocumentValue(value)) {
-      return value
+    // Handle full BlockDocumentValue (has both blockTypeSlug and blockDocumentId)
+    if (isBlockDocumentValue(value)) {
+      if (!value.blockDocumentId) {
+        return undefined
+      }
+
+      return this.createBlockDocumentReference(value.blockDocumentId)
     }
 
-    if (!value.blockDocumentId) {
-      return undefined
+    // Handle partial value (only has blockDocumentId, from SchemaFormInput.vue)
+    if (isPartialBlockDocumentValue(value)) {
+      if (!value.blockDocumentId) {
+        return undefined
+      }
+
+      return this.createBlockDocumentReference(value.blockDocumentId)
     }
 
-    const request: BlockDocumentReferenceValue = {
+    return value
+  }
+
+  private createBlockDocumentReference(blockDocumentId: string): BlockDocumentReferenceValue {
+    return {
       $ref: {
-        'block_document_id': value.blockDocumentId!,
+        block_document_id: blockDocumentId,
       },
     }
-
-    return request
   }
 
   protected response(value: SchemaValue): unknown {

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -2,7 +2,7 @@ import { JsonInput } from '@/components'
 import { isBlockDocumentReferenceValue, isBlockDocumentValue } from '@/models'
 import { schemaPropertyServiceFactory } from '@/services/schemas/properties'
 import { SchemaProperty, SchemaPropertyInputAttrs, Schema, SchemaValues, SchemaValue, schemaHas, SchemaPropertyAnyOf, SchemaPropertyAllOf } from '@/types/schemas'
-import { isArray } from '@/utilities'
+import { isArray, isString } from '@/utilities'
 import { withPropsWithoutExcludedFactory } from '@/utilities/components'
 import { stringify } from '@/utilities/json'
 import { isRecord } from '@/utilities/object'
@@ -249,6 +249,10 @@ export function getSchemaValueDefinitionIndex(definitions: Schema[], value: Sche
   }
 }
 
+function isPartialBlockDocumentValue(value: object): value is { blockDocumentId: string | null } {
+  return isRecord(value) && 'blockDocumentId' in value && (isString(value.blockDocumentId) || value.blockDocumentId === null)
+}
+
 function findObjectDefinitionIndex(definitions: Schema[], value: object | null): number | null {
   if (value === null) {
     return null
@@ -256,6 +260,11 @@ function findObjectDefinitionIndex(definitions: Schema[], value: object | null):
 
   if (isBlockDocumentValue(value)) {
     return definitions.findIndex(definition => definition.blockTypeSlug === value.blockTypeSlug)
+  }
+
+  // Handle partial block document value (only has blockDocumentId, from SchemaFormInput.vue)
+  if (isPartialBlockDocumentValue(value)) {
+    return definitions.findIndex(definition => definition.type === 'block')
   }
 
   if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary
Fixes the handling of block document references when editing blocks with nested block fields (e.g., a `GitHubRepository` block with a `credentials` field referencing a `GitHubCredentials` block).

The fix addresses two issues:
1. **utilities.ts**: The `findObjectDefinitionIndex` function couldn't match partial block values (`{blockDocumentId: "..."}`) to block type definitions when resolving `anyOf` schemas
2. **SchemaPropertyBlock.ts**: Extended `request()` to handle partial block document values alongside full `BlockDocumentValue` objects

## Problem
When editing a block that has a nested block reference (e.g., a `GitHubRepository` block with a `credentials` field referencing a `GitHubCredentials` block), selecting an existing credentials block and saving would result in the credentials showing as "None" after save.

**Root cause:** `SchemaFormInput.vue` stores block values as `{ blockDocumentId: string }` using the field key `${propKey}.blockDocumentId`. When the form submits, the `anyOf` schema matching in `utilities.ts` couldn't recognize this partial format, causing it to log "Schema property with anyOf had a value but could not be associated with a definition" and skip calling `SchemaPropertyBlock.request()` entirely.

As a result, the PATCH request was sending:
```json
{"credentials": {"blockDocumentId": "..."}}
```

Instead of the correct format:
```json
{"credentials": {"$ref": {"block_document_id": "..."}}}
```

## Solution
1. Added `isPartialBlockDocumentValue()` function in `utilities.ts` to detect partial block values
2. Updated `findObjectDefinitionIndex()` to match partial block values to `type: 'block'` definitions
3. Extended `SchemaPropertyBlock.request()` to handle partial values and transform them to the correct `$ref` format

## Test plan
- [x] Create a `GitHubCredentials` block
- [x] Create a `GitHubRepository` block without credentials
- [x] Edit the repository block and select the credentials block from the dropdown
- [x] Save and verify the credentials field shows the selected block name instead of "None"
- [x] Verify the PATCH request sends `{"credentials": {"$ref": {"block_document_id": "..."}}}`

Fixes PrefectHQ/prefect#19532

🤖 Generated with [Claude Code](https://claude.com/claude-code)