### PR TITLE
chore(codeowners): migrate to cloud-* engineering teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @PrefectHQ/frontend
+* @PrefectHQ/cloud-frontend
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
Migrate this repo's CODEOWNERS from the broad `platform`/`backend`/`frontend` teams to the product-scoped `cloud-*` teams. This repo was missed in the first migration pass.

Mapping (1:1): `platform → cloud-platform`, `backend → cloud-backend`, `frontend → cloud-frontend`. No other ownership routing changed.

> [!NOTE]
> Confirm the relevant `cloud-*` team(s) have access to this repo before merging. GitHub silently ignores CODEOWNERS entries for teams without repo access.

Related to https://linear.app/prefect/issue/ENGPAR-72/revisit-github-engineering-teams