### PR TITLE
  Fixes retry delay display in flow run details by using the correct API field with backwards compatibility support.

### DIFF
--- a/src/components/FlowRunDetails.vue
+++ b/src/components/FlowRunDetails.vue
@@ -47,7 +47,7 @@
 
       <template v-if="flowRun.empiricalPolicy">
         <p-key-value label="Retries" :value="flowRun.empiricalPolicy.retries" :alternate="alternate" />
-        <p-key-value label="Retry Delay" :value="`${flowRun.empiricalPolicy.retryDelaySeconds}s`" :alternate="alternate" />
+        <p-key-value label="Retry Delay" :value="`${flowRun.empiricalPolicy.retryDelay}s`" :alternate="alternate" />
       </template>
     </template>
   </div>

--- a/src/maps/empiricalPolicy.ts
+++ b/src/maps/empiricalPolicy.ts
@@ -6,7 +6,7 @@ import { MapFunction } from '@/services/Mapper'
 export const mapEmpiricalPolicyResponseToEmpiricalPolicy: MapFunction<EmpiricalPolicyResponse, EmpiricalPolicy> = function(source) {
   return new EmpiricalPolicy({
     retries: source.retries,
-    retryDelay: source.retry_delay,
+    retryDelay: source.retry_delay ?? source.retry_delay_seconds,
     maxRetries: source.max_retries,
     retryJitterFactor: source.retry_jitter_factor,
     retryDelaySeconds: source.retry_delay_seconds,


### PR DESCRIPTION
Fixes #3122

  ## Problem

  When a flow is created with `@flow(retries=5, retry_delay_seconds=25)`, the flow run details page was displaying "0s" instead of "25s" for the retry delay.

  The root cause: new Prefect API returns the retry delay value in the `retry_delay` field, while the deprecated `retry_delay_seconds` field is set to 0. The UI was only reading from `retry_delay_seconds`, causing it to always display 0.

  ## Solution

  Updated the `mapEmpiricalPolicyResponseToEmpiricalPolicy` mapper to populate `retryDelay` with fallback logic:
  ```typescript
  retryDelay: source.retry_delay ?? source.retry_delay_seconds
```

  This ensures:
  - newer Prefect versions: Uses retry_delay (the new field)
  - Prefect 2.x: Falls back to retry_delay_seconds (the legacy field)

  Changes

  - src/maps/empiricalPolicy.ts: Added fallback logic to support both API versions
  - src/components/FlowRunDetails.vue: Updated to use retryDelay instead of retryDelaySeconds

  Test plan

  - Tested with Prefect 3.0 API (retry_delay: 25, retry_delay_seconds: 0) - displays "25s"
  - Backwards compatibility with Prefect 2.x API needs verification (retry_delay: null, retry_delay_seconds: 25)