### PR TITLE
fix: reduce redundant API calls on deployments page

### DIFF
--- a/src/components/DeploymentList.vue
+++ b/src/components/DeploymentList.vue
@@ -8,7 +8,7 @@
 
       <template #controls>
         <SearchInput v-model="nameLike" size="small" placeholder="Search deployments..." class="deployment-list__search-input" label="Search deployments" />
-        <DeploymentTagsInput v-model:selected="filter.deployments.tags.name" small multiple />
+        <DeploymentTagsInput v-model:selected="filter.deployments.tags.name" :deployments="deployments" small multiple />
       </template>
 
       <template #sort>

--- a/src/components/DeploymentTagsInput.vue
+++ b/src/components/DeploymentTagsInput.vue
@@ -5,6 +5,7 @@
 <script lang="ts" setup>
   import { computed } from 'vue'
   import { useDeployments } from '@/compositions'
+  import { Deployment } from '@/models'
   import { DeploymentsFilter } from '@/models/Filters'
   import { unique } from '@/utilities/arrays'
 
@@ -12,6 +13,8 @@
     selected: string[] | null | undefined,
     emptyMessage?: string,
     filter?: DeploymentsFilter,
+    /** When provided, tags are extracted from these deployments instead of making an API call */
+    deployments?: Deployment[],
   }>()
 
   const emits = defineEmits<{
@@ -29,10 +32,18 @@
     },
   })
 
-  const { deployments } = useDeployments(() => props.filter ?? {})
+  // Only fetch deployments if not provided via props
+  const { deployments: fetchedDeployments } = useDeployments(() => {
+    if (props.deployments) {
+      return null
+    }
+    return props.filter ?? {}
+  })
+
+  const allDeployments = computed(() => props.deployments ?? fetchedDeployments.value)
 
   const options = computed(() => {
-    const tags = deployments.value.flatMap(deployment => deployment.tags ?? [])
+    const tags = allDeployments.value.flatMap(deployment => deployment.tags ?? [])
 
     return unique(tags).sort((tagA, tagB) => tagA.localeCompare(tagB))
   })


### PR DESCRIPTION
## Summary

Reduces redundant API calls when loading the deployments page.

### Problem

When viewing the deployments list page, the UI makes redundant API calls:
1. `POST /api/deployments/paginate` with filters (for the list) ✅
2. `POST /api/deployments/paginate` **without filters** (from DeploymentTagsInput) ❌

The second call fetches **all deployments** just to extract tag names for the filter dropdown.

### This PR's Approach

- Adds an optional `deployments` prop to `DeploymentTagsInput`
- When provided, tags are extracted from the prop instead of making an API call
- Updates `DeploymentList` to pass its already-fetched deployments

### ⚠️ Trade-offs & Pattern Concerns

**1. Breaks from established pattern:** All other `*TagsInput` components (`FlowRunTagsInput`, `TaskRunTagsInput`, `VariableTagsInput`) self-fetch their data. This change introduces an inconsistent pattern.

**2. Changes semantics:** The tags dropdown will now only show tags from the **current page** of deployments, not all available tags. Users filtering by a tag that exists on page 2 won't see it in the dropdown.

### Better Alternative (Not Implemented)

The proper fix would be:
1. **Backend**: Add a dedicated `GET /api/deployments/tags` endpoint that returns unique tag names only (very lightweight query)
2. **Frontend**: Update `DeploymentTagsInput` to use that endpoint

This would:
- Maintain the self-fetching pattern
- Show all available tags
- Be far more efficient than fetching all deployment data

### Questions for Reviewers

1. Is the semantic change (current page tags only) acceptable?
2. Should we instead pursue the dedicated tags endpoint approach?
3. Should this pattern be applied to other `*TagsInput` components for consistency?

---

Relates to: https://github.com/PrefectHQ/prefect/issues/20397

Note: There's still a separate redundant call (`POST /api/deployments/filter`) from the OSS UI page component for empty state detection.