### PR TITLE
PLA-2798: migrate prefect-ui-library workflows to prefect-ci-bot trust-tier Apps

### DIFF
--- a/.github/workflows/npm_update_latest_prefect.yaml
+++ b/.github/workflows/npm_update_latest_prefect.yaml
@@ -19,7 +19,14 @@
         contents: write
       steps:
         - uses: actions/checkout@v4
-  
+
+        - name: Generate prefect-ci-bot-public token
+          id: app_token
+          uses: actions/create-github-app-token@v3
+          with:
+            client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
+            private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
+
         - name: Configure Git
           run: |
             git config user.name "$GITHUB_ACTOR"
@@ -58,4 +65,4 @@
               Release information can be found at https://github.com/${{ inputs.package_name }}/releases/tag/${{ inputs.package_version }}." \
               --label maintenance
           env:
-            GITHUB_TOKEN: ${{ secrets.UI_COMPONENTS_CONTENTS_PRS_RW }}
+            GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,17 +25,34 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Generate prefect-ci-bot-public release token
+        id: release_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
+          private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
+
       - uses: prefecthq/actions-release-ui-components@main
         id: release-ui-components
         with:
           NPM_TOKEN: ${{ secrets.PREFECT_UI_COMPONENTS_NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.UI_COMPONENTS_CONTENTS_PRS_RW }}
+          GITHUB_TOKEN: ${{ steps.release_token.outputs.token }}
           RELEASE_TYPE: ${{ inputs.release_type }}
+
+      - name: Generate prefect-ci-bot-public token for prefect
+        if: ${{ steps.release-ui-components.outputs.type }}
+        id: prefect_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
+          private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
+          owner: PrefectHQ
+          repositories: prefect
 
       - uses: prefecthq/actions-trigger-downstream-npm-package-updates@main
         id: trigger-downstream-npm-package-update-prefect-oss
         if: ${{ steps.release-ui-components.outputs.type }}
         with:
-          GITHUB_TOKEN: ${{ secrets.PREFECT_ACTIONS_RW }}
+          GITHUB_TOKEN: ${{ steps.prefect_token.outputs.token }}
           DOWNSTREAM_REPO_NAME: prefect
           RELEASE_TAG: ${{ steps.release-ui-components.outputs.version}}


### PR DESCRIPTION
## Summary

Per the three-tier App design ([PLA-2825](https://linear.app/prefect/issue/PLA-2825)), `prefect-ui-library` is a public repo so workflows now use `prefect-ci-bot-public` for public-to-public operations and `prefect-ci-bot-bridge` when reaching internal targets like `nebula-ui`.

Migrates two workflows:

- `release.yml`: `prefect-ci-bot-public` for the same-repo release-ui-components and the downstream trigger to `prefect`.
- `npm_update_latest_prefect.yaml`: `prefect-ci-bot-public` for same-repo PR creation.

Resolves the `prefect-ui-library` portion of PLA-2798.

## Test plan

- [ ] After merge, cut the next release on this repo via `workflow_dispatch` and verify all downstream triggers succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)